### PR TITLE
Fix submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "Conveyor-src/amazon-freertos"]
 	path = conveyor-src/amazon-freertos
 	url = https://github.com/aws/amazon-freertos.git
+	branch = v1.4.1

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,3 @@
 [submodule "Conveyor-src/amazon-freertos"]
 	path = conveyor-src/amazon-freertos
 	url = https://github.com/aws/amazon-freertos.git
-	branch = v1.4.1


### PR DESCRIPTION
There are changes to the Amazon FreeRTOS project that broke the conveyor project configure and make scripts. This commit fixes the FreeRTOS submodule at a commit that works for the conveyor project. 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
