### PR TITLE
Shorter legs for smaller printers

### DIFF
--- a/conveyor-design-files/3d-stl-files/conveyor-shortleg.scad
+++ b/conveyor-design-files/3d-stl-files/conveyor-shortleg.scad
@@ -1,0 +1,49 @@
+echo(version=version());
+
+
+module chamfer(len,r,rs=4)
+{
+	p=r+0.1;
+	linear_extrude(height=len) difference()
+	{
+		square([p,p]);
+		circle(r,$fn=(rs+1)*4);
+	}
+}
+
+//chamfer(10,14,20);
+
+x =   0;
+y =   0;
+h =  20;
+w = 230;
+
+difference()
+{
+  union()
+  {
+    color("red" ) 
+    {
+      translate([x         ,y         , 0]) cylinder(r=10,h=10,center=true,$fn = 200);
+      translate([x + w     ,y         , 0]) cylinder(r=10,h=10,center=true,$fn = 200);
+      translate([x         ,y + h     , 0]) cylinder(r=10,h=10,center=true,$fn = 200);
+      translate([x + w     ,y + h     , 0]) cylinder(r=10,h=10,center=true,$fn = 200);
+    }
+    color("blue" )
+    {
+      translate([x         ,y + h - 10,-5]) cube([  w,20,10]);
+      translate([x -     10,y         ,-5]) cube([ 20, h,10]);
+      translate([x + w - 10,y         ,-5]) cube([ 20, h,10]);
+    }
+  }
+  union()
+  {
+    color("green"){ 
+    translate([  0    ,  0,-0.1]) cylinder(r=1.5, h=10, center=true,$fn = 200);
+    translate([  0    ,  0,   5]) cylinder(r=  3, h=10, center=true,$fn = 200);
+
+    translate([  x + w,  0,-0.1]) cylinder(r=1.5, h=10, center=true,$fn = 200);
+    translate([  x + w,  0,   5]) cylinder(r=  3, h=10, center=true,$fn = 200);
+  }
+  }
+}

--- a/conveyor-design-files/3d-stl-files/conveyor-shortleg.stl
+++ b/conveyor-design-files/3d-stl-files/conveyor-shortleg.stl
@@ -1,0 +1,30998 @@
+solid OpenSCAD_Model
+  facet normal -0.718127 -0.695912 0
+    outer loop
+      vertex -7.07107 -7.07107 -5
+      vertex -7.28969 -6.84547 5
+      vertex -7.28969 -6.84547 -5
+    endloop
+  endfacet
+  facet normal -0.718127 -0.695912 0
+    outer loop
+      vertex -7.28969 -6.84547 5
+      vertex -7.07107 -7.07107 -5
+      vertex -7.07107 -7.07107 5
+    endloop
+  endfacet
+  facet normal 0.835808 -0.549022 0
+    outer loop
+      vertex 8.27081 -5.62083 5
+      vertex 8.44328 -5.35827 -5
+      vertex 8.44328 -5.35827 5
+    endloop
+  endfacet
+  facet normal 0.835808 -0.549022 0
+    outer loop
+      vertex 8.44328 -5.35827 -5
+      vertex 8.27081 -5.62083 5
+      vertex 8.27081 -5.62083 -5
+    endloop
+  endfacet
+  facet normal 0.202789 -0.979222 0
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 2.18143 -9.75917 5
+      vertex 1.87381 -9.82287 5
+    endloop
+  endfacet
+  facet normal 0.202789 -0.979222 0
+    outer loop
+      vertex 2.18143 -9.75917 5
+      vertex 1.87381 -9.82287 -5
+      vertex 2.18143 -9.75917 -5
+    endloop
+  endfacet
+  facet normal 0.649447 -0.760407 0
+    outer loop
+      vertex 6.37424 -7.70513 -5
+      vertex 6.61312 -7.50111 5
+      vertex 6.37424 -7.70513 5
+    endloop
+  endfacet
+  facet normal 0.649447 -0.760407 0
+    outer loop
+      vertex 6.61312 -7.50111 5
+      vertex 6.37424 -7.70513 -5
+      vertex 6.61312 -7.50111 -5
+    endloop
+  endfacet
+  facet normal -0.353473 -0.935445 0
+    outer loop
+      vertex -3.68124 -9.29776 -5
+      vertex -3.38738 -9.40881 5
+      vertex -3.68124 -9.29776 5
+    endloop
+  endfacet
+  facet normal -0.353473 -0.935445 -0
+    outer loop
+      vertex -3.38738 -9.40881 5
+      vertex -3.68124 -9.29776 -5
+      vertex -3.38738 -9.40881 -5
+    endloop
+  endfacet
+  facet normal 0.46793 -0.883766 0
+    outer loop
+      vertex 4.5399 -8.91006 -5
+      vertex 4.81754 -8.76307 5
+      vertex 4.5399 -8.91006 5
+    endloop
+  endfacet
+  facet normal 0.46793 -0.883766 0
+    outer loop
+      vertex 4.81754 -8.76307 5
+      vertex 4.5399 -8.91006 -5
+      vertex 4.81754 -8.76307 -5
+    endloop
+  endfacet
+  facet normal 0.625244 -0.780429 0
+    outer loop
+      vertex 6.12907 -7.90155 -5
+      vertex 6.37424 -7.70513 5
+      vertex 6.12907 -7.90155 5
+    endloop
+  endfacet
+  facet normal 0.625244 -0.780429 0
+    outer loop
+      vertex 6.37424 -7.70513 5
+      vertex 6.12907 -7.90155 -5
+      vertex 6.37424 -7.70513 -5
+    endloop
+  endfacet
+  facet normal 0.98511 -0.171928 0
+    outer loop
+      vertex 9.82287 -1.87381 5
+      vertex 9.87688 -1.56434 -5
+      vertex 9.87688 -1.56434 5
+    endloop
+  endfacet
+  facet normal 0.98511 -0.171928 0
+    outer loop
+      vertex 9.87688 -1.56434 -5
+      vertex 9.82287 -1.87381 5
+      vertex 9.82287 -1.87381 -5
+    endloop
+  endfacet
+  facet normal -0.923879 -0.382685 0
+    outer loop
+      vertex -9.17755 -3.97148 -5
+      vertex -9.29776 -3.68124 5
+      vertex -9.29776 -3.68124 -5
+    endloop
+  endfacet
+  facet normal -0.923879 -0.382685 0
+    outer loop
+      vertex -9.29776 -3.68124 5
+      vertex -9.17755 -3.97148 -5
+      vertex -9.17755 -3.97148 5
+    endloop
+  endfacet
+  facet normal 0.109734 -0.993961 0
+    outer loop
+      vertex 0.941083 -9.95562 -5
+      vertex 1.25333 -9.92115 5
+      vertex 0.941083 -9.95562 5
+    endloop
+  endfacet
+  facet normal 0.109734 -0.993961 0
+    outer loop
+      vertex 1.25333 -9.92115 5
+      vertex 0.941083 -9.95562 -5
+      vertex 1.25333 -9.92115 -5
+    endloop
+  endfacet
+  facet normal 0.29404 -0.955793 0
+    outer loop
+      vertex 2.78991 -9.60294 -5
+      vertex 3.09017 -9.51056 5
+      vertex 2.78991 -9.60294 5
+    endloop
+  endfacet
+  facet normal 0.29404 -0.955793 0
+    outer loop
+      vertex 3.09017 -9.51056 5
+      vertex 2.78991 -9.60294 -5
+      vertex 3.09017 -9.51056 -5
+    endloop
+  endfacet
+  facet normal 0.575004 -0.818151 0
+    outer loop
+      vertex 5.62083 -8.27081 -5
+      vertex 5.87785 -8.09017 5
+      vertex 5.62083 -8.27081 5
+    endloop
+  endfacet
+  facet normal 0.575004 -0.818151 0
+    outer loop
+      vertex 5.87785 -8.09017 5
+      vertex 5.62083 -8.27081 -5
+      vertex 5.87785 -8.09017 -5
+    endloop
+  endfacet
+  facet normal 0.495458 -0.868632 0
+    outer loop
+      vertex 4.81754 -8.76307 -5
+      vertex 5.09041 -8.60742 5
+      vertex 4.81754 -8.76307 5
+    endloop
+  endfacet
+  facet normal 0.495458 -0.868632 0
+    outer loop
+      vertex 5.09041 -8.60742 5
+      vertex 4.81754 -8.76307 -5
+      vertex 5.09041 -8.60742 -5
+    endloop
+  endfacet
+  facet normal 0.964558 -0.263872 0
+    outer loop
+      vertex 9.60294 -2.78991 5
+      vertex 9.68583 -2.4869 -5
+      vertex 9.68583 -2.4869 5
+    endloop
+  endfacet
+  facet normal 0.964558 -0.263872 0
+    outer loop
+      vertex 9.68583 -2.4869 -5
+      vertex 9.60294 -2.78991 5
+      vertex 9.60294 -2.78991 -5
+    endloop
+  endfacet
+  facet normal -0.263872 -0.964558 0
+    outer loop
+      vertex -2.78991 -9.60294 -5
+      vertex -2.4869 -9.68583 5
+      vertex -2.78991 -9.60294 5
+    endloop
+  endfacet
+  facet normal -0.263872 -0.964558 -0
+    outer loop
+      vertex -2.4869 -9.68583 5
+      vertex -2.78991 -9.60294 -5
+      vertex -2.4869 -9.68583 -5
+    endloop
+  endfacet
+  facet normal -0.0784593 -0.996917 0
+    outer loop
+      vertex -0.941083 -9.95562 -5
+      vertex -0.627905 -9.98027 5
+      vertex -0.941083 -9.95562 5
+    endloop
+  endfacet
+  facet normal -0.0784593 -0.996917 -0
+    outer loop
+      vertex -0.627905 -9.98027 5
+      vertex -0.941083 -9.95562 -5
+      vertex -0.627905 -9.98027 -5
+    endloop
+  endfacet
+  facet normal -0.818151 -0.575004 0
+    outer loop
+      vertex -8.09017 -5.87785 -5
+      vertex -8.27081 -5.62083 5
+      vertex -8.27081 -5.62083 -5
+    endloop
+  endfacet
+  facet normal -0.818151 -0.575004 0
+    outer loop
+      vertex -8.27081 -5.62083 5
+      vertex -8.09017 -5.87785 -5
+      vertex -8.09017 -5.87785 5
+    endloop
+  endfacet
+  facet normal -0.760407 -0.649447 0
+    outer loop
+      vertex -7.50111 -6.61312 -5
+      vertex -7.70513 -6.37424 5
+      vertex -7.70513 -6.37424 -5
+    endloop
+  endfacet
+  facet normal -0.760407 -0.649447 0
+    outer loop
+      vertex -7.70513 -6.37424 5
+      vertex -7.50111 -6.61312 -5
+      vertex -7.50111 -6.61312 5
+    endloop
+  endfacet
+  facet normal -0.868632 -0.495458 0
+    outer loop
+      vertex -8.60742 -5.09041 -5
+      vertex -8.76307 -4.81754 5
+      vertex -8.76307 -4.81754 -5
+    endloop
+  endfacet
+  facet normal -0.868632 -0.495458 0
+    outer loop
+      vertex -8.76307 -4.81754 5
+      vertex -8.60742 -5.09041 -5
+      vertex -8.60742 -5.09041 5
+    endloop
+  endfacet
+  facet normal -0.955793 -0.29404 0
+    outer loop
+      vertex -9.51056 -3.09017 -5
+      vertex -9.60294 -2.78991 5
+      vertex -9.60294 -2.78991 -5
+    endloop
+  endfacet
+  facet normal -0.955793 -0.29404 0
+    outer loop
+      vertex -9.60294 -2.78991 5
+      vertex -9.51056 -3.09017 -5
+      vertex -9.51056 -3.09017 5
+    endloop
+  endfacet
+  facet normal -0.993961 -0.109734 0
+    outer loop
+      vertex -9.92115 -1.25333 -5
+      vertex -9.95562 -0.941083 5
+      vertex -9.95562 -0.941083 -5
+    endloop
+  endfacet
+  facet normal -0.993961 -0.109734 0
+    outer loop
+      vertex -9.95562 -0.941083 5
+      vertex -9.92115 -1.25333 -5
+      vertex -9.92115 -1.25333 5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.5 0 -5
+      vertex 10 0 -5
+      vertex 9.99506 -0.314107 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 9.99506 -0.314107 -5
+      vertex 1.49926 -0.0471153 -5
+      vertex 1.5 0 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.49704 -0.0941849 -5
+      vertex 1.49926 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.49334 -0.141162 -5
+      vertex 1.49704 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.48817 -0.188 -5
+      vertex 1.49334 -0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.48153 -0.234652 -5
+      vertex 1.48817 -0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.47343 -0.281072 -5
+      vertex 1.48153 -0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.46387 -0.327214 -5
+      vertex 1.47343 -0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.45287 -0.373034 -5
+      vertex 1.46387 -0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.44044 -0.418487 -5
+      vertex 1.45287 -0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.42658 -0.463525 -5
+      vertex 1.44044 -0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.41132 -0.508106 -5
+      vertex 1.42658 -0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.39466 -0.552186 -5
+      vertex 1.41132 -0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.37663 -0.595721 -5
+      vertex 1.39466 -0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.35724 -0.638668 -5
+      vertex 1.37663 -0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.33651 -0.680985 -5
+      vertex 1.35724 -0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.31446 -0.722631 -5
+      vertex 1.33651 -0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.29111 -0.763561 -5
+      vertex 1.31446 -0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.26649 -0.80374 -5
+      vertex 1.29111 -0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.234652 -1.48153 -5
+      vertex 1.56434 -9.87688 -5
+      vertex 1.25333 -9.92115 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.24062 -0.843124 -5
+      vertex 1.26649 -0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.21352 -0.881678 -5
+      vertex 1.24062 -0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.18523 -0.91936 -5
+      vertex 1.21352 -0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.15577 -0.956136 -5
+      vertex 1.18523 -0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.12517 -0.991967 -5
+      vertex 1.15577 -0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.09345 -1.02682 -5
+      vertex 1.12517 -0.991967 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.06066 -1.06066 -5
+      vertex 1.09345 -1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 1.02682 -1.09345 -5
+      vertex 1.06066 -1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.991967 -1.12517 -5
+      vertex 1.02682 -1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.956136 -1.15577 -5
+      vertex 0.991967 -1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.188 -1.48817 -5
+      vertex 1.25333 -9.92115 -5
+      vertex 0.941083 -9.95562 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.91936 -1.18523 -5
+      vertex 0.956136 -1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.881678 -1.21352 -5
+      vertex 0.91936 -1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.843124 -1.24062 -5
+      vertex 0.881678 -1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.80374 -1.26649 -5
+      vertex 0.843124 -1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.763561 -1.29111 -5
+      vertex 0.80374 -1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.722631 -1.31446 -5
+      vertex 0.763561 -1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.680985 -1.33651 -5
+      vertex 0.722631 -1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.638668 -1.35724 -5
+      vertex 0.680985 -1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.141162 -1.49334 -5
+      vertex 0.941083 -9.95562 -5
+      vertex 0.627905 -9.98027 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.595721 -1.37663 -5
+      vertex 0.638668 -1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.552186 -1.39466 -5
+      vertex 0.595721 -1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.508106 -1.41132 -5
+      vertex 0.552186 -1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.463525 -1.42658 -5
+      vertex 0.508106 -1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.418487 -1.44044 -5
+      vertex 0.463525 -1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.373034 -1.45287 -5
+      vertex 0.418487 -1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.327214 -1.46387 -5
+      vertex 0.373034 -1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.0941849 -1.49704 -5
+      vertex 0.627905 -9.98027 -5
+      vertex 0.314107 -9.99506 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.87381 -9.82287 -5
+      vertex 0.281072 -1.47343 -5
+      vertex 0.327214 -1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.56434 -9.87688 -5
+      vertex 0.234652 -1.48153 -5
+      vertex 0.281072 -1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.25333 -9.92115 -5
+      vertex 0.188 -1.48817 -5
+      vertex 0.234652 -1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.941083 -9.95562 -5
+      vertex 0.141162 -1.49334 -5
+      vertex 0.188 -1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.627905 -9.98027 -5
+      vertex 0.0941849 -1.49704 -5
+      vertex 0.141162 -1.49334 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.314107 -9.99506 -5
+      vertex 0.0471153 -1.49926 -5
+      vertex 0.0941849 -1.49704 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -10 -5
+      vertex 0.0471153 -1.49926 -5
+      vertex 0.314107 -9.99506 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -10 -5
+      vertex 0 -1.5 -5
+      vertex 0.0471153 -1.49926 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 -10 -5
+      vertex -0.0471153 -1.49926 -5
+      vertex 0 -1.5 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.314107 -9.99506 -5
+      vertex -0.0471153 -1.49926 -5
+      vertex 0 -10 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.0471153 -1.49926 -5
+      vertex -0.314107 -9.99506 -5
+      vertex -0.0941849 -1.49704 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.627905 -9.98027 -5
+      vertex -0.0941849 -1.49704 -5
+      vertex -0.314107 -9.99506 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.0941849 -1.49704 -5
+      vertex -0.627905 -9.98027 -5
+      vertex -0.141162 -1.49334 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.941083 -9.95562 -5
+      vertex -0.141162 -1.49334 -5
+      vertex -0.627905 -9.98027 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.141162 -1.49334 -5
+      vertex -0.941083 -9.95562 -5
+      vertex -0.188 -1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.25333 -9.92115 -5
+      vertex -0.188 -1.48817 -5
+      vertex -0.941083 -9.95562 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.188 -1.48817 -5
+      vertex -1.25333 -9.92115 -5
+      vertex -0.234652 -1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.56434 -9.87688 -5
+      vertex -0.234652 -1.48153 -5
+      vertex -1.25333 -9.92115 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.234652 -1.48153 -5
+      vertex -1.56434 -9.87688 -5
+      vertex -0.281072 -1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.87381 -9.82287 -5
+      vertex -0.281072 -1.47343 -5
+      vertex -1.56434 -9.87688 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.281072 -1.47343 -5
+      vertex -1.87381 -9.82287 -5
+      vertex -0.327214 -1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18143 -9.75917 -5
+      vertex -0.327214 -1.46387 -5
+      vertex -1.87381 -9.82287 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.327214 -1.46387 -5
+      vertex -2.18143 -9.75917 -5
+      vertex -0.373034 -1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.4869 -9.68583 -5
+      vertex -0.373034 -1.45287 -5
+      vertex -2.18143 -9.75917 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.373034 -1.45287 -5
+      vertex -2.4869 -9.68583 -5
+      vertex -0.418487 -1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.78991 -9.60294 -5
+      vertex -0.418487 -1.44044 -5
+      vertex -2.4869 -9.68583 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.418487 -1.44044 -5
+      vertex -2.78991 -9.60294 -5
+      vertex -0.463525 -1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.09017 -9.51056 -5
+      vertex -0.463525 -1.42658 -5
+      vertex -2.78991 -9.60294 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.463525 -1.42658 -5
+      vertex -3.09017 -9.51056 -5
+      vertex -0.508106 -1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.38738 -9.40881 -5
+      vertex -0.508106 -1.41132 -5
+      vertex -3.09017 -9.51056 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.508106 -1.41132 -5
+      vertex -3.38738 -9.40881 -5
+      vertex -0.552186 -1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.68124 -9.29776 -5
+      vertex -0.552186 -1.39466 -5
+      vertex -3.38738 -9.40881 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.552186 -1.39466 -5
+      vertex -3.68124 -9.29776 -5
+      vertex -0.595721 -1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.97148 -9.17755 -5
+      vertex -0.595721 -1.37663 -5
+      vertex -3.68124 -9.29776 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.595721 -1.37663 -5
+      vertex -3.97148 -9.17755 -5
+      vertex -0.638668 -1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.25779 -9.04827 -5
+      vertex -0.638668 -1.35724 -5
+      vertex -3.97148 -9.17755 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.638668 -1.35724 -5
+      vertex -4.25779 -9.04827 -5
+      vertex -0.680985 -1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.5399 -8.91006 -5
+      vertex -0.680985 -1.33651 -5
+      vertex -4.25779 -9.04827 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.680985 -1.33651 -5
+      vertex -4.5399 -8.91006 -5
+      vertex -0.722631 -1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.81754 -8.76307 -5
+      vertex -0.722631 -1.31446 -5
+      vertex -4.5399 -8.91006 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.722631 -1.31446 -5
+      vertex -4.81754 -8.76307 -5
+      vertex -0.763561 -1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.09041 -8.60742 -5
+      vertex -0.763561 -1.29111 -5
+      vertex -4.81754 -8.76307 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.763561 -1.29111 -5
+      vertex -5.09041 -8.60742 -5
+      vertex -0.80374 -1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.35827 -8.44328 -5
+      vertex -0.80374 -1.26649 -5
+      vertex -5.09041 -8.60742 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.80374 -1.26649 -5
+      vertex -5.35827 -8.44328 -5
+      vertex -0.843124 -1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.62083 -8.27081 -5
+      vertex -0.843124 -1.24062 -5
+      vertex -5.35827 -8.44328 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.843124 -1.24062 -5
+      vertex -5.62083 -8.27081 -5
+      vertex -0.881678 -1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.87785 -8.09017 -5
+      vertex -0.881678 -1.21352 -5
+      vertex -5.62083 -8.27081 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.881678 -1.21352 -5
+      vertex -5.87785 -8.09017 -5
+      vertex -0.91936 -1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.12907 -7.90155 -5
+      vertex -0.91936 -1.18523 -5
+      vertex -5.87785 -8.09017 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.91936 -1.18523 -5
+      vertex -6.12907 -7.90155 -5
+      vertex -0.956136 -1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.37424 -7.70513 -5
+      vertex -0.956136 -1.15577 -5
+      vertex -6.12907 -7.90155 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.956136 -1.15577 -5
+      vertex -6.37424 -7.70513 -5
+      vertex -0.991967 -1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.61312 -7.50111 -5
+      vertex -0.991967 -1.12517 -5
+      vertex -6.37424 -7.70513 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.991967 -1.12517 -5
+      vertex -6.61312 -7.50111 -5
+      vertex -1.02682 -1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.84547 -7.28969 -5
+      vertex -1.02682 -1.09345 -5
+      vertex -6.61312 -7.50111 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.02682 -1.09345 -5
+      vertex -6.84547 -7.28969 -5
+      vertex -1.06066 -1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.07107 -7.07107 -5
+      vertex -1.06066 -1.06066 -5
+      vertex -6.84547 -7.28969 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.06066 -1.06066 -5
+      vertex -7.07107 -7.07107 -5
+      vertex -1.09345 -1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.28969 -6.84547 -5
+      vertex -1.09345 -1.02682 -5
+      vertex -7.07107 -7.07107 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.09345 -1.02682 -5
+      vertex -7.28969 -6.84547 -5
+      vertex -1.12517 -0.991967 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.12517 -0.991967 -5
+      vertex -7.50111 -6.61312 -5
+      vertex -1.15577 -0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.50111 -6.61312 -5
+      vertex -1.12517 -0.991967 -5
+      vertex -7.28969 -6.84547 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.5 0 -5
+      vertex 240 0 -5
+      vertex 239.995 -0.314107 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.843 1.24062 -5
+      vertex 240 0 -5
+      vertex 230.882 1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.499 -0.0471153 -5
+      vertex 239.995 -0.314107 -5
+      vertex 239.98 -0.627905 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 230.919 1.18523 -5
+      vertex 230.882 1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.497 -0.0941849 -5
+      vertex 239.98 -0.627905 -5
+      vertex 239.956 -0.941083 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 230.843 1.24062 -5
+      vertex 240 20 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.493 -0.141162 -5
+      vertex 239.956 -0.941083 -5
+      vertex 239.921 -1.25333 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 230.956 1.15577 -5
+      vertex 230.919 1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.488 -0.188 -5
+      vertex 239.921 -1.25333 -5
+      vertex 239.877 -1.56434 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 230.992 1.12517 -5
+      vertex 230.956 1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.482 -0.234652 -5
+      vertex 239.877 -1.56434 -5
+      vertex 239.823 -1.87381 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.804 1.26649 -5
+      vertex 240 20 -5
+      vertex 230.843 1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.473 -0.281072 -5
+      vertex 239.823 -1.87381 -5
+      vertex 239.759 -2.18143 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.027 1.09345 -5
+      vertex 230.992 1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.464 -0.327214 -5
+      vertex 239.759 -2.18143 -5
+      vertex 239.686 -2.4869 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.061 1.06066 -5
+      vertex 231.027 1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.453 -0.373034 -5
+      vertex 239.686 -2.4869 -5
+      vertex 239.603 -2.78991 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.093 1.02682 -5
+      vertex 231.061 1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.44 -0.418487 -5
+      vertex 239.603 -2.78991 -5
+      vertex 239.511 -3.09017 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.764 1.29111 -5
+      vertex 240 20 -5
+      vertex 230.804 1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.427 -0.463525 -5
+      vertex 239.511 -3.09017 -5
+      vertex 239.409 -3.38738 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.125 0.991967 -5
+      vertex 231.093 1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.411 -0.508106 -5
+      vertex 239.409 -3.38738 -5
+      vertex 239.298 -3.68124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.156 0.956136 -5
+      vertex 231.125 0.991967 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.395 -0.552186 -5
+      vertex 239.298 -3.68124 -5
+      vertex 239.178 -3.97148 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.723 1.31446 -5
+      vertex 240 20 -5
+      vertex 230.764 1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.377 -0.595721 -5
+      vertex 239.178 -3.97148 -5
+      vertex 239.048 -4.25779 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.185 0.91936 -5
+      vertex 231.156 0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.357 -0.638668 -5
+      vertex 239.048 -4.25779 -5
+      vertex 238.91 -4.5399 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.214 0.881678 -5
+      vertex 231.185 0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.337 -0.680985 -5
+      vertex 238.91 -4.5399 -5
+      vertex 238.763 -4.81754 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.241 0.843124 -5
+      vertex 231.214 0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.314 -0.722631 -5
+      vertex 238.763 -4.81754 -5
+      vertex 238.607 -5.09041 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.681 1.33651 -5
+      vertex 240 20 -5
+      vertex 230.723 1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.291 -0.763561 -5
+      vertex 238.607 -5.09041 -5
+      vertex 238.443 -5.35827 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.266 0.80374 -5
+      vertex 231.241 0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.266 -0.80374 -5
+      vertex 238.443 -5.35827 -5
+      vertex 238.271 -5.62083 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.291 0.763561 -5
+      vertex 231.266 0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.241 -0.843124 -5
+      vertex 238.271 -5.62083 -5
+      vertex 238.09 -5.87785 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.639 1.35724 -5
+      vertex 240 20 -5
+      vertex 230.681 1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.214 -0.881678 -5
+      vertex 238.09 -5.87785 -5
+      vertex 237.902 -6.12907 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.314 0.722631 -5
+      vertex 231.291 0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.185 -0.91936 -5
+      vertex 237.902 -6.12907 -5
+      vertex 237.705 -6.37424 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.337 0.680985 -5
+      vertex 231.314 0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.156 -0.956136 -5
+      vertex 237.705 -6.37424 -5
+      vertex 237.501 -6.61312 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.596 1.37663 -5
+      vertex 240 20 -5
+      vertex 230.639 1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.125 -0.991967 -5
+      vertex 237.501 -6.61312 -5
+      vertex 237.29 -6.84547 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.357 0.638668 -5
+      vertex 231.337 0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.093 -1.02682 -5
+      vertex 237.29 -6.84547 -5
+      vertex 237.071 -7.07107 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.377 0.595721 -5
+      vertex 231.357 0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.061 -1.06066 -5
+      vertex 237.071 -7.07107 -5
+      vertex 236.845 -7.28969 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.552 1.39466 -5
+      vertex 240 20 -5
+      vertex 230.596 1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.027 -1.09345 -5
+      vertex 236.845 -7.28969 -5
+      vertex 236.613 -7.50111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.395 0.552186 -5
+      vertex 231.377 0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.992 -1.12517 -5
+      vertex 236.613 -7.50111 -5
+      vertex 236.374 -7.70513 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.411 0.508106 -5
+      vertex 231.395 0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.956 -1.15577 -5
+      vertex 236.374 -7.70513 -5
+      vertex 236.129 -7.90155 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.508 1.41132 -5
+      vertex 240 20 -5
+      vertex 230.552 1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.919 -1.18523 -5
+      vertex 236.129 -7.90155 -5
+      vertex 235.878 -8.09017 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.427 0.463525 -5
+      vertex 231.411 0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.882 -1.21352 -5
+      vertex 235.878 -8.09017 -5
+      vertex 235.621 -8.27081 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.44 0.418487 -5
+      vertex 231.427 0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.843 -1.24062 -5
+      vertex 235.621 -8.27081 -5
+      vertex 235.358 -8.44328 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.464 1.42658 -5
+      vertex 240 20 -5
+      vertex 230.508 1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.804 -1.26649 -5
+      vertex 235.358 -8.44328 -5
+      vertex 235.09 -8.60742 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.453 0.373034 -5
+      vertex 231.44 0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.764 -1.29111 -5
+      vertex 235.09 -8.60742 -5
+      vertex 234.818 -8.76307 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.464 0.327214 -5
+      vertex 231.453 0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.723 -1.31446 -5
+      vertex 234.818 -8.76307 -5
+      vertex 234.54 -8.91006 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.418 1.44044 -5
+      vertex 240 20 -5
+      vertex 230.464 1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.681 -1.33651 -5
+      vertex 234.54 -8.91006 -5
+      vertex 234.258 -9.04827 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.473 0.281072 -5
+      vertex 231.464 0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.639 -1.35724 -5
+      vertex 234.258 -9.04827 -5
+      vertex 233.971 -9.17755 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.482 0.234652 -5
+      vertex 231.473 0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.596 -1.37663 -5
+      vertex 233.971 -9.17755 -5
+      vertex 233.681 -9.29776 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.373 1.45287 -5
+      vertex 240 20 -5
+      vertex 230.418 1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.552 -1.39466 -5
+      vertex 233.681 -9.29776 -5
+      vertex 233.387 -9.40881 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.488 0.188 -5
+      vertex 231.482 0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.508 -1.41132 -5
+      vertex 233.387 -9.40881 -5
+      vertex 233.09 -9.51056 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.493 0.141162 -5
+      vertex 231.488 0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.464 -1.42658 -5
+      vertex 233.09 -9.51056 -5
+      vertex 232.79 -9.60294 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.327 1.46387 -5
+      vertex 240 20 -5
+      vertex 230.373 1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.418 -1.44044 -5
+      vertex 232.79 -9.60294 -5
+      vertex 232.487 -9.68583 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.497 0.0941849 -5
+      vertex 231.493 0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.373 -1.45287 -5
+      vertex 232.487 -9.68583 -5
+      vertex 232.181 -9.75917 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.499 0.0471153 -5
+      vertex 231.497 0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.327 -1.46387 -5
+      vertex 232.181 -9.75917 -5
+      vertex 231.874 -9.82287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 240 0 -5
+      vertex 231.5 0 -5
+      vertex 231.499 0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.281 -1.47343 -5
+      vertex 231.874 -9.82287 -5
+      vertex 231.564 -9.87688 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.281 1.47343 -5
+      vertex 240 20 -5
+      vertex 230.327 1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.235 1.48153 -5
+      vertex 240 20 -5
+      vertex 230.281 1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.995 -0.314107 -5
+      vertex 231.499 -0.0471153 -5
+      vertex 231.5 0 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.98 -0.627905 -5
+      vertex 231.497 -0.0941849 -5
+      vertex 231.499 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.956 -0.941083 -5
+      vertex 231.493 -0.141162 -5
+      vertex 231.497 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.921 -1.25333 -5
+      vertex 231.488 -0.188 -5
+      vertex 231.493 -0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.877 -1.56434 -5
+      vertex 231.482 -0.234652 -5
+      vertex 231.488 -0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.823 -1.87381 -5
+      vertex 231.473 -0.281072 -5
+      vertex 231.482 -0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.759 -2.18143 -5
+      vertex 231.464 -0.327214 -5
+      vertex 231.473 -0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.686 -2.4869 -5
+      vertex 231.453 -0.373034 -5
+      vertex 231.464 -0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.603 -2.78991 -5
+      vertex 231.44 -0.418487 -5
+      vertex 231.453 -0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.511 -3.09017 -5
+      vertex 231.427 -0.463525 -5
+      vertex 231.44 -0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.409 -3.38738 -5
+      vertex 231.411 -0.508106 -5
+      vertex 231.427 -0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.298 -3.68124 -5
+      vertex 231.395 -0.552186 -5
+      vertex 231.411 -0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.178 -3.97148 -5
+      vertex 231.377 -0.595721 -5
+      vertex 231.395 -0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 239.048 -4.25779 -5
+      vertex 231.357 -0.638668 -5
+      vertex 231.377 -0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 238.91 -4.5399 -5
+      vertex 231.337 -0.680985 -5
+      vertex 231.357 -0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 238.763 -4.81754 -5
+      vertex 231.314 -0.722631 -5
+      vertex 231.337 -0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 238.607 -5.09041 -5
+      vertex 231.291 -0.763561 -5
+      vertex 231.314 -0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 238.443 -5.35827 -5
+      vertex 231.266 -0.80374 -5
+      vertex 231.291 -0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.235 -1.48153 -5
+      vertex 231.564 -9.87688 -5
+      vertex 231.253 -9.92115 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 238.271 -5.62083 -5
+      vertex 231.241 -0.843124 -5
+      vertex 231.266 -0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 238.09 -5.87785 -5
+      vertex 231.214 -0.881678 -5
+      vertex 231.241 -0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 237.902 -6.12907 -5
+      vertex 231.185 -0.91936 -5
+      vertex 231.214 -0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 237.705 -6.37424 -5
+      vertex 231.156 -0.956136 -5
+      vertex 231.185 -0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 237.501 -6.61312 -5
+      vertex 231.125 -0.991967 -5
+      vertex 231.156 -0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 237.29 -6.84547 -5
+      vertex 231.093 -1.02682 -5
+      vertex 231.125 -0.991967 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 237.071 -7.07107 -5
+      vertex 231.061 -1.06066 -5
+      vertex 231.093 -1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 236.845 -7.28969 -5
+      vertex 231.027 -1.09345 -5
+      vertex 231.061 -1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 236.613 -7.50111 -5
+      vertex 230.992 -1.12517 -5
+      vertex 231.027 -1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 236.374 -7.70513 -5
+      vertex 230.956 -1.15577 -5
+      vertex 230.992 -1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.188 -1.48817 -5
+      vertex 231.253 -9.92115 -5
+      vertex 230.941 -9.95562 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 236.129 -7.90155 -5
+      vertex 230.919 -1.18523 -5
+      vertex 230.956 -1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 235.878 -8.09017 -5
+      vertex 230.882 -1.21352 -5
+      vertex 230.919 -1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 235.621 -8.27081 -5
+      vertex 230.843 -1.24062 -5
+      vertex 230.882 -1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 235.358 -8.44328 -5
+      vertex 230.804 -1.26649 -5
+      vertex 230.843 -1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 235.09 -8.60742 -5
+      vertex 230.764 -1.29111 -5
+      vertex 230.804 -1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 234.818 -8.76307 -5
+      vertex 230.723 -1.31446 -5
+      vertex 230.764 -1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 234.54 -8.91006 -5
+      vertex 230.681 -1.33651 -5
+      vertex 230.723 -1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 234.258 -9.04827 -5
+      vertex 230.639 -1.35724 -5
+      vertex 230.681 -1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.141 -1.49334 -5
+      vertex 230.941 -9.95562 -5
+      vertex 230.628 -9.98027 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 233.971 -9.17755 -5
+      vertex 230.596 -1.37663 -5
+      vertex 230.639 -1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 233.681 -9.29776 -5
+      vertex 230.552 -1.39466 -5
+      vertex 230.596 -1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 233.387 -9.40881 -5
+      vertex 230.508 -1.41132 -5
+      vertex 230.552 -1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 233.09 -9.51056 -5
+      vertex 230.464 -1.42658 -5
+      vertex 230.508 -1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 232.79 -9.60294 -5
+      vertex 230.418 -1.44044 -5
+      vertex 230.464 -1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 232.487 -9.68583 -5
+      vertex 230.373 -1.45287 -5
+      vertex 230.418 -1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 232.181 -9.75917 -5
+      vertex 230.327 -1.46387 -5
+      vertex 230.373 -1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.094 -1.49704 -5
+      vertex 230.628 -9.98027 -5
+      vertex 230.314 -9.99506 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.874 -9.82287 -5
+      vertex 230.281 -1.47343 -5
+      vertex 230.327 -1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.564 -9.87688 -5
+      vertex 230.235 -1.48153 -5
+      vertex 230.281 -1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 231.253 -9.92115 -5
+      vertex 230.188 -1.48817 -5
+      vertex 230.235 -1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.941 -9.95562 -5
+      vertex 230.141 -1.49334 -5
+      vertex 230.188 -1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.628 -9.98027 -5
+      vertex 230.094 -1.49704 -5
+      vertex 230.141 -1.49334 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.314 -9.99506 -5
+      vertex 230.047 -1.49926 -5
+      vertex 230.094 -1.49704 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230 -10 -5
+      vertex 230.047 -1.49926 -5
+      vertex 230.314 -9.99506 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230 -10 -5
+      vertex 230 -1.5 -5
+      vertex 230.047 -1.49926 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230 -10 -5
+      vertex 229.953 -1.49926 -5
+      vertex 230 -1.5 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 229.686 -9.99506 -5
+      vertex 229.953 -1.49926 -5
+      vertex 230 -10 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.953 -1.49926 -5
+      vertex 229.686 -9.99506 -5
+      vertex 229.906 -1.49704 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 229.372 -9.98027 -5
+      vertex 229.906 -1.49704 -5
+      vertex 229.686 -9.99506 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.906 -1.49704 -5
+      vertex 229.372 -9.98027 -5
+      vertex 229.859 -1.49334 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 229.059 -9.95562 -5
+      vertex 229.859 -1.49334 -5
+      vertex 229.372 -9.98027 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.859 -1.49334 -5
+      vertex 229.059 -9.95562 -5
+      vertex 229.812 -1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 228.747 -9.92115 -5
+      vertex 229.812 -1.48817 -5
+      vertex 229.059 -9.95562 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.812 -1.48817 -5
+      vertex 228.747 -9.92115 -5
+      vertex 229.765 -1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 228.436 -9.87688 -5
+      vertex 229.765 -1.48153 -5
+      vertex 228.747 -9.92115 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.765 -1.48153 -5
+      vertex 228.436 -9.87688 -5
+      vertex 229.719 -1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 228.126 -9.82287 -5
+      vertex 229.719 -1.47343 -5
+      vertex 228.436 -9.87688 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.719 -1.47343 -5
+      vertex 228.126 -9.82287 -5
+      vertex 229.673 -1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 227.819 -9.75917 -5
+      vertex 229.673 -1.46387 -5
+      vertex 228.126 -9.82287 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.673 -1.46387 -5
+      vertex 227.819 -9.75917 -5
+      vertex 229.627 -1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 227.513 -9.68583 -5
+      vertex 229.627 -1.45287 -5
+      vertex 227.819 -9.75917 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.627 -1.45287 -5
+      vertex 227.513 -9.68583 -5
+      vertex 229.582 -1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 227.21 -9.60294 -5
+      vertex 229.582 -1.44044 -5
+      vertex 227.513 -9.68583 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.582 -1.44044 -5
+      vertex 227.21 -9.60294 -5
+      vertex 229.536 -1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 226.91 -9.51056 -5
+      vertex 229.536 -1.42658 -5
+      vertex 227.21 -9.60294 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.536 -1.42658 -5
+      vertex 226.91 -9.51056 -5
+      vertex 229.492 -1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 226.613 -9.40881 -5
+      vertex 229.492 -1.41132 -5
+      vertex 226.91 -9.51056 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.492 -1.41132 -5
+      vertex 226.613 -9.40881 -5
+      vertex 229.448 -1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 226.319 -9.29776 -5
+      vertex 229.448 -1.39466 -5
+      vertex 226.613 -9.40881 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.448 -1.39466 -5
+      vertex 226.319 -9.29776 -5
+      vertex 229.404 -1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 226.029 -9.17755 -5
+      vertex 229.404 -1.37663 -5
+      vertex 226.319 -9.29776 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.404 -1.37663 -5
+      vertex 226.029 -9.17755 -5
+      vertex 229.361 -1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 225.742 -9.04827 -5
+      vertex 229.361 -1.35724 -5
+      vertex 226.029 -9.17755 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.361 -1.35724 -5
+      vertex 225.742 -9.04827 -5
+      vertex 229.319 -1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 225.46 -8.91006 -5
+      vertex 229.319 -1.33651 -5
+      vertex 225.742 -9.04827 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.319 -1.33651 -5
+      vertex 225.46 -8.91006 -5
+      vertex 229.277 -1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 225.182 -8.76307 -5
+      vertex 229.277 -1.31446 -5
+      vertex 225.46 -8.91006 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.277 -1.31446 -5
+      vertex 225.182 -8.76307 -5
+      vertex 229.236 -1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.91 -8.60742 -5
+      vertex 229.236 -1.29111 -5
+      vertex 225.182 -8.76307 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.236 -1.29111 -5
+      vertex 224.91 -8.60742 -5
+      vertex 229.196 -1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.642 -8.44328 -5
+      vertex 229.196 -1.26649 -5
+      vertex 224.91 -8.60742 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.196 -1.26649 -5
+      vertex 224.642 -8.44328 -5
+      vertex 229.157 -1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.379 -8.27081 -5
+      vertex 229.157 -1.24062 -5
+      vertex 224.642 -8.44328 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.157 -1.24062 -5
+      vertex 224.379 -8.27081 -5
+      vertex 229.118 -1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 224.122 -8.09017 -5
+      vertex 229.118 -1.21352 -5
+      vertex 224.379 -8.27081 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.118 -1.21352 -5
+      vertex 224.122 -8.09017 -5
+      vertex 229.081 -1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.871 -7.90155 -5
+      vertex 229.081 -1.18523 -5
+      vertex 224.122 -8.09017 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.081 -1.18523 -5
+      vertex 223.871 -7.90155 -5
+      vertex 229.044 -1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.626 -7.70513 -5
+      vertex 229.044 -1.15577 -5
+      vertex 223.871 -7.90155 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.044 -1.15577 -5
+      vertex 223.626 -7.70513 -5
+      vertex 229.008 -1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.387 -7.50111 -5
+      vertex 229.008 -1.12517 -5
+      vertex 223.626 -7.70513 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 229.008 -1.12517 -5
+      vertex 223.387 -7.50111 -5
+      vertex 228.973 -1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 223.155 -7.28969 -5
+      vertex 228.973 -1.09345 -5
+      vertex 223.387 -7.50111 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.973 -1.09345 -5
+      vertex 223.155 -7.28969 -5
+      vertex 228.939 -1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.929 -7.07107 -5
+      vertex 228.939 -1.06066 -5
+      vertex 223.155 -7.28969 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.939 -1.06066 -5
+      vertex 222.929 -7.07107 -5
+      vertex 228.907 -1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.71 -6.84547 -5
+      vertex 228.907 -1.02682 -5
+      vertex 222.929 -7.07107 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.907 -1.02682 -5
+      vertex 222.71 -6.84547 -5
+      vertex 228.875 -0.991967 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.875 -0.991967 -5
+      vertex 222.499 -6.61312 -5
+      vertex 228.844 -0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.499 -6.61312 -5
+      vertex 228.875 -0.991967 -5
+      vertex 222.71 -6.84547 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.188 1.48817 -5
+      vertex 240 20 -5
+      vertex 230.235 1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 230.141 1.49334 -5
+      vertex 240 20 -5
+      vertex 230.188 1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 240 20 -5
+      vertex 230.141 1.49334 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 240 20 -5
+      vertex 220 10 -5
+      vertex 239.995 20.3141 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.995 20.3141 -5
+      vertex 220 10 -5
+      vertex 239.98 20.6279 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.98 20.6279 -5
+      vertex 220 10 -5
+      vertex 239.956 20.9411 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.921 21.2533 -5
+      vertex 220 10 -5
+      vertex 239.877 21.5643 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.877 21.5643 -5
+      vertex 220 10 -5
+      vertex 239.823 21.8738 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.823 21.8738 -5
+      vertex 220 10 -5
+      vertex 239.759 22.1814 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.759 22.1814 -5
+      vertex 220 10 -5
+      vertex 239.686 22.4869 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.686 22.4869 -5
+      vertex 220 10 -5
+      vertex 239.603 22.7899 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.603 22.7899 -5
+      vertex 220 10 -5
+      vertex 239.511 23.0902 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.511 23.0902 -5
+      vertex 220 10 -5
+      vertex 239.409 23.3874 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.298 23.6812 -5
+      vertex 220 10 -5
+      vertex 239.178 23.9715 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.178 23.9715 -5
+      vertex 220 10 -5
+      vertex 239.048 24.2578 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.048 24.2578 -5
+      vertex 220 10 -5
+      vertex 238.91 24.5399 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 238.91 24.5399 -5
+      vertex 220 10 -5
+      vertex 238.763 24.8175 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 238.763 24.8175 -5
+      vertex 220 10 -5
+      vertex 238.607 25.0904 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 238.607 25.0904 -5
+      vertex 220 10 -5
+      vertex 238.443 25.3583 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 238.443 25.3583 -5
+      vertex 220 10 -5
+      vertex 238.271 25.6208 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 238.271 25.6208 -5
+      vertex 220 10 -5
+      vertex 238.09 25.8779 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 238.09 25.8779 -5
+      vertex 220 10 -5
+      vertex 237.902 26.1291 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 237.902 26.1291 -5
+      vertex 220 10 -5
+      vertex 237.705 26.3742 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 237.501 26.6131 -5
+      vertex 220 10 -5
+      vertex 237.29 26.8455 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 237.29 26.8455 -5
+      vertex 220 10 -5
+      vertex 237.071 27.0711 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 237.071 27.0711 -5
+      vertex 220 10 -5
+      vertex 236.845 27.2897 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 236.845 27.2897 -5
+      vertex 220 10 -5
+      vertex 236.613 27.5011 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 236.613 27.5011 -5
+      vertex 220 10 -5
+      vertex 236.374 27.7051 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 236.374 27.7051 -5
+      vertex 220 10 -5
+      vertex 236.129 27.9016 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 236.129 27.9016 -5
+      vertex 220 10 -5
+      vertex 235.878 28.0902 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 235.878 28.0902 -5
+      vertex 220 10 -5
+      vertex 235.621 28.2708 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 235.621 28.2708 -5
+      vertex 220 10 -5
+      vertex 235.358 28.4433 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 235.358 28.4433 -5
+      vertex 220 10 -5
+      vertex 235.09 28.6074 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 235.09 28.6074 -5
+      vertex 220 10 -5
+      vertex 234.818 28.7631 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 234.818 28.7631 -5
+      vertex 220 10 -5
+      vertex 234.54 28.9101 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 234.54 28.9101 -5
+      vertex 220 10 -5
+      vertex 234.258 29.0483 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 233.971 29.1775 -5
+      vertex 220 10 -5
+      vertex 233.681 29.2978 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 233.681 29.2978 -5
+      vertex 220 10 -5
+      vertex 233.387 29.4088 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 233.387 29.4088 -5
+      vertex 220 10 -5
+      vertex 233.09 29.5106 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 233.09 29.5106 -5
+      vertex 220 10 -5
+      vertex 232.79 29.6029 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 232.79 29.6029 -5
+      vertex 220 10 -5
+      vertex 232.487 29.6858 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 232.487 29.6858 -5
+      vertex 220 10 -5
+      vertex 232.181 29.7592 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 232.181 29.7592 -5
+      vertex 220 10 -5
+      vertex 231.874 29.8229 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 231.874 29.8229 -5
+      vertex 220 10 -5
+      vertex 231.564 29.8769 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 231.564 29.8769 -5
+      vertex 220 10 -5
+      vertex 231.253 29.9211 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 231.253 29.9211 -5
+      vertex 220 10 -5
+      vertex 230.941 29.9556 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 230.941 29.9556 -5
+      vertex 220 10 -5
+      vertex 230.628 29.9803 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 234.258 29.0483 -5
+      vertex 220 10 -5
+      vertex 233.971 29.1775 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 237.705 26.3742 -5
+      vertex 220 10 -5
+      vertex 237.501 26.6131 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.409 23.3874 -5
+      vertex 220 10 -5
+      vertex 239.298 23.6812 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 239.956 20.9411 -5
+      vertex 220 10 -5
+      vertex 239.921 21.2533 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 230.141 1.49334 -5
+      vertex 230.094 1.49704 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 230.094 1.49704 -5
+      vertex 230.047 1.49926 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 230.047 1.49926 -5
+      vertex 230 1.5 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 230.628 29.9803 -5
+      vertex 220 10 -5
+      vertex 230.314 29.9951 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 230 1.5 -5
+      vertex 229.953 1.49926 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.953 1.49926 -5
+      vertex 229.906 1.49704 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.906 1.49704 -5
+      vertex 229.859 1.49334 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.859 1.49334 -5
+      vertex 229.812 1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.812 1.48817 -5
+      vertex 229.765 1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.765 1.48153 -5
+      vertex 229.719 1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.719 1.47343 -5
+      vertex 229.673 1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.673 1.46387 -5
+      vertex 229.627 1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.627 1.45287 -5
+      vertex 229.582 1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.582 1.44044 -5
+      vertex 229.536 1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.536 1.42658 -5
+      vertex 229.492 1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.492 1.41132 -5
+      vertex 229.448 1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.448 1.39466 -5
+      vertex 229.404 1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.404 1.37663 -5
+      vertex 229.361 1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.361 1.35724 -5
+      vertex 229.319 1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.319 1.33651 -5
+      vertex 229.277 1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.277 1.31446 -5
+      vertex 229.236 1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.236 1.29111 -5
+      vertex 229.196 1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.196 1.26649 -5
+      vertex 229.157 1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.157 1.24062 -5
+      vertex 229.118 1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.118 1.21352 -5
+      vertex 229.081 1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.081 1.18523 -5
+      vertex 229.044 1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.044 1.15577 -5
+      vertex 229.008 1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 229.008 1.12517 -5
+      vertex 228.973 1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 228.973 1.09345 -5
+      vertex 228.939 1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 228.939 1.06066 -5
+      vertex 228.907 1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 228.907 1.02682 -5
+      vertex 228.875 0.991967 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 10 -5
+      vertex 228.875 0.991967 -5
+      vertex 228.844 0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.844 0.956136 -5
+      vertex 228.815 0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.815 0.91936 -5
+      vertex 228.786 0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.786 0.881678 -5
+      vertex 228.759 0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.759 0.843124 -5
+      vertex 228.734 0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.734 0.80374 -5
+      vertex 228.709 0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.709 0.763561 -5
+      vertex 228.686 0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.686 0.722631 -5
+      vertex 228.663 0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.663 0.680985 -5
+      vertex 228.643 0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.643 0.638668 -5
+      vertex 228.623 0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.623 0.595721 -5
+      vertex 228.605 0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.605 0.552186 -5
+      vertex 228.589 0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.589 0.508106 -5
+      vertex 228.573 0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.573 0.463525 -5
+      vertex 228.56 0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.56 0.418487 -5
+      vertex 228.547 0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.547 0.373034 -5
+      vertex 228.536 0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.536 0.327214 -5
+      vertex 228.527 0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.527 0.281072 -5
+      vertex 228.518 0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.518 0.234652 -5
+      vertex 228.512 0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.512 0.188 -5
+      vertex 228.507 0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.507 0.141162 -5
+      vertex 228.503 0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.295 -6.37424 -5
+      vertex 228.844 -0.956136 -5
+      vertex 222.499 -6.61312 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.844 -0.956136 -5
+      vertex 222.295 -6.37424 -5
+      vertex 228.815 -0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 222.098 -6.12907 -5
+      vertex 228.815 -0.91936 -5
+      vertex 222.295 -6.37424 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.815 -0.91936 -5
+      vertex 222.098 -6.12907 -5
+      vertex 228.786 -0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 221.91 -5.87785 -5
+      vertex 228.786 -0.881678 -5
+      vertex 222.098 -6.12907 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.786 -0.881678 -5
+      vertex 221.91 -5.87785 -5
+      vertex 228.759 -0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 221.729 -5.62083 -5
+      vertex 228.759 -0.843124 -5
+      vertex 221.91 -5.87785 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.759 -0.843124 -5
+      vertex 221.729 -5.62083 -5
+      vertex 228.734 -0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 221.557 -5.35827 -5
+      vertex 228.734 -0.80374 -5
+      vertex 221.729 -5.62083 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.734 -0.80374 -5
+      vertex 221.557 -5.35827 -5
+      vertex 228.709 -0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 221.393 -5.09041 -5
+      vertex 228.709 -0.763561 -5
+      vertex 221.557 -5.35827 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.709 -0.763561 -5
+      vertex 221.393 -5.09041 -5
+      vertex 228.686 -0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 221.237 -4.81754 -5
+      vertex 228.686 -0.722631 -5
+      vertex 221.393 -5.09041 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.686 -0.722631 -5
+      vertex 221.237 -4.81754 -5
+      vertex 228.663 -0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 221.09 -4.5399 -5
+      vertex 228.663 -0.680985 -5
+      vertex 221.237 -4.81754 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.663 -0.680985 -5
+      vertex 221.09 -4.5399 -5
+      vertex 228.643 -0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.952 -4.25779 -5
+      vertex 228.643 -0.638668 -5
+      vertex 221.09 -4.5399 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.643 -0.638668 -5
+      vertex 220.952 -4.25779 -5
+      vertex 228.623 -0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.822 -3.97148 -5
+      vertex 228.623 -0.595721 -5
+      vertex 220.952 -4.25779 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.623 -0.595721 -5
+      vertex 220.822 -3.97148 -5
+      vertex 228.605 -0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.702 -3.68124 -5
+      vertex 228.605 -0.552186 -5
+      vertex 220.822 -3.97148 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.605 -0.552186 -5
+      vertex 220.702 -3.68124 -5
+      vertex 228.589 -0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.591 -3.38738 -5
+      vertex 228.589 -0.508106 -5
+      vertex 220.702 -3.68124 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.589 -0.508106 -5
+      vertex 220.591 -3.38738 -5
+      vertex 228.573 -0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.489 -3.09017 -5
+      vertex 228.573 -0.463525 -5
+      vertex 220.591 -3.38738 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.573 -0.463525 -5
+      vertex 220.489 -3.09017 -5
+      vertex 228.56 -0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.397 -2.78991 -5
+      vertex 228.56 -0.418487 -5
+      vertex 220.489 -3.09017 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.56 -0.418487 -5
+      vertex 220.397 -2.78991 -5
+      vertex 228.547 -0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.314 -2.4869 -5
+      vertex 228.547 -0.373034 -5
+      vertex 220.397 -2.78991 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.547 -0.373034 -5
+      vertex 220.314 -2.4869 -5
+      vertex 228.536 -0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.241 -2.18143 -5
+      vertex 228.536 -0.327214 -5
+      vertex 220.314 -2.4869 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.536 -0.327214 -5
+      vertex 220.241 -2.18143 -5
+      vertex 228.527 -0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.177 -1.87381 -5
+      vertex 228.527 -0.281072 -5
+      vertex 220.241 -2.18143 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.527 -0.281072 -5
+      vertex 220.177 -1.87381 -5
+      vertex 228.518 -0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.123 -1.56434 -5
+      vertex 228.518 -0.234652 -5
+      vertex 220.177 -1.87381 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.518 -0.234652 -5
+      vertex 220.123 -1.56434 -5
+      vertex 228.512 -0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.079 -1.25333 -5
+      vertex 228.512 -0.188 -5
+      vertex 220.123 -1.56434 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.512 -0.188 -5
+      vertex 220.079 -1.25333 -5
+      vertex 228.507 -0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.044 -0.941083 -5
+      vertex 228.507 -0.141162 -5
+      vertex 220.079 -1.25333 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.507 -0.141162 -5
+      vertex 220.044 -0.941083 -5
+      vertex 228.503 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.02 -0.627905 -5
+      vertex 228.503 -0.0941849 -5
+      vertex 220.044 -0.941083 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.503 -0.0941849 -5
+      vertex 220.02 -0.627905 -5
+      vertex 228.501 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220.005 -0.314107 -5
+      vertex 228.501 -0.0471153 -5
+      vertex 220.02 -0.627905 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.501 -0.0471153 -5
+      vertex 220.005 -0.314107 -5
+      vertex 228.5 0 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 220 0 -5
+      vertex 228.5 0 -5
+      vertex 220.005 -0.314107 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 228.5 0 -5
+      vertex 220 0 -5
+      vertex 228.501 0.0471153 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.501 0.0471153 -5
+      vertex 220 0 -5
+      vertex 228.503 0.0941849 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 228.844 0.956136 -5
+      vertex 220 0 -5
+      vertex 220 10 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 230.314 29.9951 -5
+      vertex 220 10 -5
+      vertex 230 30 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 10 -5
+      vertex 230 30 -5
+      vertex 220 10 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.99506 -0.314107 -5
+      vertex 9.98027 -0.627905 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.98027 -0.627905 -5
+      vertex 9.95562 -0.941083 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.95562 -0.941083 -5
+      vertex 9.92115 -1.25333 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.92115 -1.25333 -5
+      vertex 9.87688 -1.56434 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.87688 -1.56434 -5
+      vertex 9.82287 -1.87381 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.82287 -1.87381 -5
+      vertex 9.75917 -2.18143 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.75917 -2.18143 -5
+      vertex 9.68583 -2.4869 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.68583 -2.4869 -5
+      vertex 9.60294 -2.78991 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.60294 -2.78991 -5
+      vertex 9.51056 -3.09017 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.51056 -3.09017 -5
+      vertex 9.40881 -3.38738 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.40881 -3.38738 -5
+      vertex 9.29776 -3.68124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.29776 -3.68124 -5
+      vertex 9.17755 -3.97148 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.17755 -3.97148 -5
+      vertex 9.04827 -4.25779 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 9.04827 -4.25779 -5
+      vertex 8.91006 -4.5399 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 8.91006 -4.5399 -5
+      vertex 8.76307 -4.81754 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 8.76307 -4.81754 -5
+      vertex 8.60742 -5.09041 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 8.60742 -5.09041 -5
+      vertex 8.44328 -5.35827 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 8.44328 -5.35827 -5
+      vertex 8.27081 -5.62083 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 8.27081 -5.62083 -5
+      vertex 8.09017 -5.87785 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 8.09017 -5.87785 -5
+      vertex 7.90155 -6.12907 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 7.90155 -6.12907 -5
+      vertex 7.70513 -6.37424 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 7.70513 -6.37424 -5
+      vertex 7.50111 -6.61312 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 7.50111 -6.61312 -5
+      vertex 7.28969 -6.84547 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 7.28969 -6.84547 -5
+      vertex 7.07107 -7.07107 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 7.07107 -7.07107 -5
+      vertex 6.84547 -7.28969 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 6.84547 -7.28969 -5
+      vertex 6.61312 -7.50111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 6.61312 -7.50111 -5
+      vertex 6.37424 -7.70513 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 6.37424 -7.70513 -5
+      vertex 6.12907 -7.90155 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 6.12907 -7.90155 -5
+      vertex 5.87785 -8.09017 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 5.87785 -8.09017 -5
+      vertex 5.62083 -8.27081 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 5.62083 -8.27081 -5
+      vertex 5.35827 -8.44328 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 5.35827 -8.44328 -5
+      vertex 5.09041 -8.60742 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 5.09041 -8.60742 -5
+      vertex 4.81754 -8.76307 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 4.81754 -8.76307 -5
+      vertex 4.5399 -8.91006 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 4.5399 -8.91006 -5
+      vertex 4.25779 -9.04827 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 4.25779 -9.04827 -5
+      vertex 3.97148 -9.17755 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 3.97148 -9.17755 -5
+      vertex 3.68124 -9.29776 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 3.68124 -9.29776 -5
+      vertex 3.38738 -9.40881 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 3.38738 -9.40881 -5
+      vertex 3.09017 -9.51056 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 3.09017 -9.51056 -5
+      vertex 2.78991 -9.60294 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 2.78991 -9.60294 -5
+      vertex 2.4869 -9.68583 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 2.4869 -9.68583 -5
+      vertex 2.18143 -9.75917 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 2.18143 -9.75917 -5
+      vertex 1.87381 -9.82287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.281072 -1.47343 -5
+      vertex 1.87381 -9.82287 -5
+      vertex 1.56434 -9.87688 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.5 0 -5
+      vertex 1.49926 0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.49926 0.0471153 -5
+      vertex 1.49704 0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.49704 0.0941849 -5
+      vertex 1.49334 0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.49334 0.141162 -5
+      vertex 1.48817 0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.48817 0.188 -5
+      vertex 1.48153 0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.48153 0.234652 -5
+      vertex 1.47343 0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.47343 0.281072 -5
+      vertex 1.46387 0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.46387 0.327214 -5
+      vertex 1.45287 0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.45287 0.373034 -5
+      vertex 1.44044 0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.44044 0.418487 -5
+      vertex 1.42658 0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.42658 0.463525 -5
+      vertex 1.41132 0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.41132 0.508106 -5
+      vertex 1.39466 0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.39466 0.552186 -5
+      vertex 1.37663 0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.37663 0.595721 -5
+      vertex 1.35724 0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.35724 0.638668 -5
+      vertex 1.33651 0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.33651 0.680985 -5
+      vertex 1.31446 0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.31446 0.722631 -5
+      vertex 1.29111 0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.29111 0.763561 -5
+      vertex 1.26649 0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.26649 0.80374 -5
+      vertex 1.24062 0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.24062 0.843124 -5
+      vertex 1.21352 0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.21352 0.881678 -5
+      vertex 1.18523 0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.15577 0.956136 -5
+      vertex 10 0 -5
+      vertex 1.18523 0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 0 -5
+      vertex 1.15577 0.956136 -5
+      vertex 10 10 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.12517 0.991967 -5
+      vertex 10 10 -5
+      vertex 1.15577 0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.09345 1.02682 -5
+      vertex 10 10 -5
+      vertex 1.12517 0.991967 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.06066 1.06066 -5
+      vertex 10 10 -5
+      vertex 1.09345 1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 1.02682 1.09345 -5
+      vertex 10 10 -5
+      vertex 1.06066 1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.991967 1.12517 -5
+      vertex 10 10 -5
+      vertex 1.02682 1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.956136 1.15577 -5
+      vertex 10 10 -5
+      vertex 0.991967 1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.91936 1.18523 -5
+      vertex 10 10 -5
+      vertex 0.956136 1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.881678 1.21352 -5
+      vertex 10 10 -5
+      vertex 0.91936 1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.843124 1.24062 -5
+      vertex 10 10 -5
+      vertex 0.881678 1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.80374 1.26649 -5
+      vertex 10 10 -5
+      vertex 0.843124 1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.763561 1.29111 -5
+      vertex 10 10 -5
+      vertex 0.80374 1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.722631 1.31446 -5
+      vertex 10 10 -5
+      vertex 0.763561 1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.680985 1.33651 -5
+      vertex 10 10 -5
+      vertex 0.722631 1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.638668 1.35724 -5
+      vertex 10 10 -5
+      vertex 0.680985 1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.595721 1.37663 -5
+      vertex 10 10 -5
+      vertex 0.638668 1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.552186 1.39466 -5
+      vertex 10 10 -5
+      vertex 0.595721 1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.508106 1.41132 -5
+      vertex 10 10 -5
+      vertex 0.552186 1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.463525 1.42658 -5
+      vertex 10 10 -5
+      vertex 0.508106 1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.418487 1.44044 -5
+      vertex 10 10 -5
+      vertex 0.463525 1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.373034 1.45287 -5
+      vertex 10 10 -5
+      vertex 0.418487 1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.327214 1.46387 -5
+      vertex 10 10 -5
+      vertex 0.373034 1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.281072 1.47343 -5
+      vertex 10 10 -5
+      vertex 0.327214 1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.234652 1.48153 -5
+      vertex 10 10 -5
+      vertex 0.281072 1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.188 1.48817 -5
+      vertex 10 10 -5
+      vertex 0.234652 1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.141162 1.49334 -5
+      vertex 10 10 -5
+      vertex 0.188 1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.0941849 1.49704 -5
+      vertex 10 10 -5
+      vertex 0.141162 1.49334 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0.0471153 1.49926 -5
+      vertex 10 10 -5
+      vertex 0.0941849 1.49704 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 1.5 -5
+      vertex 10 10 -5
+      vertex 0.0471153 1.49926 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 10 -5
+      vertex 0 30 -5
+      vertex 230 30 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.0471153 1.49926 -5
+      vertex 10 10 -5
+      vertex 0 1.5 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.0941849 1.49704 -5
+      vertex 10 10 -5
+      vertex -0.0471153 1.49926 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex 10 10 -5
+      vertex -0.0941849 1.49704 -5
+      vertex -10 20 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.0941849 1.49704 -5
+      vertex -0.141162 1.49334 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.141162 1.49334 -5
+      vertex -0.188 1.48817 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.188 1.48817 -5
+      vertex -0.234652 1.48153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.234652 1.48153 -5
+      vertex -0.281072 1.47343 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 10 10 -5
+      vertex -10 20 -5
+      vertex 0 30 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.281072 1.47343 -5
+      vertex -0.327214 1.46387 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.327214 1.46387 -5
+      vertex -0.373034 1.45287 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.373034 1.45287 -5
+      vertex -0.418487 1.44044 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.418487 1.44044 -5
+      vertex -0.463525 1.42658 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.463525 1.42658 -5
+      vertex -0.508106 1.41132 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.508106 1.41132 -5
+      vertex -0.552186 1.39466 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.552186 1.39466 -5
+      vertex -0.595721 1.37663 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex 0 30 -5
+      vertex -10 20 -5
+      vertex -0.314107 29.9951 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.595721 1.37663 -5
+      vertex -0.638668 1.35724 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.638668 1.35724 -5
+      vertex -0.680985 1.33651 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.680985 1.33651 -5
+      vertex -0.722631 1.31446 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.722631 1.31446 -5
+      vertex -0.763561 1.29111 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.763561 1.29111 -5
+      vertex -0.80374 1.26649 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 20 -5
+      vertex -0.80374 1.26649 -5
+      vertex -0.843124 1.24062 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -0.843124 1.24062 -5
+      vertex -0.881678 1.21352 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -0.881678 1.21352 -5
+      vertex -0.91936 1.18523 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.314107 29.9951 -5
+      vertex -10 20 -5
+      vertex -0.627905 29.9803 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -0.91936 1.18523 -5
+      vertex -0.956136 1.15577 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -0.956136 1.15577 -5
+      vertex -0.991967 1.12517 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -0.991967 1.12517 -5
+      vertex -1.02682 1.09345 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.02682 1.09345 -5
+      vertex -1.06066 1.06066 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.06066 1.06066 -5
+      vertex -1.09345 1.02682 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.09345 1.02682 -5
+      vertex -1.12517 0.991967 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.12517 0.991967 -5
+      vertex -1.15577 0.956136 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.15577 0.956136 -5
+      vertex -1.18523 0.91936 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.18523 0.91936 -5
+      vertex -1.21352 0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.21352 0.881678 -5
+      vertex -1.24062 0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.627905 29.9803 -5
+      vertex -10 20 -5
+      vertex -0.941083 29.9556 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.24062 0.843124 -5
+      vertex -1.26649 0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.26649 0.80374 -5
+      vertex -1.29111 0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.29111 0.763561 -5
+      vertex -1.31446 0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.31446 0.722631 -5
+      vertex -1.33651 0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.33651 0.680985 -5
+      vertex -1.35724 0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.35724 0.638668 -5
+      vertex -1.37663 0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.37663 0.595721 -5
+      vertex -1.39466 0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.39466 0.552186 -5
+      vertex -1.41132 0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.41132 0.508106 -5
+      vertex -1.42658 0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.42658 0.463525 -5
+      vertex -1.44044 0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.44044 0.418487 -5
+      vertex -1.45287 0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.45287 0.373034 -5
+      vertex -1.46387 0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.46387 0.327214 -5
+      vertex -1.47343 0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.47343 0.281072 -5
+      vertex -1.48153 0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.48153 0.234652 -5
+      vertex -1.48817 0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.48817 0.188 -5
+      vertex -1.49334 0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.49334 0.141162 -5
+      vertex -1.49704 0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.49704 0.0941849 -5
+      vertex -1.49926 0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -10 0 -5
+      vertex -1.49926 0.0471153 -5
+      vertex -1.5 0 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -0.941083 29.9556 -5
+      vertex -10 20 -5
+      vertex -1.25333 29.9211 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.70513 -6.37424 -5
+      vertex -1.15577 -0.956136 -5
+      vertex -7.50111 -6.61312 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.15577 -0.956136 -5
+      vertex -7.70513 -6.37424 -5
+      vertex -1.18523 -0.91936 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -0.843124 1.24062 -5
+      vertex -10 0 -5
+      vertex -10 20 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.90155 -6.12907 -5
+      vertex -1.18523 -0.91936 -5
+      vertex -7.70513 -6.37424 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.25333 29.9211 -5
+      vertex -10 20 -5
+      vertex -1.56434 29.8769 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.18523 -0.91936 -5
+      vertex -7.90155 -6.12907 -5
+      vertex -1.21352 -0.881678 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.56434 29.8769 -5
+      vertex -10 20 -5
+      vertex -1.87381 29.8229 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.09017 -5.87785 -5
+      vertex -1.21352 -0.881678 -5
+      vertex -7.90155 -6.12907 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -1.87381 29.8229 -5
+      vertex -10 20 -5
+      vertex -2.18143 29.7592 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.21352 -0.881678 -5
+      vertex -8.09017 -5.87785 -5
+      vertex -1.24062 -0.843124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.18143 29.7592 -5
+      vertex -10 20 -5
+      vertex -2.4869 29.6858 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.27081 -5.62083 -5
+      vertex -1.24062 -0.843124 -5
+      vertex -8.09017 -5.87785 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.4869 29.6858 -5
+      vertex -10 20 -5
+      vertex -2.78991 29.6029 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.24062 -0.843124 -5
+      vertex -8.27081 -5.62083 -5
+      vertex -1.26649 -0.80374 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -2.78991 29.6029 -5
+      vertex -10 20 -5
+      vertex -3.09017 29.5106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.44328 -5.35827 -5
+      vertex -1.26649 -0.80374 -5
+      vertex -8.27081 -5.62083 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.09017 29.5106 -5
+      vertex -10 20 -5
+      vertex -3.38738 29.4088 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.26649 -0.80374 -5
+      vertex -8.44328 -5.35827 -5
+      vertex -1.29111 -0.763561 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.38738 29.4088 -5
+      vertex -10 20 -5
+      vertex -3.68124 29.2978 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60742 -5.09041 -5
+      vertex -1.29111 -0.763561 -5
+      vertex -8.44328 -5.35827 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.68124 29.2978 -5
+      vertex -10 20 -5
+      vertex -3.97148 29.1775 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.29111 -0.763561 -5
+      vertex -8.60742 -5.09041 -5
+      vertex -1.31446 -0.722631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -3.97148 29.1775 -5
+      vertex -10 20 -5
+      vertex -4.25779 29.0483 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.76307 -4.81754 -5
+      vertex -1.31446 -0.722631 -5
+      vertex -8.60742 -5.09041 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.25779 29.0483 -5
+      vertex -10 20 -5
+      vertex -4.5399 28.9101 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.31446 -0.722631 -5
+      vertex -8.76307 -4.81754 -5
+      vertex -1.33651 -0.680985 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.5399 28.9101 -5
+      vertex -10 20 -5
+      vertex -4.81754 28.7631 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.91006 -4.5399 -5
+      vertex -1.33651 -0.680985 -5
+      vertex -8.76307 -4.81754 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -4.81754 28.7631 -5
+      vertex -10 20 -5
+      vertex -5.09041 28.6074 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.33651 -0.680985 -5
+      vertex -8.91006 -4.5399 -5
+      vertex -1.35724 -0.638668 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.09041 28.6074 -5
+      vertex -10 20 -5
+      vertex -5.35827 28.4433 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.04827 -4.25779 -5
+      vertex -1.35724 -0.638668 -5
+      vertex -8.91006 -4.5399 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.35827 28.4433 -5
+      vertex -10 20 -5
+      vertex -5.62083 28.2708 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.35724 -0.638668 -5
+      vertex -9.04827 -4.25779 -5
+      vertex -1.37663 -0.595721 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.62083 28.2708 -5
+      vertex -10 20 -5
+      vertex -5.87785 28.0902 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.17755 -3.97148 -5
+      vertex -1.37663 -0.595721 -5
+      vertex -9.04827 -4.25779 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -5.87785 28.0902 -5
+      vertex -10 20 -5
+      vertex -6.12907 27.9016 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.37663 -0.595721 -5
+      vertex -9.17755 -3.97148 -5
+      vertex -1.39466 -0.552186 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.12907 27.9016 -5
+      vertex -10 20 -5
+      vertex -6.37424 27.7051 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.29776 -3.68124 -5
+      vertex -1.39466 -0.552186 -5
+      vertex -9.17755 -3.97148 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.37424 27.7051 -5
+      vertex -10 20 -5
+      vertex -6.61312 27.5011 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.39466 -0.552186 -5
+      vertex -9.29776 -3.68124 -5
+      vertex -1.41132 -0.508106 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.61312 27.5011 -5
+      vertex -10 20 -5
+      vertex -6.84547 27.2897 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.40881 -3.38738 -5
+      vertex -1.41132 -0.508106 -5
+      vertex -9.29776 -3.68124 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -6.84547 27.2897 -5
+      vertex -10 20 -5
+      vertex -7.07107 27.0711 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.41132 -0.508106 -5
+      vertex -9.40881 -3.38738 -5
+      vertex -1.42658 -0.463525 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.07107 27.0711 -5
+      vertex -10 20 -5
+      vertex -7.28969 26.8455 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.51056 -3.09017 -5
+      vertex -1.42658 -0.463525 -5
+      vertex -9.40881 -3.38738 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.28969 26.8455 -5
+      vertex -10 20 -5
+      vertex -7.50111 26.6131 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.42658 -0.463525 -5
+      vertex -9.51056 -3.09017 -5
+      vertex -1.44044 -0.418487 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.50111 26.6131 -5
+      vertex -10 20 -5
+      vertex -7.70513 26.3742 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.60294 -2.78991 -5
+      vertex -1.44044 -0.418487 -5
+      vertex -9.51056 -3.09017 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.70513 26.3742 -5
+      vertex -10 20 -5
+      vertex -7.90155 26.1291 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.44044 -0.418487 -5
+      vertex -9.60294 -2.78991 -5
+      vertex -1.45287 -0.373034 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -7.90155 26.1291 -5
+      vertex -10 20 -5
+      vertex -8.09017 25.8779 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.68583 -2.4869 -5
+      vertex -1.45287 -0.373034 -5
+      vertex -9.60294 -2.78991 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.09017 25.8779 -5
+      vertex -10 20 -5
+      vertex -8.27081 25.6208 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.45287 -0.373034 -5
+      vertex -9.68583 -2.4869 -5
+      vertex -1.46387 -0.327214 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.27081 25.6208 -5
+      vertex -10 20 -5
+      vertex -8.44328 25.3583 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.75917 -2.18143 -5
+      vertex -1.46387 -0.327214 -5
+      vertex -9.68583 -2.4869 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.44328 25.3583 -5
+      vertex -10 20 -5
+      vertex -8.60742 25.0904 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.46387 -0.327214 -5
+      vertex -9.75917 -2.18143 -5
+      vertex -1.47343 -0.281072 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.60742 25.0904 -5
+      vertex -10 20 -5
+      vertex -8.76307 24.8175 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.82287 -1.87381 -5
+      vertex -1.47343 -0.281072 -5
+      vertex -9.75917 -2.18143 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.76307 24.8175 -5
+      vertex -10 20 -5
+      vertex -8.91006 24.5399 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.47343 -0.281072 -5
+      vertex -9.82287 -1.87381 -5
+      vertex -1.48153 -0.234652 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -8.91006 24.5399 -5
+      vertex -10 20 -5
+      vertex -9.04827 24.2578 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.87688 -1.56434 -5
+      vertex -1.48153 -0.234652 -5
+      vertex -9.82287 -1.87381 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.04827 24.2578 -5
+      vertex -10 20 -5
+      vertex -9.17755 23.9715 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.48153 -0.234652 -5
+      vertex -9.87688 -1.56434 -5
+      vertex -1.48817 -0.188 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.17755 23.9715 -5
+      vertex -10 20 -5
+      vertex -9.29776 23.6812 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.92115 -1.25333 -5
+      vertex -1.48817 -0.188 -5
+      vertex -9.87688 -1.56434 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.29776 23.6812 -5
+      vertex -10 20 -5
+      vertex -9.40881 23.3874 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.48817 -0.188 -5
+      vertex -9.92115 -1.25333 -5
+      vertex -1.49334 -0.141162 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.40881 23.3874 -5
+      vertex -10 20 -5
+      vertex -9.51056 23.0902 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.95562 -0.941083 -5
+      vertex -1.49334 -0.141162 -5
+      vertex -9.92115 -1.25333 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.51056 23.0902 -5
+      vertex -10 20 -5
+      vertex -9.60294 22.7899 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.49334 -0.141162 -5
+      vertex -9.95562 -0.941083 -5
+      vertex -1.49704 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.60294 22.7899 -5
+      vertex -10 20 -5
+      vertex -9.68583 22.4869 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.98027 -0.627905 -5
+      vertex -1.49704 -0.0941849 -5
+      vertex -9.95562 -0.941083 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.68583 22.4869 -5
+      vertex -10 20 -5
+      vertex -9.75917 22.1814 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.49704 -0.0941849 -5
+      vertex -9.98027 -0.627905 -5
+      vertex -1.49926 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.75917 22.1814 -5
+      vertex -10 20 -5
+      vertex -9.82287 21.8738 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.99506 -0.314107 -5
+      vertex -1.49926 -0.0471153 -5
+      vertex -9.98027 -0.627905 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.82287 21.8738 -5
+      vertex -10 20 -5
+      vertex -9.87688 21.5643 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.49926 -0.0471153 -5
+      vertex -9.99506 -0.314107 -5
+      vertex -1.5 0 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.87688 21.5643 -5
+      vertex -10 20 -5
+      vertex -9.92115 21.2533 -5
+    endloop
+  endfacet
+  facet normal -0 0 -1
+    outer loop
+      vertex -1.5 0 -5
+      vertex -9.99506 -0.314107 -5
+      vertex -10 0 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.92115 21.2533 -5
+      vertex -10 20 -5
+      vertex -9.95562 20.9411 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.95562 20.9411 -5
+      vertex -10 20 -5
+      vertex -9.98027 20.6279 -5
+    endloop
+  endfacet
+  facet normal 0 0 -1
+    outer loop
+      vertex -9.98027 20.6279 -5
+      vertex -10 20 -5
+      vertex -9.99506 20.3141 -5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 240 20 5
+      vertex 239.995 20.3141 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.912 2.31154 5
+      vertex 240 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.995 20.3141 5
+      vertex 239.98 20.6279 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.054 2.18691 5
+      vertex 240 0 5
+      vertex 231.984 2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.98 20.6279 5
+      vertex 239.956 20.9411 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.187 2.05364 5
+      vertex 240 0 5
+      vertex 232.121 2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.956 20.9411 5
+      vertex 239.921 21.2533 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.312 1.91227 5
+      vertex 240 0 5
+      vertex 232.25 1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.921 21.2533 5
+      vertex 239.877 21.5643 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.37 1.83872 5
+      vertex 240 0 5
+      vertex 232.312 1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.877 21.5643 5
+      vertex 239.823 21.8738 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.481 1.68625 5
+      vertex 240 0 5
+      vertex 232.427 1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.823 21.8738 5
+      vertex 239.759 22.1814 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.582 1.52712 5
+      vertex 240 0 5
+      vertex 232.533 1.60748 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.759 22.1814 5
+      vertex 239.686 22.4869 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.629 1.44526 5
+      vertex 240 0 5
+      vertex 232.582 1.52712 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.686 22.4869 5
+      vertex 239.603 22.7899 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.714 1.27734 5
+      vertex 240 0 5
+      vertex 232.673 1.36197 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.603 22.7899 5
+      vertex 239.511 23.0902 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.789 1.10437 5
+      vertex 240 0 5
+      vertex 232.753 1.19144 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.511 23.0902 5
+      vertex 239.409 23.3874 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.853 0.927051 5
+      vertex 240 0 5
+      vertex 232.823 1.01621 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.409 23.3874 5
+      vertex 239.298 23.6812 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.881 0.836973 5
+      vertex 240 0 5
+      vertex 232.853 0.927051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.298 23.6812 5
+      vertex 239.178 23.9715 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.928 0.654429 5
+      vertex 240 0 5
+      vertex 232.906 0.746069 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.178 23.9715 5
+      vertex 239.048 24.2578 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.963 0.469303 5
+      vertex 240 0 5
+      vertex 232.947 0.562143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 239.048 24.2578 5
+      vertex 238.91 24.5399 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.976 0.375999 5
+      vertex 240 0 5
+      vertex 232.963 0.469303 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 238.91 24.5399 5
+      vertex 238.763 24.8175 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.994 0.188371 5
+      vertex 240 0 5
+      vertex 232.987 0.282325 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 238.763 24.8175 5
+      vertex 238.607 25.0904 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 233 0 5
+      vertex 240 0 5
+      vertex 232.999 0.0942316 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 238.607 25.0904 5
+      vertex 238.443 25.3583 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 0 5
+      vertex 233 0 5
+      vertex 239.995 -0.314107 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 238.443 25.3583 5
+      vertex 238.271 25.6208 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.995 -0.314107 5
+      vertex 232.999 -0.0942316 5
+      vertex 239.98 -0.627905 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 238.271 25.6208 5
+      vertex 238.09 25.8779 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.98 -0.627905 5
+      vertex 232.994 -0.188371 5
+      vertex 239.956 -0.941083 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 238.09 25.8779 5
+      vertex 237.902 26.1291 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.987 -0.282325 5
+      vertex 239.956 -0.941083 5
+      vertex 232.994 -0.188371 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 237.902 26.1291 5
+      vertex 237.705 26.3742 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.976 -0.375999 5
+      vertex 239.921 -1.25333 5
+      vertex 232.987 -0.282325 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 237.705 26.3742 5
+      vertex 237.501 26.6131 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.963 -0.469303 5
+      vertex 239.877 -1.56434 5
+      vertex 232.976 -0.375999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 237.501 26.6131 5
+      vertex 237.29 26.8455 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.947 -0.562143 5
+      vertex 239.823 -1.87381 5
+      vertex 232.963 -0.469303 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 237.29 26.8455 5
+      vertex 237.071 27.0711 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.823 -1.87381 5
+      vertex 232.947 -0.562143 5
+      vertex 239.759 -2.18143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 237.071 27.0711 5
+      vertex 236.845 27.2897 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.759 -2.18143 5
+      vertex 232.928 -0.654429 5
+      vertex 239.686 -2.4869 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 236.845 27.2897 5
+      vertex 236.613 27.5011 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.686 -2.4869 5
+      vertex 232.906 -0.746069 5
+      vertex 239.603 -2.78991 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 236.613 27.5011 5
+      vertex 236.374 27.7051 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.881 -0.836973 5
+      vertex 239.603 -2.78991 5
+      vertex 232.906 -0.746069 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 236.374 27.7051 5
+      vertex 236.129 27.9016 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.853 -0.927051 5
+      vertex 239.511 -3.09017 5
+      vertex 232.881 -0.836973 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 236.129 27.9016 5
+      vertex 235.878 28.0902 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.823 -1.01621 5
+      vertex 239.409 -3.38738 5
+      vertex 232.853 -0.927051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 235.878 28.0902 5
+      vertex 235.621 28.2708 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.409 -3.38738 5
+      vertex 232.823 -1.01621 5
+      vertex 239.298 -3.68124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 235.621 28.2708 5
+      vertex 235.358 28.4433 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.298 -3.68124 5
+      vertex 232.789 -1.10437 5
+      vertex 239.178 -3.97148 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 235.358 28.4433 5
+      vertex 235.09 28.6074 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.178 -3.97148 5
+      vertex 232.753 -1.19144 5
+      vertex 239.048 -4.25779 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 235.09 28.6074 5
+      vertex 234.818 28.7631 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.714 -1.27734 5
+      vertex 239.048 -4.25779 5
+      vertex 232.753 -1.19144 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 234.818 28.7631 5
+      vertex 234.54 28.9101 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.673 -1.36197 5
+      vertex 238.91 -4.5399 5
+      vertex 232.714 -1.27734 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 234.54 28.9101 5
+      vertex 234.258 29.0483 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.629 -1.44526 5
+      vertex 238.763 -4.81754 5
+      vertex 232.673 -1.36197 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 234.258 29.0483 5
+      vertex 233.971 29.1775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 238.763 -4.81754 5
+      vertex 232.629 -1.44526 5
+      vertex 238.607 -5.09041 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 233.971 29.1775 5
+      vertex 233.681 29.2978 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 238.607 -5.09041 5
+      vertex 232.582 -1.52712 5
+      vertex 238.443 -5.35827 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 233.681 29.2978 5
+      vertex 233.387 29.4088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 238.443 -5.35827 5
+      vertex 232.533 -1.60748 5
+      vertex 238.271 -5.62083 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 233.387 29.4088 5
+      vertex 233.09 29.5106 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.481 -1.68625 5
+      vertex 238.271 -5.62083 5
+      vertex 232.533 -1.60748 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.427 -1.76336 5
+      vertex 238.09 -5.87785 5
+      vertex 232.481 -1.68625 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 238.271 -5.62083 5
+      vertex 232.481 -1.68625 5
+      vertex 238.09 -5.87785 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.533 -1.60748 5
+      vertex 238.443 -5.35827 5
+      vertex 232.582 -1.52712 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.582 -1.52712 5
+      vertex 238.607 -5.09041 5
+      vertex 232.629 -1.44526 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 238.91 -4.5399 5
+      vertex 232.673 -1.36197 5
+      vertex 238.763 -4.81754 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.048 -4.25779 5
+      vertex 232.714 -1.27734 5
+      vertex 238.91 -4.5399 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.753 -1.19144 5
+      vertex 239.178 -3.97148 5
+      vertex 232.789 -1.10437 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.789 -1.10437 5
+      vertex 239.298 -3.68124 5
+      vertex 232.823 -1.01621 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.511 -3.09017 5
+      vertex 232.853 -0.927051 5
+      vertex 239.409 -3.38738 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.603 -2.78991 5
+      vertex 232.881 -0.836973 5
+      vertex 239.511 -3.09017 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.906 -0.746069 5
+      vertex 239.686 -2.4869 5
+      vertex 232.928 -0.654429 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.928 -0.654429 5
+      vertex 239.759 -2.18143 5
+      vertex 232.947 -0.562143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 233.09 29.5106 5
+      vertex 232.79 29.6029 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.877 -1.56434 5
+      vertex 232.963 -0.469303 5
+      vertex 239.823 -1.87381 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.921 -1.25333 5
+      vertex 232.976 -0.375999 5
+      vertex 239.877 -1.56434 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 239.956 -0.941083 5
+      vertex 232.987 -0.282325 5
+      vertex 239.921 -1.25333 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.994 -0.188371 5
+      vertex 239.98 -0.627905 5
+      vertex 232.999 -0.0942316 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.999 -0.0942316 5
+      vertex 239.995 -0.314107 5
+      vertex 233 0 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.999 0.0942316 5
+      vertex 240 0 5
+      vertex 232.994 0.188371 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.987 0.282325 5
+      vertex 240 0 5
+      vertex 232.976 0.375999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 232.79 29.6029 5
+      vertex 232.487 29.6858 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.947 0.562143 5
+      vertex 240 0 5
+      vertex 232.928 0.654429 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.906 0.746069 5
+      vertex 240 0 5
+      vertex 232.881 0.836973 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.823 1.01621 5
+      vertex 240 0 5
+      vertex 232.789 1.10437 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.753 1.19144 5
+      vertex 240 0 5
+      vertex 232.714 1.27734 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.673 1.36197 5
+      vertex 240 0 5
+      vertex 232.629 1.44526 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.533 1.60748 5
+      vertex 240 0 5
+      vertex 232.481 1.68625 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 232.487 29.6858 5
+      vertex 232.181 29.7592 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.427 1.76336 5
+      vertex 240 0 5
+      vertex 232.37 1.83872 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.25 1.98394 5
+      vertex 240 0 5
+      vertex 232.187 2.05364 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 232.121 2.12132 5
+      vertex 240 0 5
+      vertex 232.054 2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 0 5
+      vertex 231.912 2.31154 5
+      vertex 231.984 2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 232.181 29.7592 5
+      vertex 231.874 29.8229 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.839 2.37046 5
+      vertex 231.912 2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.763 2.42705 5
+      vertex 231.839 2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.686 2.48124 5
+      vertex 231.763 2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.607 2.53298 5
+      vertex 231.686 2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 231.874 29.8229 5
+      vertex 231.564 29.8769 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.527 2.58223 5
+      vertex 231.607 2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.445 2.62892 5
+      vertex 231.527 2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.362 2.67302 5
+      vertex 231.445 2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.277 2.71448 5
+      vertex 231.362 2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 231.564 29.8769 5
+      vertex 231.253 29.9211 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.191 2.75326 5
+      vertex 231.277 2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.104 2.78933 5
+      vertex 231.191 2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 231.016 2.82264 5
+      vertex 231.104 2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 231.253 29.9211 5
+      vertex 230.941 29.9556 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.927 2.85317 5
+      vertex 231.016 2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.837 2.88088 5
+      vertex 230.927 2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.746 2.90575 5
+      vertex 230.837 2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.654 2.92775 5
+      vertex 230.746 2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 230.941 29.9556 5
+      vertex 230.628 29.9803 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.562 2.94686 5
+      vertex 230.654 2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.469 2.96306 5
+      vertex 230.562 2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.376 2.97634 5
+      vertex 230.469 2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 230.628 29.9803 5
+      vertex 230.314 29.9951 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 220 10 5
+      vertex 230.094 2.99852 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.282 2.98669 5
+      vertex 230.376 2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.188 2.99408 5
+      vertex 230.282 2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 10 5
+      vertex 230.314 29.9951 5
+      vertex 230 30 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 240 20 5
+      vertex 230.094 2.99852 5
+      vertex 230.188 2.99408 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.094 2.99852 5
+      vertex 220 10 5
+      vertex 230 3 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230 3 5
+      vertex 220 10 5
+      vertex 229.906 2.99852 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.906 2.99852 5
+      vertex 220 10 5
+      vertex 229.812 2.99408 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.812 2.99408 5
+      vertex 220 10 5
+      vertex 229.718 2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.718 2.98669 5
+      vertex 220 10 5
+      vertex 229.624 2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.624 2.97634 5
+      vertex 220 10 5
+      vertex 229.531 2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.531 2.96306 5
+      vertex 220 10 5
+      vertex 229.438 2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.438 2.94686 5
+      vertex 220 10 5
+      vertex 229.346 2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.346 2.92775 5
+      vertex 220 10 5
+      vertex 229.254 2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.254 2.90575 5
+      vertex 220 10 5
+      vertex 229.163 2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.163 2.88088 5
+      vertex 220 10 5
+      vertex 229.073 2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.073 2.85317 5
+      vertex 220 10 5
+      vertex 228.984 2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.984 2.82264 5
+      vertex 220 10 5
+      vertex 228.896 2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.896 2.78933 5
+      vertex 220 10 5
+      vertex 228.809 2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.809 2.75326 5
+      vertex 220 10 5
+      vertex 228.723 2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.723 2.71448 5
+      vertex 220 10 5
+      vertex 228.638 2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.638 2.67302 5
+      vertex 220 10 5
+      vertex 228.555 2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.555 2.62892 5
+      vertex 220 10 5
+      vertex 228.473 2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.473 2.58223 5
+      vertex 220 10 5
+      vertex 228.393 2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.393 2.53298 5
+      vertex 220 10 5
+      vertex 228.314 2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.314 2.48124 5
+      vertex 220 10 5
+      vertex 228.237 2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.237 2.42705 5
+      vertex 220 10 5
+      vertex 228.161 2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.161 2.37046 5
+      vertex 220 10 5
+      vertex 228.088 2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.088 2.31154 5
+      vertex 220 10 5
+      vertex 228.016 2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.016 2.25033 5
+      vertex 220 10 5
+      vertex 227.946 2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.946 2.18691 5
+      vertex 220 10 5
+      vertex 227.879 2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.879 2.12132 5
+      vertex 220 10 5
+      vertex 227.813 2.05364 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.813 2.05364 5
+      vertex 220 10 5
+      vertex 227.75 1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.75 1.98394 5
+      vertex 220 10 5
+      vertex 227.688 1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.688 1.91227 5
+      vertex 220 10 5
+      vertex 227.63 1.83872 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.63 1.83872 5
+      vertex 220 10 5
+      vertex 227.573 1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.573 1.76336 5
+      vertex 220 10 5
+      vertex 227.519 1.68625 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 0 5
+      vertex 227.519 1.68625 5
+      vertex 220 10 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.519 1.68625 5
+      vertex 220 0 5
+      vertex 227.467 1.60748 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.467 1.60748 5
+      vertex 220 0 5
+      vertex 227.418 1.52712 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.418 1.52712 5
+      vertex 220 0 5
+      vertex 227.371 1.44526 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.371 1.44526 5
+      vertex 220 0 5
+      vertex 227.327 1.36197 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.327 1.36197 5
+      vertex 220 0 5
+      vertex 227.286 1.27734 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.286 1.27734 5
+      vertex 220 0 5
+      vertex 227.247 1.19144 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.247 1.19144 5
+      vertex 220 0 5
+      vertex 227.211 1.10437 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.211 1.10437 5
+      vertex 220 0 5
+      vertex 227.177 1.01621 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.177 1.01621 5
+      vertex 220 0 5
+      vertex 227.147 0.927051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.147 0.927051 5
+      vertex 220 0 5
+      vertex 227.119 0.836973 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.119 0.836973 5
+      vertex 220 0 5
+      vertex 227.094 0.746069 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.094 0.746069 5
+      vertex 220 0 5
+      vertex 227.072 0.654429 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.072 0.654429 5
+      vertex 220 0 5
+      vertex 227.053 0.562143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.053 0.562143 5
+      vertex 220 0 5
+      vertex 227.037 0.469303 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.984 -2.82264 5
+      vertex 226.613 -9.40881 5
+      vertex 226.91 -9.51056 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 0 5
+      vertex 227 0 5
+      vertex 227.001 0.0942316 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 226.319 -9.29776 5
+      vertex 226.613 -9.40881 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 0 5
+      vertex 227.001 0.0942316 5
+      vertex 227.006 0.188371 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 226.029 -9.17755 5
+      vertex 226.319 -9.29776 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220 0 5
+      vertex 227.006 0.188371 5
+      vertex 227.013 0.282325 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.037 0.469303 5
+      vertex 220 0 5
+      vertex 227.024 0.375999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.024 0.375999 5
+      vertex 220 0 5
+      vertex 227.013 0.282325 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227 0 5
+      vertex 220 0 5
+      vertex 220.005 -0.314107 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 225.742 -9.04827 5
+      vertex 226.029 -9.17755 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 225.46 -8.91006 5
+      vertex 225.742 -9.04827 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 225.182 -8.76307 5
+      vertex 225.46 -8.91006 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 224.91 -8.60742 5
+      vertex 225.182 -8.76307 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 224.642 -8.44328 5
+      vertex 224.91 -8.60742 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 224.379 -8.27081 5
+      vertex 224.642 -8.44328 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 224.122 -8.09017 5
+      vertex 224.379 -8.27081 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 223.871 -7.90155 5
+      vertex 224.122 -8.09017 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 223.626 -7.70513 5
+      vertex 223.871 -7.90155 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 223.387 -7.50111 5
+      vertex 223.626 -7.70513 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 223.155 -7.28969 5
+      vertex 223.387 -7.50111 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 222.929 -7.07107 5
+      vertex 223.155 -7.28969 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 222.71 -6.84547 5
+      vertex 222.929 -7.07107 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 222.499 -6.61312 5
+      vertex 222.71 -6.84547 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 222.295 -6.37424 5
+      vertex 222.499 -6.61312 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 222.098 -6.12907 5
+      vertex 222.295 -6.37424 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 221.91 -5.87785 5
+      vertex 222.098 -6.12907 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 221.729 -5.62083 5
+      vertex 221.91 -5.87785 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 221.557 -5.35827 5
+      vertex 221.729 -5.62083 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 221.393 -5.09041 5
+      vertex 221.557 -5.35827 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 221.237 -4.81754 5
+      vertex 221.393 -5.09041 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 221.09 -4.5399 5
+      vertex 221.237 -4.81754 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.822 -3.97148 5
+      vertex 220.952 -4.25779 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.702 -3.68124 5
+      vertex 220.822 -3.97148 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.591 -3.38738 5
+      vertex 220.702 -3.68124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.489 -3.09017 5
+      vertex 220.591 -3.38738 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.397 -2.78991 5
+      vertex 220.489 -3.09017 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.314 -2.4869 5
+      vertex 220.397 -2.78991 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.241 -2.18143 5
+      vertex 220.314 -2.4869 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.177 -1.87381 5
+      vertex 220.241 -2.18143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.123 -1.56434 5
+      vertex 220.177 -1.87381 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.079 -1.25333 5
+      vertex 220.123 -1.56434 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.044 -0.941083 5
+      vertex 220.079 -1.25333 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.02 -0.627905 5
+      vertex 220.044 -0.941083 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.952 -4.25779 5
+      vertex 221.09 -4.5399 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230 30 5
+      vertex 10 10 5
+      vertex 220 10 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.48124 1.68625 5
+      vertex 10 0 5
+      vertex 10 10 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.58223 1.52712 5
+      vertex 10 0 5
+      vertex 2.53298 1.60748 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.62892 1.44526 5
+      vertex 10 0 5
+      vertex 2.58223 1.52712 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.71448 1.27734 5
+      vertex 10 0 5
+      vertex 2.67302 1.36197 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.78933 1.10437 5
+      vertex 10 0 5
+      vertex 2.75326 1.19144 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.85317 0.927051 5
+      vertex 10 0 5
+      vertex 2.82264 1.01621 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.90575 0.746069 5
+      vertex 10 0 5
+      vertex 2.88088 0.836973 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.92775 0.654429 5
+      vertex 10 0 5
+      vertex 2.90575 0.746069 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.96306 0.469303 5
+      vertex 10 0 5
+      vertex 2.94686 0.562143 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.98669 0.282325 5
+      vertex 10 0 5
+      vertex 2.97634 0.375999 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.99408 0.188371 5
+      vertex 10 0 5
+      vertex 2.98669 0.282325 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex 3 0 5
+      vertex 10 0 5
+      vertex 2.99852 0.0942316 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.99852 -0.0942316 5
+      vertex 9.99506 -0.314107 5
+      vertex 3 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.99506 -0.314107 5
+      vertex 2.99852 -0.0942316 5
+      vertex 9.98027 -0.627905 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.98027 -0.627905 5
+      vertex 2.99408 -0.188371 5
+      vertex 9.95562 -0.941083 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.95562 -0.941083 5
+      vertex 2.98669 -0.282325 5
+      vertex 9.92115 -1.25333 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.97634 -0.375999 5
+      vertex 9.92115 -1.25333 5
+      vertex 2.98669 -0.282325 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.96306 -0.469303 5
+      vertex 9.87688 -1.56434 5
+      vertex 2.97634 -0.375999 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.94686 -0.562143 5
+      vertex 9.82287 -1.87381 5
+      vertex 2.96306 -0.469303 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.82287 -1.87381 5
+      vertex 2.94686 -0.562143 5
+      vertex 9.75917 -2.18143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.75917 -2.18143 5
+      vertex 2.92775 -0.654429 5
+      vertex 9.68583 -2.4869 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.68583 -2.4869 5
+      vertex 2.90575 -0.746069 5
+      vertex 9.60294 -2.78991 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.88088 -0.836973 5
+      vertex 9.60294 -2.78991 5
+      vertex 2.90575 -0.746069 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.85317 -0.927051 5
+      vertex 9.51056 -3.09017 5
+      vertex 2.88088 -0.836973 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.82264 -1.01621 5
+      vertex 9.40881 -3.38738 5
+      vertex 2.85317 -0.927051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.40881 -3.38738 5
+      vertex 2.82264 -1.01621 5
+      vertex 9.29776 -3.68124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.29776 -3.68124 5
+      vertex 2.78933 -1.10437 5
+      vertex 9.17755 -3.97148 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.17755 -3.97148 5
+      vertex 2.75326 -1.19144 5
+      vertex 9.04827 -4.25779 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.71448 -1.27734 5
+      vertex 9.04827 -4.25779 5
+      vertex 2.75326 -1.19144 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.67302 -1.36197 5
+      vertex 8.91006 -4.5399 5
+      vertex 2.71448 -1.27734 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.91006 -4.5399 5
+      vertex 2.67302 -1.36197 5
+      vertex 8.76307 -4.81754 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.76307 -4.81754 5
+      vertex 2.62892 -1.44526 5
+      vertex 8.60742 -5.09041 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.60742 -5.09041 5
+      vertex 2.58223 -1.52712 5
+      vertex 8.44328 -5.35827 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.53298 -1.60748 5
+      vertex 8.44328 -5.35827 5
+      vertex 2.58223 -1.52712 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.48124 -1.68625 5
+      vertex 8.27081 -5.62083 5
+      vertex 2.53298 -1.60748 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.27081 -5.62083 5
+      vertex 2.48124 -1.68625 5
+      vertex 8.09017 -5.87785 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.09017 -5.87785 5
+      vertex 2.42705 -1.76336 5
+      vertex 7.90155 -6.12907 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.90155 -6.12907 5
+      vertex 2.37046 -1.83872 5
+      vertex 7.70513 -6.37424 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.31154 -1.91227 5
+      vertex 7.70513 -6.37424 5
+      vertex 2.37046 -1.83872 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.25033 -1.98394 5
+      vertex 7.50111 -6.61312 5
+      vertex 2.31154 -1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.04827 -4.25779 5
+      vertex 2.71448 -1.27734 5
+      vertex 8.91006 -4.5399 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.75326 -1.19144 5
+      vertex 9.17755 -3.97148 5
+      vertex 2.78933 -1.10437 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.78933 -1.10437 5
+      vertex 9.29776 -3.68124 5
+      vertex 2.82264 -1.01621 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.51056 -3.09017 5
+      vertex 2.85317 -0.927051 5
+      vertex 9.40881 -3.38738 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.60294 -2.78991 5
+      vertex 2.88088 -0.836973 5
+      vertex 9.51056 -3.09017 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.90575 -0.746069 5
+      vertex 9.68583 -2.4869 5
+      vertex 2.92775 -0.654429 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.92775 -0.654429 5
+      vertex 9.75917 -2.18143 5
+      vertex 2.94686 -0.562143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.87688 -1.56434 5
+      vertex 2.96306 -0.469303 5
+      vertex 9.82287 -1.87381 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 9.92115 -1.25333 5
+      vertex 2.97634 -0.375999 5
+      vertex 9.87688 -1.56434 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.98669 -0.282325 5
+      vertex 9.95562 -0.941083 5
+      vertex 2.99408 -0.188371 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.99408 -0.188371 5
+      vertex 9.98027 -0.627905 5
+      vertex 2.99852 -0.0942316 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 0 5
+      vertex 3 0 5
+      vertex 9.99506 -0.314107 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.99852 0.0942316 5
+      vertex 10 0 5
+      vertex 2.99408 0.188371 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.97634 0.375999 5
+      vertex 10 0 5
+      vertex 2.96306 0.469303 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.94686 0.562143 5
+      vertex 10 0 5
+      vertex 2.92775 0.654429 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.88088 0.836973 5
+      vertex 10 0 5
+      vertex 2.85317 0.927051 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.82264 1.01621 5
+      vertex 10 0 5
+      vertex 2.78933 1.10437 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.75326 1.19144 5
+      vertex 10 0 5
+      vertex 2.71448 1.27734 5
+    endloop
+  endfacet
+  facet normal -0 -0 1
+    outer loop
+      vertex 2.67302 1.36197 5
+      vertex 10 0 5
+      vertex 2.62892 1.44526 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 0 5
+      vertex 2.48124 1.68625 5
+      vertex 2.53298 1.60748 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 2.42705 1.76336 5
+      vertex 2.48124 1.68625 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 2.37046 1.83872 5
+      vertex 2.42705 1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 2.31154 1.91227 5
+      vertex 2.37046 1.83872 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 2.25033 1.98394 5
+      vertex 2.31154 1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 2.18691 2.05364 5
+      vertex 2.25033 1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 2.12132 2.12132 5
+      vertex 2.18691 2.05364 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 2.05364 2.18691 5
+      vertex 2.12132 2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.98394 2.25033 5
+      vertex 2.05364 2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.91227 2.31154 5
+      vertex 1.98394 2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.83872 2.37046 5
+      vertex 1.91227 2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.76336 2.42705 5
+      vertex 1.83872 2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.68625 2.48124 5
+      vertex 1.76336 2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.60748 2.53298 5
+      vertex 1.68625 2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.52712 2.58223 5
+      vertex 1.60748 2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.44526 2.62892 5
+      vertex 1.52712 2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.36197 2.67302 5
+      vertex 1.44526 2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.27734 2.71448 5
+      vertex 1.36197 2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.19144 2.75326 5
+      vertex 1.27734 2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.10437 2.78933 5
+      vertex 1.19144 2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 1.01621 2.82264 5
+      vertex 1.10437 2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.927051 2.85317 5
+      vertex 1.01621 2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.836973 2.88088 5
+      vertex 0.927051 2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.746069 2.90575 5
+      vertex 0.836973 2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.654429 2.92775 5
+      vertex 0.746069 2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.562143 2.94686 5
+      vertex 0.654429 2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.469303 2.96306 5
+      vertex 0.562143 2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.375999 2.97634 5
+      vertex 0.469303 2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.282325 2.98669 5
+      vertex 0.375999 2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.188371 2.99408 5
+      vertex 0.282325 2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0.0942316 2.99852 5
+      vertex 0.188371 2.99408 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 30 5
+      vertex 10 10 5
+      vertex 230 30 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex 10 10 5
+      vertex 0 30 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -0.0942316 2.99852 5
+      vertex 10 10 5
+      vertex -10 20 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex 0 3 5
+      vertex 0.0942316 2.99852 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 10 10 5
+      vertex -0.0942316 2.99852 5
+      vertex 0 3 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0942316 2.99852 5
+      vertex -10 20 5
+      vertex -0.188371 2.99408 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex 0 30 5
+      vertex -0.314107 29.9951 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.188371 2.99408 5
+      vertex -10 20 5
+      vertex -0.282325 2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.282325 2.98669 5
+      vertex -10 20 5
+      vertex -0.375999 2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.375999 2.97634 5
+      vertex -10 20 5
+      vertex -0.469303 2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -0.314107 29.9951 5
+      vertex -0.627905 29.9803 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.469303 2.96306 5
+      vertex -10 20 5
+      vertex -0.562143 2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.562143 2.94686 5
+      vertex -10 20 5
+      vertex -0.654429 2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.654429 2.92775 5
+      vertex -10 20 5
+      vertex -0.746069 2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.746069 2.90575 5
+      vertex -10 20 5
+      vertex -0.836973 2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -0.627905 29.9803 5
+      vertex -0.941083 29.9556 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.836973 2.88088 5
+      vertex -10 20 5
+      vertex -0.927051 2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.927051 2.85317 5
+      vertex -10 20 5
+      vertex -1.01621 2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.01621 2.82264 5
+      vertex -10 20 5
+      vertex -1.10437 2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -0.941083 29.9556 5
+      vertex -1.25333 29.9211 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.10437 2.78933 5
+      vertex -10 20 5
+      vertex -1.19144 2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.19144 2.75326 5
+      vertex -10 20 5
+      vertex -1.27734 2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.27734 2.71448 5
+      vertex -10 20 5
+      vertex -1.36197 2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.36197 2.67302 5
+      vertex -10 20 5
+      vertex -1.44526 2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -1.25333 29.9211 5
+      vertex -1.56434 29.8769 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44526 2.62892 5
+      vertex -10 20 5
+      vertex -1.52712 2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.52712 2.58223 5
+      vertex -10 20 5
+      vertex -1.60748 2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.60748 2.53298 5
+      vertex -10 20 5
+      vertex -1.68625 2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.68625 2.48124 5
+      vertex -10 20 5
+      vertex -1.76336 2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -1.56434 29.8769 5
+      vertex -1.87381 29.8229 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.76336 2.42705 5
+      vertex -10 20 5
+      vertex -1.83872 2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.83872 2.37046 5
+      vertex -10 20 5
+      vertex -1.91227 2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.91227 2.31154 5
+      vertex -10 20 5
+      vertex -1.98394 2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 0 5
+      vertex -1.98394 2.25033 5
+      vertex -10 20 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -1.87381 29.8229 5
+      vertex -2.18143 29.7592 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.98394 2.25033 5
+      vertex -10 0 5
+      vertex -2.05364 2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.05364 2.18691 5
+      vertex -10 0 5
+      vertex -2.12132 2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.12132 2.12132 5
+      vertex -10 0 5
+      vertex -2.18691 2.05364 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18691 2.05364 5
+      vertex -10 0 5
+      vertex -2.25033 1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.25033 1.98394 5
+      vertex -10 0 5
+      vertex -2.31154 1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.31154 1.91227 5
+      vertex -10 0 5
+      vertex -2.37046 1.83872 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -2.18143 29.7592 5
+      vertex -2.4869 29.6858 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.37046 1.83872 5
+      vertex -10 0 5
+      vertex -2.42705 1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.42705 1.76336 5
+      vertex -10 0 5
+      vertex -2.48124 1.68625 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.48124 1.68625 5
+      vertex -10 0 5
+      vertex -2.53298 1.60748 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.53298 1.60748 5
+      vertex -10 0 5
+      vertex -2.58223 1.52712 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.58223 1.52712 5
+      vertex -10 0 5
+      vertex -2.62892 1.44526 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.62892 1.44526 5
+      vertex -10 0 5
+      vertex -2.67302 1.36197 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.67302 1.36197 5
+      vertex -10 0 5
+      vertex -2.71448 1.27734 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -2.4869 29.6858 5
+      vertex -2.78991 29.6029 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.71448 1.27734 5
+      vertex -10 0 5
+      vertex -2.75326 1.19144 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.75326 1.19144 5
+      vertex -10 0 5
+      vertex -2.78933 1.10437 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.78933 1.10437 5
+      vertex -10 0 5
+      vertex -2.82264 1.01621 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.82264 1.01621 5
+      vertex -10 0 5
+      vertex -2.85317 0.927051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.85317 0.927051 5
+      vertex -10 0 5
+      vertex -2.88088 0.836973 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.88088 0.836973 5
+      vertex -10 0 5
+      vertex -2.90575 0.746069 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.90575 0.746069 5
+      vertex -10 0 5
+      vertex -2.92775 0.654429 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.92775 0.654429 5
+      vertex -10 0 5
+      vertex -2.94686 0.562143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.94686 0.562143 5
+      vertex -10 0 5
+      vertex -2.96306 0.469303 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.96306 0.469303 5
+      vertex -10 0 5
+      vertex -2.97634 0.375999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.97634 0.375999 5
+      vertex -10 0 5
+      vertex -2.98669 0.282325 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.98669 0.282325 5
+      vertex -10 0 5
+      vertex -2.99408 0.188371 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -2.78991 29.6029 5
+      vertex -3.09017 29.5106 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 238.09 -5.87785 5
+      vertex 232.427 -1.76336 5
+      vertex 237.902 -6.12907 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.37 -1.83872 5
+      vertex 237.902 -6.12907 5
+      vertex 232.427 -1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 237.902 -6.12907 5
+      vertex 232.37 -1.83872 5
+      vertex 237.705 -6.37424 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.312 -1.91227 5
+      vertex 237.705 -6.37424 5
+      vertex 232.37 -1.83872 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 237.705 -6.37424 5
+      vertex 232.312 -1.91227 5
+      vertex 237.501 -6.61312 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.25 -1.98394 5
+      vertex 237.501 -6.61312 5
+      vertex 232.312 -1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 237.501 -6.61312 5
+      vertex 232.25 -1.98394 5
+      vertex 237.29 -6.84547 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.187 -2.05364 5
+      vertex 237.29 -6.84547 5
+      vertex 232.25 -1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 237.29 -6.84547 5
+      vertex 232.187 -2.05364 5
+      vertex 237.071 -7.07107 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.121 -2.12132 5
+      vertex 237.071 -7.07107 5
+      vertex 232.187 -2.05364 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 237.071 -7.07107 5
+      vertex 232.121 -2.12132 5
+      vertex 236.845 -7.28969 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 232.054 -2.18691 5
+      vertex 236.845 -7.28969 5
+      vertex 232.121 -2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 236.845 -7.28969 5
+      vertex 232.054 -2.18691 5
+      vertex 236.613 -7.50111 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.984 -2.25033 5
+      vertex 236.613 -7.50111 5
+      vertex 232.054 -2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 236.613 -7.50111 5
+      vertex 231.984 -2.25033 5
+      vertex 236.374 -7.70513 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.912 -2.31154 5
+      vertex 236.374 -7.70513 5
+      vertex 231.984 -2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 236.374 -7.70513 5
+      vertex 231.912 -2.31154 5
+      vertex 236.129 -7.90155 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.839 -2.37046 5
+      vertex 236.129 -7.90155 5
+      vertex 231.912 -2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 236.129 -7.90155 5
+      vertex 231.839 -2.37046 5
+      vertex 235.878 -8.09017 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.763 -2.42705 5
+      vertex 235.878 -8.09017 5
+      vertex 231.839 -2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 235.878 -8.09017 5
+      vertex 231.763 -2.42705 5
+      vertex 235.621 -8.27081 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.686 -2.48124 5
+      vertex 235.621 -8.27081 5
+      vertex 231.763 -2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 235.621 -8.27081 5
+      vertex 231.686 -2.48124 5
+      vertex 235.358 -8.44328 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.607 -2.53298 5
+      vertex 235.358 -8.44328 5
+      vertex 231.686 -2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 235.358 -8.44328 5
+      vertex 231.607 -2.53298 5
+      vertex 235.09 -8.60742 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.527 -2.58223 5
+      vertex 235.09 -8.60742 5
+      vertex 231.607 -2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 235.09 -8.60742 5
+      vertex 231.527 -2.58223 5
+      vertex 234.818 -8.76307 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.445 -2.62892 5
+      vertex 234.818 -8.76307 5
+      vertex 231.527 -2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 234.818 -8.76307 5
+      vertex 231.445 -2.62892 5
+      vertex 234.54 -8.91006 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.362 -2.67302 5
+      vertex 234.54 -8.91006 5
+      vertex 231.445 -2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 234.54 -8.91006 5
+      vertex 231.362 -2.67302 5
+      vertex 234.258 -9.04827 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.277 -2.71448 5
+      vertex 234.258 -9.04827 5
+      vertex 231.362 -2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 234.258 -9.04827 5
+      vertex 231.277 -2.71448 5
+      vertex 233.971 -9.17755 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.191 -2.75326 5
+      vertex 233.971 -9.17755 5
+      vertex 231.277 -2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 233.971 -9.17755 5
+      vertex 231.191 -2.75326 5
+      vertex 233.681 -9.29776 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.104 -2.78933 5
+      vertex 233.681 -9.29776 5
+      vertex 231.191 -2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 233.681 -9.29776 5
+      vertex 231.104 -2.78933 5
+      vertex 233.387 -9.40881 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.016 -2.82264 5
+      vertex 233.387 -9.40881 5
+      vertex 231.104 -2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 233.387 -9.40881 5
+      vertex 231.016 -2.82264 5
+      vertex 233.09 -9.51056 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.927 -2.85317 5
+      vertex 233.09 -9.51056 5
+      vertex 231.016 -2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 233.09 -9.51056 5
+      vertex 230.927 -2.85317 5
+      vertex 232.79 -9.60294 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.837 -2.88088 5
+      vertex 232.79 -9.60294 5
+      vertex 230.927 -2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.79 -9.60294 5
+      vertex 230.837 -2.88088 5
+      vertex 232.487 -9.68583 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.746 -2.90575 5
+      vertex 232.487 -9.68583 5
+      vertex 230.837 -2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.487 -9.68583 5
+      vertex 230.746 -2.90575 5
+      vertex 232.181 -9.75917 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.654 -2.92775 5
+      vertex 232.181 -9.75917 5
+      vertex 230.746 -2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.181 -9.75917 5
+      vertex 230.654 -2.92775 5
+      vertex 231.874 -9.82287 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.562 -2.94686 5
+      vertex 231.874 -9.82287 5
+      vertex 230.654 -2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.874 -9.82287 5
+      vertex 230.562 -2.94686 5
+      vertex 231.564 -9.87688 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.469 -2.96306 5
+      vertex 231.564 -9.87688 5
+      vertex 230.562 -2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.564 -9.87688 5
+      vertex 230.469 -2.96306 5
+      vertex 231.253 -9.92115 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.376 -2.97634 5
+      vertex 231.253 -9.92115 5
+      vertex 230.469 -2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.253 -9.92115 5
+      vertex 230.376 -2.97634 5
+      vertex 230.941 -9.95562 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.282 -2.98669 5
+      vertex 230.941 -9.95562 5
+      vertex 230.376 -2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.941 -9.95562 5
+      vertex 230.282 -2.98669 5
+      vertex 230.628 -9.98027 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.188 -2.99408 5
+      vertex 230.628 -9.98027 5
+      vertex 230.282 -2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.628 -9.98027 5
+      vertex 230.188 -2.99408 5
+      vertex 230.314 -9.99506 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.094 -2.99852 5
+      vertex 230.314 -9.99506 5
+      vertex 230.188 -2.99408 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230 -3 5
+      vertex 230.314 -9.99506 5
+      vertex 230.094 -2.99852 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230 -3 5
+      vertex 230 -10 5
+      vertex 230.314 -9.99506 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.906 -2.99852 5
+      vertex 230 -10 5
+      vertex 230 -3 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.686 -9.99506 5
+      vertex 229.906 -2.99852 5
+      vertex 229.812 -2.99408 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.372 -9.98027 5
+      vertex 229.812 -2.99408 5
+      vertex 229.718 -2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.906 -2.99852 5
+      vertex 229.686 -9.99506 5
+      vertex 230 -10 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.059 -9.95562 5
+      vertex 229.718 -2.98669 5
+      vertex 229.624 -2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.747 -9.92115 5
+      vertex 229.624 -2.97634 5
+      vertex 229.531 -2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.436 -9.87688 5
+      vertex 229.531 -2.96306 5
+      vertex 229.438 -2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.812 -2.99408 5
+      vertex 229.372 -9.98027 5
+      vertex 229.686 -9.99506 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.126 -9.82287 5
+      vertex 229.438 -2.94686 5
+      vertex 229.346 -2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.819 -9.75917 5
+      vertex 229.346 -2.92775 5
+      vertex 229.254 -2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.513 -9.68583 5
+      vertex 229.254 -2.90575 5
+      vertex 229.163 -2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.21 -9.60294 5
+      vertex 229.163 -2.88088 5
+      vertex 229.073 -2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.718 -2.98669 5
+      vertex 229.059 -9.95562 5
+      vertex 229.372 -9.98027 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.91 -9.51056 5
+      vertex 229.073 -2.85317 5
+      vertex 228.984 -2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.984 -2.82264 5
+      vertex 228.896 -2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.896 -2.78933 5
+      vertex 228.809 -2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.624 -2.97634 5
+      vertex 228.747 -9.92115 5
+      vertex 229.059 -9.95562 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.809 -2.75326 5
+      vertex 228.723 -2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.723 -2.71448 5
+      vertex 228.638 -2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.638 -2.67302 5
+      vertex 228.555 -2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.555 -2.62892 5
+      vertex 228.473 -2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.531 -2.96306 5
+      vertex 228.436 -9.87688 5
+      vertex 228.747 -9.92115 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.473 -2.58223 5
+      vertex 228.393 -2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.393 -2.53298 5
+      vertex 228.314 -2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.314 -2.48124 5
+      vertex 228.237 -2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.237 -2.42705 5
+      vertex 228.161 -2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.438 -2.94686 5
+      vertex 228.126 -9.82287 5
+      vertex 228.436 -9.87688 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.161 -2.37046 5
+      vertex 228.088 -2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.088 -2.31154 5
+      vertex 228.016 -2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 228.016 -2.25033 5
+      vertex 227.946 -2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.946 -2.18691 5
+      vertex 227.879 -2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.346 -2.92775 5
+      vertex 227.819 -9.75917 5
+      vertex 228.126 -9.82287 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.879 -2.12132 5
+      vertex 227.813 -2.05364 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.813 -2.05364 5
+      vertex 227.75 -1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.75 -1.98394 5
+      vertex 227.688 -1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.688 -1.91227 5
+      vertex 227.63 -1.83872 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.63 -1.83872 5
+      vertex 227.573 -1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.573 -1.76336 5
+      vertex 227.519 -1.68625 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.254 -2.90575 5
+      vertex 227.513 -9.68583 5
+      vertex 227.819 -9.75917 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.519 -1.68625 5
+      vertex 227.467 -1.60748 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.467 -1.60748 5
+      vertex 227.418 -1.52712 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.418 -1.52712 5
+      vertex 227.371 -1.44526 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.371 -1.44526 5
+      vertex 227.327 -1.36197 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.327 -1.36197 5
+      vertex 227.286 -1.27734 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.286 -1.27734 5
+      vertex 227.247 -1.19144 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.247 -1.19144 5
+      vertex 227.211 -1.10437 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.163 -2.88088 5
+      vertex 227.21 -9.60294 5
+      vertex 227.513 -9.68583 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.211 -1.10437 5
+      vertex 227.177 -1.01621 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.177 -1.01621 5
+      vertex 227.147 -0.927051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.147 -0.927051 5
+      vertex 227.119 -0.836973 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.119 -0.836973 5
+      vertex 227.094 -0.746069 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.094 -0.746069 5
+      vertex 227.072 -0.654429 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.072 -0.654429 5
+      vertex 227.053 -0.562143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.053 -0.562143 5
+      vertex 227.037 -0.469303 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.037 -0.469303 5
+      vertex 227.024 -0.375999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.024 -0.375999 5
+      vertex 227.013 -0.282325 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.013 -0.282325 5
+      vertex 227.006 -0.188371 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 227.006 -0.188371 5
+      vertex 227.001 -0.0942316 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.073 -2.85317 5
+      vertex 226.91 -9.51056 5
+      vertex 227.21 -9.60294 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 220.005 -0.314107 5
+      vertex 227.001 -0.0942316 5
+      vertex 227 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 220.005 -0.314107 5
+      vertex 220.02 -0.627905 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.62892 -1.44526 5
+      vertex 8.76307 -4.81754 5
+      vertex 2.67302 -1.36197 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.58223 -1.52712 5
+      vertex 8.60742 -5.09041 5
+      vertex 2.62892 -1.44526 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 8.44328 -5.35827 5
+      vertex 2.53298 -1.60748 5
+      vertex 8.27081 -5.62083 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.42705 -1.76336 5
+      vertex 8.09017 -5.87785 5
+      vertex 2.48124 -1.68625 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.37046 -1.83872 5
+      vertex 7.90155 -6.12907 5
+      vertex 2.42705 -1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.70513 -6.37424 5
+      vertex 2.31154 -1.91227 5
+      vertex 7.50111 -6.61312 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.50111 -6.61312 5
+      vertex 2.25033 -1.98394 5
+      vertex 7.28969 -6.84547 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.18691 -2.05364 5
+      vertex 7.28969 -6.84547 5
+      vertex 2.25033 -1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.28969 -6.84547 5
+      vertex 2.18691 -2.05364 5
+      vertex 7.07107 -7.07107 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.12132 -2.12132 5
+      vertex 7.07107 -7.07107 5
+      vertex 2.18691 -2.05364 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 7.07107 -7.07107 5
+      vertex 2.12132 -2.12132 5
+      vertex 6.84547 -7.28969 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 2.05364 -2.18691 5
+      vertex 6.84547 -7.28969 5
+      vertex 2.12132 -2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.84547 -7.28969 5
+      vertex 2.05364 -2.18691 5
+      vertex 6.61312 -7.50111 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.98394 -2.25033 5
+      vertex 6.61312 -7.50111 5
+      vertex 2.05364 -2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.61312 -7.50111 5
+      vertex 1.98394 -2.25033 5
+      vertex 6.37424 -7.70513 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.91227 -2.31154 5
+      vertex 6.37424 -7.70513 5
+      vertex 1.98394 -2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.37424 -7.70513 5
+      vertex 1.91227 -2.31154 5
+      vertex 6.12907 -7.90155 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.83872 -2.37046 5
+      vertex 6.12907 -7.90155 5
+      vertex 1.91227 -2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 6.12907 -7.90155 5
+      vertex 1.83872 -2.37046 5
+      vertex 5.87785 -8.09017 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.76336 -2.42705 5
+      vertex 5.87785 -8.09017 5
+      vertex 1.83872 -2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.87785 -8.09017 5
+      vertex 1.76336 -2.42705 5
+      vertex 5.62083 -8.27081 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.68625 -2.48124 5
+      vertex 5.62083 -8.27081 5
+      vertex 1.76336 -2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.62083 -8.27081 5
+      vertex 1.68625 -2.48124 5
+      vertex 5.35827 -8.44328 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.60748 -2.53298 5
+      vertex 5.35827 -8.44328 5
+      vertex 1.68625 -2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.35827 -8.44328 5
+      vertex 1.60748 -2.53298 5
+      vertex 5.09041 -8.60742 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.52712 -2.58223 5
+      vertex 5.09041 -8.60742 5
+      vertex 1.60748 -2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 5.09041 -8.60742 5
+      vertex 1.52712 -2.58223 5
+      vertex 4.81754 -8.76307 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.44526 -2.62892 5
+      vertex 4.81754 -8.76307 5
+      vertex 1.52712 -2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.81754 -8.76307 5
+      vertex 1.44526 -2.62892 5
+      vertex 4.5399 -8.91006 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.36197 -2.67302 5
+      vertex 4.5399 -8.91006 5
+      vertex 1.44526 -2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.5399 -8.91006 5
+      vertex 1.36197 -2.67302 5
+      vertex 4.25779 -9.04827 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.27734 -2.71448 5
+      vertex 4.25779 -9.04827 5
+      vertex 1.36197 -2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 4.25779 -9.04827 5
+      vertex 1.27734 -2.71448 5
+      vertex 3.97148 -9.17755 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.19144 -2.75326 5
+      vertex 3.97148 -9.17755 5
+      vertex 1.27734 -2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.97148 -9.17755 5
+      vertex 1.19144 -2.75326 5
+      vertex 3.68124 -9.29776 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.10437 -2.78933 5
+      vertex 3.68124 -9.29776 5
+      vertex 1.19144 -2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.68124 -9.29776 5
+      vertex 1.10437 -2.78933 5
+      vertex 3.38738 -9.40881 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.01621 -2.82264 5
+      vertex 3.38738 -9.40881 5
+      vertex 1.10437 -2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.38738 -9.40881 5
+      vertex 1.01621 -2.82264 5
+      vertex 3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.927051 -2.85317 5
+      vertex 3.09017 -9.51056 5
+      vertex 1.01621 -2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3.09017 -9.51056 5
+      vertex 0.927051 -2.85317 5
+      vertex 2.78991 -9.60294 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.836973 -2.88088 5
+      vertex 2.78991 -9.60294 5
+      vertex 0.927051 -2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.78991 -9.60294 5
+      vertex 0.836973 -2.88088 5
+      vertex 2.4869 -9.68583 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.746069 -2.90575 5
+      vertex 2.4869 -9.68583 5
+      vertex 0.836973 -2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.4869 -9.68583 5
+      vertex 0.746069 -2.90575 5
+      vertex 2.18143 -9.75917 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.654429 -2.92775 5
+      vertex 2.18143 -9.75917 5
+      vertex 0.746069 -2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.18143 -9.75917 5
+      vertex 0.654429 -2.92775 5
+      vertex 1.87381 -9.82287 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.562143 -2.94686 5
+      vertex 1.87381 -9.82287 5
+      vertex 0.654429 -2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.87381 -9.82287 5
+      vertex 0.562143 -2.94686 5
+      vertex 1.56434 -9.87688 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.469303 -2.96306 5
+      vertex 1.56434 -9.87688 5
+      vertex 0.562143 -2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.56434 -9.87688 5
+      vertex 0.469303 -2.96306 5
+      vertex 1.25333 -9.92115 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.375999 -2.97634 5
+      vertex 1.25333 -9.92115 5
+      vertex 0.469303 -2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.25333 -9.92115 5
+      vertex 0.375999 -2.97634 5
+      vertex 0.941083 -9.95562 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.282325 -2.98669 5
+      vertex 0.941083 -9.95562 5
+      vertex 0.375999 -2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.941083 -9.95562 5
+      vertex 0.282325 -2.98669 5
+      vertex 0.627905 -9.98027 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.188371 -2.99408 5
+      vertex 0.627905 -9.98027 5
+      vertex 0.282325 -2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.627905 -9.98027 5
+      vertex 0.188371 -2.99408 5
+      vertex 0.314107 -9.99506 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.0942316 -2.99852 5
+      vertex 0.314107 -9.99506 5
+      vertex 0.188371 -2.99408 5
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -3 5
+      vertex 0.314107 -9.99506 5
+      vertex 0.0942316 -2.99852 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -3 5
+      vertex 0 -10 5
+      vertex 0.314107 -9.99506 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0942316 -2.99852 5
+      vertex 0 -10 5
+      vertex 0 -3 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.314107 -9.99506 5
+      vertex -0.0942316 -2.99852 5
+      vertex -0.188371 -2.99408 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.627905 -9.98027 5
+      vertex -0.188371 -2.99408 5
+      vertex -0.282325 -2.98669 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0942316 -2.99852 5
+      vertex -0.314107 -9.99506 5
+      vertex 0 -10 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.941083 -9.95562 5
+      vertex -0.282325 -2.98669 5
+      vertex -0.375999 -2.97634 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.25333 -9.92115 5
+      vertex -0.375999 -2.97634 5
+      vertex -0.469303 -2.96306 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.56434 -9.87688 5
+      vertex -0.469303 -2.96306 5
+      vertex -0.562143 -2.94686 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.188371 -2.99408 5
+      vertex -0.627905 -9.98027 5
+      vertex -0.314107 -9.99506 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.87381 -9.82287 5
+      vertex -0.562143 -2.94686 5
+      vertex -0.654429 -2.92775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18143 -9.75917 5
+      vertex -0.654429 -2.92775 5
+      vertex -0.746069 -2.90575 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.4869 -9.68583 5
+      vertex -0.746069 -2.90575 5
+      vertex -0.836973 -2.88088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.78991 -9.60294 5
+      vertex -0.836973 -2.88088 5
+      vertex -0.927051 -2.85317 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.282325 -2.98669 5
+      vertex -0.941083 -9.95562 5
+      vertex -0.627905 -9.98027 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.09017 -9.51056 5
+      vertex -0.927051 -2.85317 5
+      vertex -1.01621 -2.82264 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.38738 -9.40881 5
+      vertex -1.01621 -2.82264 5
+      vertex -1.10437 -2.78933 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.68124 -9.29776 5
+      vertex -1.10437 -2.78933 5
+      vertex -1.19144 -2.75326 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.375999 -2.97634 5
+      vertex -1.25333 -9.92115 5
+      vertex -0.941083 -9.95562 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3.97148 -9.17755 5
+      vertex -1.19144 -2.75326 5
+      vertex -1.27734 -2.71448 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.25779 -9.04827 5
+      vertex -1.27734 -2.71448 5
+      vertex -1.36197 -2.67302 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.5399 -8.91006 5
+      vertex -1.36197 -2.67302 5
+      vertex -1.44526 -2.62892 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -4.81754 -8.76307 5
+      vertex -1.44526 -2.62892 5
+      vertex -1.52712 -2.58223 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.469303 -2.96306 5
+      vertex -1.56434 -9.87688 5
+      vertex -1.25333 -9.92115 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.09041 -8.60742 5
+      vertex -1.52712 -2.58223 5
+      vertex -1.60748 -2.53298 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.35827 -8.44328 5
+      vertex -1.60748 -2.53298 5
+      vertex -1.68625 -2.48124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.62083 -8.27081 5
+      vertex -1.68625 -2.48124 5
+      vertex -1.76336 -2.42705 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -5.87785 -8.09017 5
+      vertex -1.76336 -2.42705 5
+      vertex -1.83872 -2.37046 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.562143 -2.94686 5
+      vertex -1.87381 -9.82287 5
+      vertex -1.56434 -9.87688 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.12907 -7.90155 5
+      vertex -1.83872 -2.37046 5
+      vertex -1.91227 -2.31154 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.37424 -7.70513 5
+      vertex -1.91227 -2.31154 5
+      vertex -1.98394 -2.25033 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.61312 -7.50111 5
+      vertex -1.98394 -2.25033 5
+      vertex -2.05364 -2.18691 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -6.84547 -7.28969 5
+      vertex -2.05364 -2.18691 5
+      vertex -2.12132 -2.12132 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.654429 -2.92775 5
+      vertex -2.18143 -9.75917 5
+      vertex -1.87381 -9.82287 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.07107 -7.07107 5
+      vertex -2.12132 -2.12132 5
+      vertex -2.18691 -2.05364 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.28969 -6.84547 5
+      vertex -2.18691 -2.05364 5
+      vertex -2.25033 -1.98394 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.50111 -6.61312 5
+      vertex -2.25033 -1.98394 5
+      vertex -2.31154 -1.91227 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.70513 -6.37424 5
+      vertex -2.31154 -1.91227 5
+      vertex -2.37046 -1.83872 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -7.90155 -6.12907 5
+      vertex -2.37046 -1.83872 5
+      vertex -2.42705 -1.76336 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.09017 -5.87785 5
+      vertex -2.42705 -1.76336 5
+      vertex -2.48124 -1.68625 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.746069 -2.90575 5
+      vertex -2.4869 -9.68583 5
+      vertex -2.18143 -9.75917 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.27081 -5.62083 5
+      vertex -2.48124 -1.68625 5
+      vertex -2.53298 -1.60748 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.44328 -5.35827 5
+      vertex -2.53298 -1.60748 5
+      vertex -2.58223 -1.52712 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.60742 -5.09041 5
+      vertex -2.58223 -1.52712 5
+      vertex -2.62892 -1.44526 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.76307 -4.81754 5
+      vertex -2.62892 -1.44526 5
+      vertex -2.67302 -1.36197 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -8.91006 -4.5399 5
+      vertex -2.67302 -1.36197 5
+      vertex -2.71448 -1.27734 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.04827 -4.25779 5
+      vertex -2.71448 -1.27734 5
+      vertex -2.75326 -1.19144 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.17755 -3.97148 5
+      vertex -2.75326 -1.19144 5
+      vertex -2.78933 -1.10437 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.836973 -2.88088 5
+      vertex -2.78991 -9.60294 5
+      vertex -2.4869 -9.68583 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.29776 -3.68124 5
+      vertex -2.78933 -1.10437 5
+      vertex -2.82264 -1.01621 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.40881 -3.38738 5
+      vertex -2.82264 -1.01621 5
+      vertex -2.85317 -0.927051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.51056 -3.09017 5
+      vertex -2.85317 -0.927051 5
+      vertex -2.88088 -0.836973 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.60294 -2.78991 5
+      vertex -2.88088 -0.836973 5
+      vertex -2.90575 -0.746069 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.68583 -2.4869 5
+      vertex -2.90575 -0.746069 5
+      vertex -2.92775 -0.654429 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.75917 -2.18143 5
+      vertex -2.92775 -0.654429 5
+      vertex -2.94686 -0.562143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.82287 -1.87381 5
+      vertex -2.94686 -0.562143 5
+      vertex -2.96306 -0.469303 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.87688 -1.56434 5
+      vertex -2.96306 -0.469303 5
+      vertex -2.97634 -0.375999 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.92115 -1.25333 5
+      vertex -2.97634 -0.375999 5
+      vertex -2.98669 -0.282325 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.95562 -0.941083 5
+      vertex -2.98669 -0.282325 5
+      vertex -2.99408 -0.188371 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.98027 -0.627905 5
+      vertex -2.99408 -0.188371 5
+      vertex -2.99852 -0.0942316 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.927051 -2.85317 5
+      vertex -3.09017 -9.51056 5
+      vertex -2.78991 -9.60294 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -9.99506 -0.314107 5
+      vertex -2.99852 -0.0942316 5
+      vertex -3 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.99408 0.188371 5
+      vertex -10 0 5
+      vertex -2.99852 0.0942316 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -3.09017 29.5106 5
+      vertex -3.38738 29.4088 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.99852 0.0942316 5
+      vertex -10 0 5
+      vertex -3 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -3.38738 29.4088 5
+      vertex -3.68124 29.2978 5
+    endloop
+  endfacet
+  facet normal 0 -0 1
+    outer loop
+      vertex -9.99506 -0.314107 5
+      vertex -3 0 5
+      vertex -10 0 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -3.68124 29.2978 5
+      vertex -3.97148 29.1775 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.01621 -2.82264 5
+      vertex -3.38738 -9.40881 5
+      vertex -3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -3.97148 29.1775 5
+      vertex -4.25779 29.0483 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.10437 -2.78933 5
+      vertex -3.68124 -9.29776 5
+      vertex -3.38738 -9.40881 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -4.25779 29.0483 5
+      vertex -4.5399 28.9101 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.19144 -2.75326 5
+      vertex -3.97148 -9.17755 5
+      vertex -3.68124 -9.29776 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -4.5399 28.9101 5
+      vertex -4.81754 28.7631 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.27734 -2.71448 5
+      vertex -4.25779 -9.04827 5
+      vertex -3.97148 -9.17755 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -4.81754 28.7631 5
+      vertex -5.09041 28.6074 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.36197 -2.67302 5
+      vertex -4.5399 -8.91006 5
+      vertex -4.25779 -9.04827 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -5.09041 28.6074 5
+      vertex -5.35827 28.4433 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44526 -2.62892 5
+      vertex -4.81754 -8.76307 5
+      vertex -4.5399 -8.91006 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -5.35827 28.4433 5
+      vertex -5.62083 28.2708 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.52712 -2.58223 5
+      vertex -5.09041 -8.60742 5
+      vertex -4.81754 -8.76307 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -5.62083 28.2708 5
+      vertex -5.87785 28.0902 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.60748 -2.53298 5
+      vertex -5.35827 -8.44328 5
+      vertex -5.09041 -8.60742 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -5.87785 28.0902 5
+      vertex -6.12907 27.9016 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.68625 -2.48124 5
+      vertex -5.62083 -8.27081 5
+      vertex -5.35827 -8.44328 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -6.12907 27.9016 5
+      vertex -6.37424 27.7051 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.76336 -2.42705 5
+      vertex -5.87785 -8.09017 5
+      vertex -5.62083 -8.27081 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -6.37424 27.7051 5
+      vertex -6.61312 27.5011 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.83872 -2.37046 5
+      vertex -6.12907 -7.90155 5
+      vertex -5.87785 -8.09017 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -6.61312 27.5011 5
+      vertex -6.84547 27.2897 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.91227 -2.31154 5
+      vertex -6.37424 -7.70513 5
+      vertex -6.12907 -7.90155 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -6.84547 27.2897 5
+      vertex -7.07107 27.0711 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.98394 -2.25033 5
+      vertex -6.61312 -7.50111 5
+      vertex -6.37424 -7.70513 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -7.07107 27.0711 5
+      vertex -7.28969 26.8455 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.05364 -2.18691 5
+      vertex -6.84547 -7.28969 5
+      vertex -6.61312 -7.50111 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -7.28969 26.8455 5
+      vertex -7.50111 26.6131 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.12132 -2.12132 5
+      vertex -7.07107 -7.07107 5
+      vertex -6.84547 -7.28969 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -7.50111 26.6131 5
+      vertex -7.70513 26.3742 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18691 -2.05364 5
+      vertex -7.28969 -6.84547 5
+      vertex -7.07107 -7.07107 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -7.70513 26.3742 5
+      vertex -7.90155 26.1291 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.25033 -1.98394 5
+      vertex -7.50111 -6.61312 5
+      vertex -7.28969 -6.84547 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -7.90155 26.1291 5
+      vertex -8.09017 25.8779 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.31154 -1.91227 5
+      vertex -7.70513 -6.37424 5
+      vertex -7.50111 -6.61312 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -8.09017 25.8779 5
+      vertex -8.27081 25.6208 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.37046 -1.83872 5
+      vertex -7.90155 -6.12907 5
+      vertex -7.70513 -6.37424 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -8.27081 25.6208 5
+      vertex -8.44328 25.3583 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.42705 -1.76336 5
+      vertex -8.09017 -5.87785 5
+      vertex -7.90155 -6.12907 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -8.44328 25.3583 5
+      vertex -8.60742 25.0904 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.48124 -1.68625 5
+      vertex -8.27081 -5.62083 5
+      vertex -8.09017 -5.87785 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -8.60742 25.0904 5
+      vertex -8.76307 24.8175 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.53298 -1.60748 5
+      vertex -8.44328 -5.35827 5
+      vertex -8.27081 -5.62083 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -8.76307 24.8175 5
+      vertex -8.91006 24.5399 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.58223 -1.52712 5
+      vertex -8.60742 -5.09041 5
+      vertex -8.44328 -5.35827 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -8.91006 24.5399 5
+      vertex -9.04827 24.2578 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.62892 -1.44526 5
+      vertex -8.76307 -4.81754 5
+      vertex -8.60742 -5.09041 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.04827 24.2578 5
+      vertex -9.17755 23.9715 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.67302 -1.36197 5
+      vertex -8.91006 -4.5399 5
+      vertex -8.76307 -4.81754 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.17755 23.9715 5
+      vertex -9.29776 23.6812 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.71448 -1.27734 5
+      vertex -9.04827 -4.25779 5
+      vertex -8.91006 -4.5399 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.29776 23.6812 5
+      vertex -9.40881 23.3874 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.75326 -1.19144 5
+      vertex -9.17755 -3.97148 5
+      vertex -9.04827 -4.25779 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.40881 23.3874 5
+      vertex -9.51056 23.0902 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.78933 -1.10437 5
+      vertex -9.29776 -3.68124 5
+      vertex -9.17755 -3.97148 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.51056 23.0902 5
+      vertex -9.60294 22.7899 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.82264 -1.01621 5
+      vertex -9.40881 -3.38738 5
+      vertex -9.29776 -3.68124 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.60294 22.7899 5
+      vertex -9.68583 22.4869 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.85317 -0.927051 5
+      vertex -9.51056 -3.09017 5
+      vertex -9.40881 -3.38738 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.68583 22.4869 5
+      vertex -9.75917 22.1814 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.88088 -0.836973 5
+      vertex -9.60294 -2.78991 5
+      vertex -9.51056 -3.09017 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.75917 22.1814 5
+      vertex -9.82287 21.8738 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.90575 -0.746069 5
+      vertex -9.68583 -2.4869 5
+      vertex -9.60294 -2.78991 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.82287 21.8738 5
+      vertex -9.87688 21.5643 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.92775 -0.654429 5
+      vertex -9.75917 -2.18143 5
+      vertex -9.68583 -2.4869 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.87688 21.5643 5
+      vertex -9.92115 21.2533 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.94686 -0.562143 5
+      vertex -9.82287 -1.87381 5
+      vertex -9.75917 -2.18143 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.92115 21.2533 5
+      vertex -9.95562 20.9411 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.96306 -0.469303 5
+      vertex -9.87688 -1.56434 5
+      vertex -9.82287 -1.87381 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.95562 20.9411 5
+      vertex -9.98027 20.6279 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.97634 -0.375999 5
+      vertex -9.92115 -1.25333 5
+      vertex -9.87688 -1.56434 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -10 20 5
+      vertex -9.98027 20.6279 5
+      vertex -9.99506 20.3141 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.98669 -0.282325 5
+      vertex -9.95562 -0.941083 5
+      vertex -9.92115 -1.25333 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.99408 -0.188371 5
+      vertex -9.98027 -0.627905 5
+      vertex -9.95562 -0.941083 5
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.99852 -0.0942316 5
+      vertex -9.99506 -0.314107 5
+      vertex -9.98027 -0.627905 5
+    endloop
+  endfacet
+  facet normal 0.0157101 -0.999877 0
+    outer loop
+      vertex 0 -10 -5
+      vertex 0.314107 -9.99506 5
+      vertex 0 -10 5
+    endloop
+  endfacet
+  facet normal 0.0157101 -0.999877 0
+    outer loop
+      vertex 0.314107 -9.99506 5
+      vertex 0 -10 -5
+      vertex 0.314107 -9.99506 -5
+    endloop
+  endfacet
+  facet normal 0.0784593 -0.996917 0
+    outer loop
+      vertex 0.627905 -9.98027 -5
+      vertex 0.941083 -9.95562 5
+      vertex 0.627905 -9.98027 5
+    endloop
+  endfacet
+  facet normal 0.0784593 -0.996917 0
+    outer loop
+      vertex 0.941083 -9.95562 5
+      vertex 0.627905 -9.98027 -5
+      vertex 0.941083 -9.95562 -5
+    endloop
+  endfacet
+  facet normal 0.140902 -0.990024 0
+    outer loop
+      vertex 1.25333 -9.92115 -5
+      vertex 1.56434 -9.87688 5
+      vertex 1.25333 -9.92115 5
+    endloop
+  endfacet
+  facet normal 0.140902 -0.990024 0
+    outer loop
+      vertex 1.56434 -9.87688 5
+      vertex 1.25333 -9.92115 -5
+      vertex 1.56434 -9.87688 -5
+    endloop
+  endfacet
+  facet normal 0.263872 -0.964558 0
+    outer loop
+      vertex 2.4869 -9.68583 -5
+      vertex 2.78991 -9.60294 5
+      vertex 2.4869 -9.68583 5
+    endloop
+  endfacet
+  facet normal 0.263872 -0.964558 0
+    outer loop
+      vertex 2.78991 -9.60294 5
+      vertex 2.4869 -9.68583 -5
+      vertex 2.78991 -9.60294 -5
+    endloop
+  endfacet
+  facet normal 0.323919 -0.946085 0
+    outer loop
+      vertex 3.09017 -9.51056 -5
+      vertex 3.38738 -9.40881 5
+      vertex 3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal 0.323919 -0.946085 0
+    outer loop
+      vertex 3.38738 -9.40881 5
+      vertex 3.09017 -9.51056 -5
+      vertex 3.38738 -9.40881 -5
+    endloop
+  endfacet
+  facet normal 0.673012 -0.739632 0
+    outer loop
+      vertex 6.61312 -7.50111 -5
+      vertex 6.84547 -7.28969 5
+      vertex 6.61312 -7.50111 5
+    endloop
+  endfacet
+  facet normal 0.673012 -0.739632 0
+    outer loop
+      vertex 6.84547 -7.28969 5
+      vertex 6.61312 -7.50111 -5
+      vertex 6.84547 -7.28969 -5
+    endloop
+  endfacet
+  facet normal 0.600422 -0.799683 0
+    outer loop
+      vertex 5.87785 -8.09017 -5
+      vertex 6.12907 -7.90155 5
+      vertex 5.87785 -8.09017 5
+    endloop
+  endfacet
+  facet normal 0.600422 -0.799683 0
+    outer loop
+      vertex 6.12907 -7.90155 5
+      vertex 5.87785 -8.09017 -5
+      vertex 6.12907 -7.90155 -5
+    endloop
+  endfacet
+  facet normal 0.43994 -0.898027 0
+    outer loop
+      vertex 4.25779 -9.04827 -5
+      vertex 4.5399 -8.91006 5
+      vertex 4.25779 -9.04827 5
+    endloop
+  endfacet
+  facet normal 0.43994 -0.898027 0
+    outer loop
+      vertex 4.5399 -8.91006 5
+      vertex 4.25779 -9.04827 -5
+      vertex 4.5399 -8.91006 -5
+    endloop
+  endfacet
+  facet normal 0.382685 -0.923879 0
+    outer loop
+      vertex 3.68124 -9.29776 -5
+      vertex 3.97148 -9.17755 5
+      vertex 3.68124 -9.29776 5
+    endloop
+  endfacet
+  facet normal 0.382685 -0.923879 0
+    outer loop
+      vertex 3.97148 -9.17755 5
+      vertex 3.68124 -9.29776 -5
+      vertex 3.97148 -9.17755 -5
+    endloop
+  endfacet
+  facet normal 0.5225 -0.852639 0
+    outer loop
+      vertex 5.09041 -8.60742 -5
+      vertex 5.35827 -8.44328 5
+      vertex 5.09041 -8.60742 5
+    endloop
+  endfacet
+  facet normal 0.5225 -0.852639 0
+    outer loop
+      vertex 5.35827 -8.44328 5
+      vertex 5.09041 -8.60742 -5
+      vertex 5.35827 -8.44328 -5
+    endloop
+  endfacet
+  facet normal 0.549022 -0.835808 0
+    outer loop
+      vertex 5.35827 -8.44328 -5
+      vertex 5.62083 -8.27081 5
+      vertex 5.35827 -8.44328 5
+    endloop
+  endfacet
+  facet normal 0.549022 -0.835808 0
+    outer loop
+      vertex 5.62083 -8.27081 5
+      vertex 5.35827 -8.44328 -5
+      vertex 5.62083 -8.27081 -5
+    endloop
+  endfacet
+  facet normal 0.718127 -0.695912 0
+    outer loop
+      vertex 7.07107 -7.07107 5
+      vertex 7.28969 -6.84547 -5
+      vertex 7.28969 -6.84547 5
+    endloop
+  endfacet
+  facet normal 0.718127 -0.695912 0
+    outer loop
+      vertex 7.28969 -6.84547 -5
+      vertex 7.07107 -7.07107 5
+      vertex 7.07107 -7.07107 -5
+    endloop
+  endfacet
+  facet normal 0.818151 -0.575004 0
+    outer loop
+      vertex 8.09017 -5.87785 5
+      vertex 8.27081 -5.62083 -5
+      vertex 8.27081 -5.62083 5
+    endloop
+  endfacet
+  facet normal 0.818151 -0.575004 0
+    outer loop
+      vertex 8.27081 -5.62083 -5
+      vertex 8.09017 -5.87785 5
+      vertex 8.09017 -5.87785 -5
+    endloop
+  endfacet
+  facet normal 0.760407 -0.649447 0
+    outer loop
+      vertex 7.50111 -6.61312 5
+      vertex 7.70513 -6.37424 -5
+      vertex 7.70513 -6.37424 5
+    endloop
+  endfacet
+  facet normal 0.760407 -0.649447 0
+    outer loop
+      vertex 7.70513 -6.37424 -5
+      vertex 7.50111 -6.61312 5
+      vertex 7.50111 -6.61312 -5
+    endloop
+  endfacet
+  facet normal 0.868632 -0.495458 0
+    outer loop
+      vertex 8.60742 -5.09041 5
+      vertex 8.76307 -4.81754 -5
+      vertex 8.76307 -4.81754 5
+    endloop
+  endfacet
+  facet normal 0.868632 -0.495458 0
+    outer loop
+      vertex 8.76307 -4.81754 -5
+      vertex 8.60742 -5.09041 5
+      vertex 8.60742 -5.09041 -5
+    endloop
+  endfacet
+  facet normal 0.883766 -0.46793 0
+    outer loop
+      vertex 8.76307 -4.81754 5
+      vertex 8.91006 -4.5399 -5
+      vertex 8.91006 -4.5399 5
+    endloop
+  endfacet
+  facet normal 0.883766 -0.46793 0
+    outer loop
+      vertex 8.91006 -4.5399 -5
+      vertex 8.76307 -4.81754 5
+      vertex 8.76307 -4.81754 -5
+    endloop
+  endfacet
+  facet normal 0.911404 -0.411513 0
+    outer loop
+      vertex 9.04827 -4.25779 5
+      vertex 9.17755 -3.97148 -5
+      vertex 9.17755 -3.97148 5
+    endloop
+  endfacet
+  facet normal 0.911404 -0.411513 0
+    outer loop
+      vertex 9.17755 -3.97148 -5
+      vertex 9.04827 -4.25779 5
+      vertex 9.04827 -4.25779 -5
+    endloop
+  endfacet
+  facet normal 0.935445 -0.353473 0
+    outer loop
+      vertex 9.29776 -3.68124 5
+      vertex 9.40881 -3.38738 -5
+      vertex 9.40881 -3.38738 5
+    endloop
+  endfacet
+  facet normal 0.935445 -0.353473 0
+    outer loop
+      vertex 9.40881 -3.38738 -5
+      vertex 9.29776 -3.68124 5
+      vertex 9.29776 -3.68124 -5
+    endloop
+  endfacet
+  facet normal 0.955793 -0.29404 0
+    outer loop
+      vertex 9.51056 -3.09017 5
+      vertex 9.60294 -2.78991 -5
+      vertex 9.60294 -2.78991 5
+    endloop
+  endfacet
+  facet normal 0.955793 -0.29404 0
+    outer loop
+      vertex 9.60294 -2.78991 -5
+      vertex 9.51056 -3.09017 5
+      vertex 9.51056 -3.09017 -5
+    endloop
+  endfacet
+  facet normal 0.97237 -0.233444 0
+    outer loop
+      vertex 9.68583 -2.4869 5
+      vertex 9.75917 -2.18143 -5
+      vertex 9.75917 -2.18143 5
+    endloop
+  endfacet
+  facet normal 0.97237 -0.233444 0
+    outer loop
+      vertex 9.75917 -2.18143 -5
+      vertex 9.68583 -2.4869 5
+      vertex 9.68583 -2.4869 -5
+    endloop
+  endfacet
+  facet normal 0.996917 -0.0784593 0
+    outer loop
+      vertex 9.95562 -0.941083 5
+      vertex 9.98027 -0.627905 -5
+      vertex 9.98027 -0.627905 5
+    endloop
+  endfacet
+  facet normal 0.996917 -0.0784593 0
+    outer loop
+      vertex 9.98027 -0.627905 -5
+      vertex 9.95562 -0.941083 5
+      vertex 9.95562 -0.941083 -5
+    endloop
+  endfacet
+  facet normal -0.695912 -0.718127 0
+    outer loop
+      vertex -7.07107 -7.07107 -5
+      vertex -6.84547 -7.28969 5
+      vertex -7.07107 -7.07107 5
+    endloop
+  endfacet
+  facet normal -0.695912 -0.718127 -0
+    outer loop
+      vertex -6.84547 -7.28969 5
+      vertex -7.07107 -7.07107 -5
+      vertex -6.84547 -7.28969 -5
+    endloop
+  endfacet
+  facet normal -0.649447 -0.760407 0
+    outer loop
+      vertex -6.61312 -7.50111 -5
+      vertex -6.37424 -7.70513 5
+      vertex -6.61312 -7.50111 5
+    endloop
+  endfacet
+  facet normal -0.649447 -0.760407 -0
+    outer loop
+      vertex -6.37424 -7.70513 5
+      vertex -6.61312 -7.50111 -5
+      vertex -6.37424 -7.70513 -5
+    endloop
+  endfacet
+  facet normal -0.575004 -0.818151 0
+    outer loop
+      vertex -5.87785 -8.09017 -5
+      vertex -5.62083 -8.27081 5
+      vertex -5.87785 -8.09017 5
+    endloop
+  endfacet
+  facet normal -0.575004 -0.818151 -0
+    outer loop
+      vertex -5.62083 -8.27081 5
+      vertex -5.87785 -8.09017 -5
+      vertex -5.62083 -8.27081 -5
+    endloop
+  endfacet
+  facet normal -0.625244 -0.780429 0
+    outer loop
+      vertex -6.37424 -7.70513 -5
+      vertex -6.12907 -7.90155 5
+      vertex -6.37424 -7.70513 5
+    endloop
+  endfacet
+  facet normal -0.625244 -0.780429 -0
+    outer loop
+      vertex -6.12907 -7.90155 5
+      vertex -6.37424 -7.70513 -5
+      vertex -6.12907 -7.90155 -5
+    endloop
+  endfacet
+  facet normal -0.46793 -0.883766 0
+    outer loop
+      vertex -4.81754 -8.76307 -5
+      vertex -4.5399 -8.91006 5
+      vertex -4.81754 -8.76307 5
+    endloop
+  endfacet
+  facet normal -0.46793 -0.883766 -0
+    outer loop
+      vertex -4.5399 -8.91006 5
+      vertex -4.81754 -8.76307 -5
+      vertex -4.5399 -8.91006 -5
+    endloop
+  endfacet
+  facet normal -0.411513 -0.911404 0
+    outer loop
+      vertex -4.25779 -9.04827 -5
+      vertex -3.97148 -9.17755 5
+      vertex -4.25779 -9.04827 5
+    endloop
+  endfacet
+  facet normal -0.411513 -0.911404 -0
+    outer loop
+      vertex -3.97148 -9.17755 5
+      vertex -4.25779 -9.04827 -5
+      vertex -3.97148 -9.17755 -5
+    endloop
+  endfacet
+  facet normal -0.495458 -0.868632 0
+    outer loop
+      vertex -5.09041 -8.60742 -5
+      vertex -4.81754 -8.76307 5
+      vertex -5.09041 -8.60742 5
+    endloop
+  endfacet
+  facet normal -0.495458 -0.868632 -0
+    outer loop
+      vertex -4.81754 -8.76307 5
+      vertex -5.09041 -8.60742 -5
+      vertex -4.81754 -8.76307 -5
+    endloop
+  endfacet
+  facet normal -0.549022 -0.835808 0
+    outer loop
+      vertex -5.62083 -8.27081 -5
+      vertex -5.35827 -8.44328 5
+      vertex -5.62083 -8.27081 5
+    endloop
+  endfacet
+  facet normal -0.549022 -0.835808 -0
+    outer loop
+      vertex -5.35827 -8.44328 5
+      vertex -5.62083 -8.27081 -5
+      vertex -5.35827 -8.44328 -5
+    endloop
+  endfacet
+  facet normal -0.29404 -0.955793 0
+    outer loop
+      vertex -3.09017 -9.51056 -5
+      vertex -2.78991 -9.60294 5
+      vertex -3.09017 -9.51056 5
+    endloop
+  endfacet
+  facet normal -0.29404 -0.955793 -0
+    outer loop
+      vertex -2.78991 -9.60294 5
+      vertex -3.09017 -9.51056 -5
+      vertex -2.78991 -9.60294 -5
+    endloop
+  endfacet
+  facet normal -0.233444 -0.97237 0
+    outer loop
+      vertex -2.4869 -9.68583 -5
+      vertex -2.18143 -9.75917 5
+      vertex -2.4869 -9.68583 5
+    endloop
+  endfacet
+  facet normal -0.233444 -0.97237 -0
+    outer loop
+      vertex -2.18143 -9.75917 5
+      vertex -2.4869 -9.68583 -5
+      vertex -2.18143 -9.75917 -5
+    endloop
+  endfacet
+  facet normal -0.171928 -0.98511 0
+    outer loop
+      vertex -1.87381 -9.82287 -5
+      vertex -1.56434 -9.87688 5
+      vertex -1.87381 -9.82287 5
+    endloop
+  endfacet
+  facet normal -0.171928 -0.98511 -0
+    outer loop
+      vertex -1.56434 -9.87688 5
+      vertex -1.87381 -9.82287 -5
+      vertex -1.56434 -9.87688 -5
+    endloop
+  endfacet
+  facet normal -0.109734 -0.993961 0
+    outer loop
+      vertex -1.25333 -9.92115 -5
+      vertex -0.941083 -9.95562 5
+      vertex -1.25333 -9.92115 5
+    endloop
+  endfacet
+  facet normal -0.109734 -0.993961 -0
+    outer loop
+      vertex -0.941083 -9.95562 5
+      vertex -1.25333 -9.92115 -5
+      vertex -0.941083 -9.95562 -5
+    endloop
+  endfacet
+  facet normal -0.0471059 -0.99889 0
+    outer loop
+      vertex -0.627905 -9.98027 -5
+      vertex -0.314107 -9.99506 5
+      vertex -0.627905 -9.98027 5
+    endloop
+  endfacet
+  facet normal -0.0471059 -0.99889 -0
+    outer loop
+      vertex -0.314107 -9.99506 5
+      vertex -0.627905 -9.98027 -5
+      vertex -0.314107 -9.99506 -5
+    endloop
+  endfacet
+  facet normal -0.799683 -0.600422 0
+    outer loop
+      vertex -7.90155 -6.12907 -5
+      vertex -8.09017 -5.87785 5
+      vertex -8.09017 -5.87785 -5
+    endloop
+  endfacet
+  facet normal -0.799683 -0.600422 0
+    outer loop
+      vertex -8.09017 -5.87785 5
+      vertex -7.90155 -6.12907 -5
+      vertex -7.90155 -6.12907 5
+    endloop
+  endfacet
+  facet normal -0.739632 -0.673012 0
+    outer loop
+      vertex -7.28969 -6.84547 -5
+      vertex -7.50111 -6.61312 5
+      vertex -7.50111 -6.61312 -5
+    endloop
+  endfacet
+  facet normal -0.739632 -0.673012 0
+    outer loop
+      vertex -7.50111 -6.61312 5
+      vertex -7.28969 -6.84547 -5
+      vertex -7.28969 -6.84547 5
+    endloop
+  endfacet
+  facet normal -0.898027 -0.43994 0
+    outer loop
+      vertex -8.91006 -4.5399 -5
+      vertex -9.04827 -4.25779 5
+      vertex -9.04827 -4.25779 -5
+    endloop
+  endfacet
+  facet normal -0.898027 -0.43994 0
+    outer loop
+      vertex -9.04827 -4.25779 5
+      vertex -8.91006 -4.5399 -5
+      vertex -8.91006 -4.5399 5
+    endloop
+  endfacet
+  facet normal -0.852639 -0.5225 0
+    outer loop
+      vertex -8.44328 -5.35827 -5
+      vertex -8.60742 -5.09041 5
+      vertex -8.60742 -5.09041 -5
+    endloop
+  endfacet
+  facet normal -0.852639 -0.5225 0
+    outer loop
+      vertex -8.60742 -5.09041 5
+      vertex -8.44328 -5.35827 -5
+      vertex -8.44328 -5.35827 5
+    endloop
+  endfacet
+  facet normal -0.979222 -0.202789 0
+    outer loop
+      vertex -9.75917 -2.18143 -5
+      vertex -9.82287 -1.87381 5
+      vertex -9.82287 -1.87381 -5
+    endloop
+  endfacet
+  facet normal -0.979222 -0.202789 0
+    outer loop
+      vertex -9.82287 -1.87381 5
+      vertex -9.75917 -2.18143 -5
+      vertex -9.75917 -2.18143 5
+    endloop
+  endfacet
+  facet normal -0.964558 -0.263872 0
+    outer loop
+      vertex -9.60294 -2.78991 -5
+      vertex -9.68583 -2.4869 5
+      vertex -9.68583 -2.4869 -5
+    endloop
+  endfacet
+  facet normal -0.964558 -0.263872 0
+    outer loop
+      vertex -9.68583 -2.4869 5
+      vertex -9.60294 -2.78991 -5
+      vertex -9.60294 -2.78991 5
+    endloop
+  endfacet
+  facet normal -0.946085 -0.323919 0
+    outer loop
+      vertex -9.40881 -3.38738 -5
+      vertex -9.51056 -3.09017 5
+      vertex -9.51056 -3.09017 -5
+    endloop
+  endfacet
+  facet normal -0.946085 -0.323919 0
+    outer loop
+      vertex -9.51056 -3.09017 5
+      vertex -9.40881 -3.38738 -5
+      vertex -9.40881 -3.38738 5
+    endloop
+  endfacet
+  facet normal -0.990024 -0.140902 0
+    outer loop
+      vertex -9.87688 -1.56434 -5
+      vertex -9.92115 -1.25333 5
+      vertex -9.92115 -1.25333 -5
+    endloop
+  endfacet
+  facet normal -0.990024 -0.140902 0
+    outer loop
+      vertex -9.92115 -1.25333 5
+      vertex -9.87688 -1.56434 -5
+      vertex -9.87688 -1.56434 5
+    endloop
+  endfacet
+  facet normal -0.996917 -0.0784593 0
+    outer loop
+      vertex -9.95562 -0.941083 -5
+      vertex -9.98027 -0.627905 5
+      vertex -9.98027 -0.627905 -5
+    endloop
+  endfacet
+  facet normal -0.996917 -0.0784593 0
+    outer loop
+      vertex -9.98027 -0.627905 5
+      vertex -9.95562 -0.941083 -5
+      vertex -9.95562 -0.941083 5
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0157101 0
+    outer loop
+      vertex -9.99506 -0.314107 -5
+      vertex -10 0 5
+      vertex -10 0 -5
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0157101 0
+    outer loop
+      vertex -10 0 5
+      vertex -9.99506 -0.314107 -5
+      vertex -9.99506 -0.314107 5
+    endloop
+  endfacet
+  facet normal 0.0471059 -0.99889 0
+    outer loop
+      vertex 0.314107 -9.99506 -5
+      vertex 0.627905 -9.98027 5
+      vertex 0.314107 -9.99506 5
+    endloop
+  endfacet
+  facet normal 0.0471059 -0.99889 0
+    outer loop
+      vertex 0.627905 -9.98027 5
+      vertex 0.314107 -9.99506 -5
+      vertex 0.627905 -9.98027 -5
+    endloop
+  endfacet
+  facet normal 0.171928 -0.98511 0
+    outer loop
+      vertex 1.56434 -9.87688 -5
+      vertex 1.87381 -9.82287 5
+      vertex 1.56434 -9.87688 5
+    endloop
+  endfacet
+  facet normal 0.171928 -0.98511 0
+    outer loop
+      vertex 1.87381 -9.82287 5
+      vertex 1.56434 -9.87688 -5
+      vertex 1.87381 -9.82287 -5
+    endloop
+  endfacet
+  facet normal 0.233444 -0.97237 0
+    outer loop
+      vertex 2.18143 -9.75917 -5
+      vertex 2.4869 -9.68583 5
+      vertex 2.18143 -9.75917 5
+    endloop
+  endfacet
+  facet normal 0.233444 -0.97237 0
+    outer loop
+      vertex 2.4869 -9.68583 5
+      vertex 2.18143 -9.75917 -5
+      vertex 2.4869 -9.68583 -5
+    endloop
+  endfacet
+  facet normal 0.353473 -0.935445 0
+    outer loop
+      vertex 3.38738 -9.40881 -5
+      vertex 3.68124 -9.29776 5
+      vertex 3.38738 -9.40881 5
+    endloop
+  endfacet
+  facet normal 0.353473 -0.935445 0
+    outer loop
+      vertex 3.68124 -9.29776 5
+      vertex 3.38738 -9.40881 -5
+      vertex 3.68124 -9.29776 -5
+    endloop
+  endfacet
+  facet normal 0.695912 -0.718127 0
+    outer loop
+      vertex 6.84547 -7.28969 -5
+      vertex 7.07107 -7.07107 5
+      vertex 6.84547 -7.28969 5
+    endloop
+  endfacet
+  facet normal 0.695912 -0.718127 0
+    outer loop
+      vertex 7.07107 -7.07107 5
+      vertex 6.84547 -7.28969 -5
+      vertex 7.07107 -7.07107 -5
+    endloop
+  endfacet
+  facet normal 0.411513 -0.911404 0
+    outer loop
+      vertex 3.97148 -9.17755 -5
+      vertex 4.25779 -9.04827 5
+      vertex 3.97148 -9.17755 5
+    endloop
+  endfacet
+  facet normal 0.411513 -0.911404 0
+    outer loop
+      vertex 4.25779 -9.04827 5
+      vertex 3.97148 -9.17755 -5
+      vertex 4.25779 -9.04827 -5
+    endloop
+  endfacet
+  facet normal 0.799683 -0.600422 0
+    outer loop
+      vertex 7.90155 -6.12907 5
+      vertex 8.09017 -5.87785 -5
+      vertex 8.09017 -5.87785 5
+    endloop
+  endfacet
+  facet normal 0.799683 -0.600422 0
+    outer loop
+      vertex 8.09017 -5.87785 -5
+      vertex 7.90155 -6.12907 5
+      vertex 7.90155 -6.12907 -5
+    endloop
+  endfacet
+  facet normal 0.739632 -0.673012 0
+    outer loop
+      vertex 7.28969 -6.84547 5
+      vertex 7.50111 -6.61312 -5
+      vertex 7.50111 -6.61312 5
+    endloop
+  endfacet
+  facet normal 0.739632 -0.673012 0
+    outer loop
+      vertex 7.50111 -6.61312 -5
+      vertex 7.28969 -6.84547 5
+      vertex 7.28969 -6.84547 -5
+    endloop
+  endfacet
+  facet normal 0.852639 -0.5225 0
+    outer loop
+      vertex 8.44328 -5.35827 5
+      vertex 8.60742 -5.09041 -5
+      vertex 8.60742 -5.09041 5
+    endloop
+  endfacet
+  facet normal 0.852639 -0.5225 0
+    outer loop
+      vertex 8.60742 -5.09041 -5
+      vertex 8.44328 -5.35827 5
+      vertex 8.44328 -5.35827 -5
+    endloop
+  endfacet
+  facet normal 0.898027 -0.43994 0
+    outer loop
+      vertex 8.91006 -4.5399 5
+      vertex 9.04827 -4.25779 -5
+      vertex 9.04827 -4.25779 5
+    endloop
+  endfacet
+  facet normal 0.898027 -0.43994 0
+    outer loop
+      vertex 9.04827 -4.25779 -5
+      vertex 8.91006 -4.5399 5
+      vertex 8.91006 -4.5399 -5
+    endloop
+  endfacet
+  facet normal 0.923879 -0.382685 0
+    outer loop
+      vertex 9.17755 -3.97148 5
+      vertex 9.29776 -3.68124 -5
+      vertex 9.29776 -3.68124 5
+    endloop
+  endfacet
+  facet normal 0.923879 -0.382685 0
+    outer loop
+      vertex 9.29776 -3.68124 -5
+      vertex 9.17755 -3.97148 5
+      vertex 9.17755 -3.97148 -5
+    endloop
+  endfacet
+  facet normal 0.946085 -0.323919 0
+    outer loop
+      vertex 9.40881 -3.38738 5
+      vertex 9.51056 -3.09017 -5
+      vertex 9.51056 -3.09017 5
+    endloop
+  endfacet
+  facet normal 0.946085 -0.323919 0
+    outer loop
+      vertex 9.51056 -3.09017 -5
+      vertex 9.40881 -3.38738 5
+      vertex 9.40881 -3.38738 -5
+    endloop
+  endfacet
+  facet normal 0.979222 -0.202789 0
+    outer loop
+      vertex 9.75917 -2.18143 5
+      vertex 9.82287 -1.87381 -5
+      vertex 9.82287 -1.87381 5
+    endloop
+  endfacet
+  facet normal 0.979222 -0.202789 0
+    outer loop
+      vertex 9.82287 -1.87381 -5
+      vertex 9.75917 -2.18143 5
+      vertex 9.75917 -2.18143 -5
+    endloop
+  endfacet
+  facet normal 0.993961 -0.109734 0
+    outer loop
+      vertex 9.92115 -1.25333 5
+      vertex 9.95562 -0.941083 -5
+      vertex 9.95562 -0.941083 5
+    endloop
+  endfacet
+  facet normal 0.993961 -0.109734 0
+    outer loop
+      vertex 9.95562 -0.941083 -5
+      vertex 9.92115 -1.25333 5
+      vertex 9.92115 -1.25333 -5
+    endloop
+  endfacet
+  facet normal 0.99889 -0.0471059 0
+    outer loop
+      vertex 9.98027 -0.627905 5
+      vertex 9.99506 -0.314107 -5
+      vertex 9.99506 -0.314107 5
+    endloop
+  endfacet
+  facet normal 0.99889 -0.0471059 0
+    outer loop
+      vertex 9.99506 -0.314107 -5
+      vertex 9.98027 -0.627905 5
+      vertex 9.98027 -0.627905 -5
+    endloop
+  endfacet
+  facet normal -0.673012 -0.739632 0
+    outer loop
+      vertex -6.84547 -7.28969 -5
+      vertex -6.61312 -7.50111 5
+      vertex -6.84547 -7.28969 5
+    endloop
+  endfacet
+  facet normal -0.673012 -0.739632 -0
+    outer loop
+      vertex -6.61312 -7.50111 5
+      vertex -6.84547 -7.28969 -5
+      vertex -6.61312 -7.50111 -5
+    endloop
+  endfacet
+  facet normal -0.600422 -0.799683 0
+    outer loop
+      vertex -6.12907 -7.90155 -5
+      vertex -5.87785 -8.09017 5
+      vertex -6.12907 -7.90155 5
+    endloop
+  endfacet
+  facet normal -0.600422 -0.799683 -0
+    outer loop
+      vertex -5.87785 -8.09017 5
+      vertex -6.12907 -7.90155 -5
+      vertex -5.87785 -8.09017 -5
+    endloop
+  endfacet
+  facet normal -0.43994 -0.898027 0
+    outer loop
+      vertex -4.5399 -8.91006 -5
+      vertex -4.25779 -9.04827 5
+      vertex -4.5399 -8.91006 5
+    endloop
+  endfacet
+  facet normal -0.43994 -0.898027 -0
+    outer loop
+      vertex -4.25779 -9.04827 5
+      vertex -4.5399 -8.91006 -5
+      vertex -4.25779 -9.04827 -5
+    endloop
+  endfacet
+  facet normal -0.382685 -0.923879 0
+    outer loop
+      vertex -3.97148 -9.17755 -5
+      vertex -3.68124 -9.29776 5
+      vertex -3.97148 -9.17755 5
+    endloop
+  endfacet
+  facet normal -0.382685 -0.923879 -0
+    outer loop
+      vertex -3.68124 -9.29776 5
+      vertex -3.97148 -9.17755 -5
+      vertex -3.68124 -9.29776 -5
+    endloop
+  endfacet
+  facet normal -0.5225 -0.852639 0
+    outer loop
+      vertex -5.35827 -8.44328 -5
+      vertex -5.09041 -8.60742 5
+      vertex -5.35827 -8.44328 5
+    endloop
+  endfacet
+  facet normal -0.5225 -0.852639 -0
+    outer loop
+      vertex -5.09041 -8.60742 5
+      vertex -5.35827 -8.44328 -5
+      vertex -5.09041 -8.60742 -5
+    endloop
+  endfacet
+  facet normal -0.323919 -0.946085 0
+    outer loop
+      vertex -3.38738 -9.40881 -5
+      vertex -3.09017 -9.51056 5
+      vertex -3.38738 -9.40881 5
+    endloop
+  endfacet
+  facet normal -0.323919 -0.946085 -0
+    outer loop
+      vertex -3.09017 -9.51056 5
+      vertex -3.38738 -9.40881 -5
+      vertex -3.09017 -9.51056 -5
+    endloop
+  endfacet
+  facet normal -0.202789 -0.979222 0
+    outer loop
+      vertex -2.18143 -9.75917 -5
+      vertex -1.87381 -9.82287 5
+      vertex -2.18143 -9.75917 5
+    endloop
+  endfacet
+  facet normal -0.202789 -0.979222 -0
+    outer loop
+      vertex -1.87381 -9.82287 5
+      vertex -2.18143 -9.75917 -5
+      vertex -1.87381 -9.82287 -5
+    endloop
+  endfacet
+  facet normal -0.140902 -0.990024 0
+    outer loop
+      vertex -1.56434 -9.87688 -5
+      vertex -1.25333 -9.92115 5
+      vertex -1.56434 -9.87688 5
+    endloop
+  endfacet
+  facet normal -0.140902 -0.990024 -0
+    outer loop
+      vertex -1.25333 -9.92115 5
+      vertex -1.56434 -9.87688 -5
+      vertex -1.25333 -9.92115 -5
+    endloop
+  endfacet
+  facet normal -0.0157101 -0.999877 0
+    outer loop
+      vertex -0.314107 -9.99506 -5
+      vertex 0 -10 5
+      vertex -0.314107 -9.99506 5
+    endloop
+  endfacet
+  facet normal -0.0157101 -0.999877 -0
+    outer loop
+      vertex 0 -10 5
+      vertex -0.314107 -9.99506 -5
+      vertex 0 -10 -5
+    endloop
+  endfacet
+  facet normal -0.780429 -0.625244 0
+    outer loop
+      vertex -7.70513 -6.37424 -5
+      vertex -7.90155 -6.12907 5
+      vertex -7.90155 -6.12907 -5
+    endloop
+  endfacet
+  facet normal -0.780429 -0.625244 0
+    outer loop
+      vertex -7.90155 -6.12907 5
+      vertex -7.70513 -6.37424 -5
+      vertex -7.70513 -6.37424 5
+    endloop
+  endfacet
+  facet normal -0.911404 -0.411513 0
+    outer loop
+      vertex -9.04827 -4.25779 -5
+      vertex -9.17755 -3.97148 5
+      vertex -9.17755 -3.97148 -5
+    endloop
+  endfacet
+  facet normal -0.911404 -0.411513 0
+    outer loop
+      vertex -9.17755 -3.97148 5
+      vertex -9.04827 -4.25779 -5
+      vertex -9.04827 -4.25779 5
+    endloop
+  endfacet
+  facet normal -0.883766 -0.46793 0
+    outer loop
+      vertex -8.76307 -4.81754 -5
+      vertex -8.91006 -4.5399 5
+      vertex -8.91006 -4.5399 -5
+    endloop
+  endfacet
+  facet normal -0.883766 -0.46793 0
+    outer loop
+      vertex -8.91006 -4.5399 5
+      vertex -8.76307 -4.81754 -5
+      vertex -8.76307 -4.81754 5
+    endloop
+  endfacet
+  facet normal -0.835808 -0.549022 0
+    outer loop
+      vertex -8.27081 -5.62083 -5
+      vertex -8.44328 -5.35827 5
+      vertex -8.44328 -5.35827 -5
+    endloop
+  endfacet
+  facet normal -0.835808 -0.549022 0
+    outer loop
+      vertex -8.44328 -5.35827 5
+      vertex -8.27081 -5.62083 -5
+      vertex -8.27081 -5.62083 5
+    endloop
+  endfacet
+  facet normal -0.97237 -0.233444 0
+    outer loop
+      vertex -9.68583 -2.4869 -5
+      vertex -9.75917 -2.18143 5
+      vertex -9.75917 -2.18143 -5
+    endloop
+  endfacet
+  facet normal -0.97237 -0.233444 0
+    outer loop
+      vertex -9.75917 -2.18143 5
+      vertex -9.68583 -2.4869 -5
+      vertex -9.68583 -2.4869 5
+    endloop
+  endfacet
+  facet normal -0.935445 -0.353473 0
+    outer loop
+      vertex -9.29776 -3.68124 -5
+      vertex -9.40881 -3.38738 5
+      vertex -9.40881 -3.38738 -5
+    endloop
+  endfacet
+  facet normal -0.935445 -0.353473 0
+    outer loop
+      vertex -9.40881 -3.38738 5
+      vertex -9.29776 -3.68124 -5
+      vertex -9.29776 -3.68124 5
+    endloop
+  endfacet
+  facet normal -0.98511 -0.171928 0
+    outer loop
+      vertex -9.82287 -1.87381 -5
+      vertex -9.87688 -1.56434 5
+      vertex -9.87688 -1.56434 -5
+    endloop
+  endfacet
+  facet normal -0.98511 -0.171928 0
+    outer loop
+      vertex -9.87688 -1.56434 5
+      vertex -9.82287 -1.87381 -5
+      vertex -9.82287 -1.87381 5
+    endloop
+  endfacet
+  facet normal -0.99889 -0.0471059 0
+    outer loop
+      vertex -9.98027 -0.627905 -5
+      vertex -9.99506 -0.314107 5
+      vertex -9.99506 -0.314107 -5
+    endloop
+  endfacet
+  facet normal -0.99889 -0.0471059 0
+    outer loop
+      vertex -9.99506 -0.314107 5
+      vertex -9.98027 -0.627905 -5
+      vertex -9.98027 -0.627905 5
+    endloop
+  endfacet
+  facet normal 0.780429 -0.625244 0
+    outer loop
+      vertex 7.70513 -6.37424 5
+      vertex 7.90155 -6.12907 -5
+      vertex 7.90155 -6.12907 5
+    endloop
+  endfacet
+  facet normal 0.780429 -0.625244 0
+    outer loop
+      vertex 7.90155 -6.12907 -5
+      vertex 7.70513 -6.37424 5
+      vertex 7.70513 -6.37424 -5
+    endloop
+  endfacet
+  facet normal 0.990024 -0.140902 0
+    outer loop
+      vertex 9.87688 -1.56434 5
+      vertex 9.92115 -1.25333 -5
+      vertex 9.92115 -1.25333 5
+    endloop
+  endfacet
+  facet normal 0.990024 -0.140902 0
+    outer loop
+      vertex 9.92115 -1.25333 -5
+      vertex 9.87688 -1.56434 5
+      vertex 9.87688 -1.56434 -5
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0157101 0
+    outer loop
+      vertex 9.99506 -0.314107 5
+      vertex 10 0 -5
+      vertex 10 0 5
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0157101 0
+    outer loop
+      vertex 10 0 -5
+      vertex 9.99506 -0.314107 5
+      vertex 9.99506 -0.314107 -5
+    endloop
+  endfacet
+  facet normal 0.998889 -0.047115 0
+    outer loop
+      vertex 239.98 -0.627905 5
+      vertex 239.995 -0.314107 -5
+      vertex 239.995 -0.314107 5
+    endloop
+  endfacet
+  facet normal 0.998889 -0.047115 0
+    outer loop
+      vertex 239.995 -0.314107 -5
+      vertex 239.98 -0.627905 5
+      vertex 239.98 -0.627905 -5
+    endloop
+  endfacet
+  facet normal 0.439949 -0.898023 0
+    outer loop
+      vertex 234.258 -9.04827 -5
+      vertex 234.54 -8.91006 5
+      vertex 234.258 -9.04827 5
+    endloop
+  endfacet
+  facet normal 0.439949 -0.898023 0
+    outer loop
+      vertex 234.54 -8.91006 5
+      vertex 234.258 -9.04827 -5
+      vertex 234.54 -8.91006 -5
+    endloop
+  endfacet
+  facet normal 0.923891 -0.382656 0
+    outer loop
+      vertex 239.178 -3.97148 5
+      vertex 239.298 -3.68124 -5
+      vertex 239.298 -3.68124 5
+    endloop
+  endfacet
+  facet normal 0.923891 -0.382656 0
+    outer loop
+      vertex 239.298 -3.68124 -5
+      vertex 239.178 -3.97148 5
+      vertex 239.178 -3.97148 -5
+    endloop
+  endfacet
+  facet normal -0.996919 -0.0784442 0
+    outer loop
+      vertex 220.044 -0.941083 -5
+      vertex 220.02 -0.627905 5
+      vertex 220.02 -0.627905 -5
+    endloop
+  endfacet
+  facet normal -0.996919 -0.0784442 0
+    outer loop
+      vertex 220.02 -0.627905 5
+      vertex 220.044 -0.941083 -5
+      vertex 220.044 -0.941083 5
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0156889 0
+    outer loop
+      vertex 220.005 -0.314107 -5
+      vertex 220 0 5
+      vertex 220 0 -5
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0156889 0
+    outer loop
+      vertex 220 0 5
+      vertex 220.005 -0.314107 -5
+      vertex 220.005 -0.314107 5
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0156889 0
+    outer loop
+      vertex 239.995 -0.314107 5
+      vertex 240 0 -5
+      vertex 240 0 5
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0156889 0
+    outer loop
+      vertex 240 0 -5
+      vertex 239.995 -0.314107 5
+      vertex 239.995 -0.314107 -5
+    endloop
+  endfacet
+  facet normal 0.996915 -0.0784925 0
+    outer loop
+      vertex 239.956 -0.941083 5
+      vertex 239.98 -0.627905 -5
+      vertex 239.98 -0.627905 5
+    endloop
+  endfacet
+  facet normal 0.996915 -0.0784925 0
+    outer loop
+      vertex 239.98 -0.627905 -5
+      vertex 239.956 -0.941083 5
+      vertex 239.956 -0.941083 -5
+    endloop
+  endfacet
+  facet normal 0.979222 -0.202789 0
+    outer loop
+      vertex 239.759 -2.18143 5
+      vertex 239.823 -1.87381 -5
+      vertex 239.823 -1.87381 5
+    endloop
+  endfacet
+  facet normal 0.979222 -0.202789 0
+    outer loop
+      vertex 239.823 -1.87381 -5
+      vertex 239.759 -2.18143 5
+      vertex 239.759 -2.18143 -5
+    endloop
+  endfacet
+  facet normal 0.964552 -0.263892 0
+    outer loop
+      vertex 239.603 -2.78991 5
+      vertex 239.686 -2.4869 -5
+      vertex 239.686 -2.4869 5
+    endloop
+  endfacet
+  facet normal 0.964552 -0.263892 0
+    outer loop
+      vertex 239.686 -2.4869 -5
+      vertex 239.603 -2.78991 5
+      vertex 239.603 -2.78991 -5
+    endloop
+  endfacet
+  facet normal 0.852643 -0.522494 0
+    outer loop
+      vertex 238.443 -5.35827 5
+      vertex 238.607 -5.09041 -5
+      vertex 238.607 -5.09041 5
+    endloop
+  endfacet
+  facet normal 0.852643 -0.522494 0
+    outer loop
+      vertex 238.607 -5.09041 -5
+      vertex 238.443 -5.35827 5
+      vertex 238.443 -5.35827 -5
+    endloop
+  endfacet
+  facet normal 0.898036 -0.439923 0
+    outer loop
+      vertex 238.91 -4.5399 5
+      vertex 239.048 -4.25779 -5
+      vertex 239.048 -4.25779 5
+    endloop
+  endfacet
+  facet normal 0.898036 -0.439923 0
+    outer loop
+      vertex 239.048 -4.25779 -5
+      vertex 238.91 -4.5399 5
+      vertex 238.91 -4.5399 -5
+    endloop
+  endfacet
+  facet normal -0.35347 -0.935446 0
+    outer loop
+      vertex 226.319 -9.29776 -5
+      vertex 226.613 -9.40881 5
+      vertex 226.319 -9.29776 5
+    endloop
+  endfacet
+  facet normal -0.35347 -0.935446 -0
+    outer loop
+      vertex 226.613 -9.40881 5
+      vertex 226.319 -9.29776 -5
+      vertex 226.613 -9.40881 -5
+    endloop
+  endfacet
+  facet normal -0.998889 -0.047115 0
+    outer loop
+      vertex 220.02 -0.627905 -5
+      vertex 220.005 -0.314107 5
+      vertex 220.005 -0.314107 -5
+    endloop
+  endfacet
+  facet normal -0.998889 -0.047115 0
+    outer loop
+      vertex 220.005 -0.314107 5
+      vertex 220.02 -0.627905 -5
+      vertex 220.02 -0.627905 5
+    endloop
+  endfacet
+  facet normal -0.993957 -0.109773 0
+    outer loop
+      vertex 220.079 -1.25333 -5
+      vertex 220.044 -0.941083 5
+      vertex 220.044 -0.941083 -5
+    endloop
+  endfacet
+  facet normal -0.993957 -0.109773 0
+    outer loop
+      vertex 220.044 -0.941083 5
+      vertex 220.079 -1.25333 -5
+      vertex 220.079 -1.25333 5
+    endloop
+  endfacet
+  facet normal 0.047106 -0.99889 0
+    outer loop
+      vertex 230.314 -9.99506 -5
+      vertex 230.628 -9.98027 5
+      vertex 230.314 -9.99506 5
+    endloop
+  endfacet
+  facet normal 0.047106 -0.99889 0
+    outer loop
+      vertex 230.628 -9.98027 5
+      vertex 230.314 -9.99506 -5
+      vertex 230.628 -9.98027 -5
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex 231.874 -9.82287 -5
+      vertex 232.181 -9.75917 5
+      vertex 231.874 -9.82287 5
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex 232.181 -9.75917 5
+      vertex 231.874 -9.82287 -5
+      vertex 232.181 -9.75917 -5
+    endloop
+  endfacet
+  facet normal 0.382681 -0.923881 0
+    outer loop
+      vertex 233.681 -9.29776 -5
+      vertex 233.971 -9.17755 5
+      vertex 233.681 -9.29776 5
+    endloop
+  endfacet
+  facet normal 0.382681 -0.923881 0
+    outer loop
+      vertex 233.971 -9.17755 5
+      vertex 233.681 -9.29776 -5
+      vertex 233.971 -9.17755 -5
+    endloop
+  endfacet
+  facet normal 0.323918 -0.946085 0
+    outer loop
+      vertex 233.09 -9.51056 -5
+      vertex 233.387 -9.40881 5
+      vertex 233.09 -9.51056 5
+    endloop
+  endfacet
+  facet normal 0.323918 -0.946085 0
+    outer loop
+      vertex 233.387 -9.40881 5
+      vertex 233.09 -9.51056 -5
+      vertex 233.387 -9.40881 -5
+    endloop
+  endfacet
+  facet normal 0.411511 -0.911405 0
+    outer loop
+      vertex 233.971 -9.17755 -5
+      vertex 234.258 -9.04827 5
+      vertex 233.971 -9.17755 5
+    endloop
+  endfacet
+  facet normal 0.411511 -0.911405 0
+    outer loop
+      vertex 234.258 -9.04827 5
+      vertex 233.971 -9.17755 -5
+      vertex 234.258 -9.04827 -5
+    endloop
+  endfacet
+  facet normal 0.993962 -0.109725 0
+    outer loop
+      vertex 239.921 -1.25333 5
+      vertex 239.956 -0.941083 -5
+      vertex 239.956 -0.941083 5
+    endloop
+  endfacet
+  facet normal 0.993962 -0.109725 0
+    outer loop
+      vertex 239.956 -0.941083 -5
+      vertex 239.921 -1.25333 5
+      vertex 239.921 -1.25333 -5
+    endloop
+  endfacet
+  facet normal 0.990023 -0.140908 0
+    outer loop
+      vertex 239.877 -1.56434 5
+      vertex 239.921 -1.25333 -5
+      vertex 239.921 -1.25333 5
+    endloop
+  endfacet
+  facet normal 0.990023 -0.140908 0
+    outer loop
+      vertex 239.921 -1.25333 -5
+      vertex 239.877 -1.56434 5
+      vertex 239.877 -1.56434 -5
+    endloop
+  endfacet
+  facet normal 0.985115 -0.171898 0
+    outer loop
+      vertex 239.823 -1.87381 5
+      vertex 239.877 -1.56434 -5
+      vertex 239.877 -1.56434 5
+    endloop
+  endfacet
+  facet normal 0.985115 -0.171898 0
+    outer loop
+      vertex 239.877 -1.56434 -5
+      vertex 239.823 -1.87381 5
+      vertex 239.823 -1.87381 -5
+    endloop
+  endfacet
+  facet normal 0.972372 -0.233438 0
+    outer loop
+      vertex 239.686 -2.4869 5
+      vertex 239.759 -2.18143 -5
+      vertex 239.759 -2.18143 5
+    endloop
+  endfacet
+  facet normal 0.972372 -0.233438 0
+    outer loop
+      vertex 239.759 -2.18143 -5
+      vertex 239.686 -2.4869 5
+      vertex 239.686 -2.4869 -5
+    endloop
+  endfacet
+  facet normal 0.935433 -0.353505 0
+    outer loop
+      vertex 239.298 -3.68124 5
+      vertex 239.409 -3.38738 -5
+      vertex 239.409 -3.38738 5
+    endloop
+  endfacet
+  facet normal 0.935433 -0.353505 0
+    outer loop
+      vertex 239.409 -3.38738 -5
+      vertex 239.298 -3.68124 5
+      vertex 239.298 -3.68124 -5
+    endloop
+  endfacet
+  facet normal 0.911389 -0.411546 0
+    outer loop
+      vertex 239.048 -4.25779 5
+      vertex 239.178 -3.97148 -5
+      vertex 239.178 -3.97148 5
+    endloop
+  endfacet
+  facet normal 0.911389 -0.411546 0
+    outer loop
+      vertex 239.178 -3.97148 -5
+      vertex 239.048 -4.25779 5
+      vertex 239.048 -4.25779 -5
+    endloop
+  endfacet
+  facet normal 0.883759 -0.467942 0
+    outer loop
+      vertex 238.763 -4.81754 5
+      vertex 238.91 -4.5399 -5
+      vertex 238.91 -4.5399 5
+    endloop
+  endfacet
+  facet normal 0.883759 -0.467942 0
+    outer loop
+      vertex 238.91 -4.5399 -5
+      vertex 238.763 -4.81754 5
+      vertex 238.763 -4.81754 -5
+    endloop
+  endfacet
+  facet normal 0.868641 -0.495442 0
+    outer loop
+      vertex 238.607 -5.09041 5
+      vertex 238.763 -4.81754 -5
+      vertex 238.763 -4.81754 5
+    endloop
+  endfacet
+  facet normal 0.868641 -0.495442 0
+    outer loop
+      vertex 238.763 -4.81754 -5
+      vertex 238.607 -5.09041 5
+      vertex 238.607 -5.09041 -5
+    endloop
+  endfacet
+  facet normal 0.649451 -0.760403 0
+    outer loop
+      vertex 236.374 -7.70513 -5
+      vertex 236.613 -7.50111 5
+      vertex 236.374 -7.70513 5
+    endloop
+  endfacet
+  facet normal 0.649451 -0.760403 0
+    outer loop
+      vertex 236.613 -7.50111 5
+      vertex 236.374 -7.70513 -5
+      vertex 236.613 -7.50111 -5
+    endloop
+  endfacet
+  facet normal 0.549011 -0.835815 0
+    outer loop
+      vertex 235.358 -8.44328 -5
+      vertex 235.621 -8.27081 5
+      vertex 235.358 -8.44328 5
+    endloop
+  endfacet
+  facet normal 0.549011 -0.835815 0
+    outer loop
+      vertex 235.621 -8.27081 5
+      vertex 235.358 -8.44328 -5
+      vertex 235.621 -8.27081 -5
+    endloop
+  endfacet
+  facet normal 0.522501 -0.852638 0
+    outer loop
+      vertex 235.09 -8.60742 -5
+      vertex 235.358 -8.44328 5
+      vertex 235.09 -8.60742 5
+    endloop
+  endfacet
+  facet normal 0.522501 -0.852638 0
+    outer loop
+      vertex 235.358 -8.44328 5
+      vertex 235.09 -8.60742 -5
+      vertex 235.358 -8.44328 -5
+    endloop
+  endfacet
+  facet normal 0.739629 -0.673015 0
+    outer loop
+      vertex 237.29 -6.84547 5
+      vertex 237.501 -6.61312 -5
+      vertex 237.501 -6.61312 5
+    endloop
+  endfacet
+  facet normal 0.739629 -0.673015 0
+    outer loop
+      vertex 237.501 -6.61312 -5
+      vertex 237.29 -6.84547 5
+      vertex 237.29 -6.84547 -5
+    endloop
+  endfacet
+  facet normal -0.575004 -0.818151 0
+    outer loop
+      vertex 224.122 -8.09017 -5
+      vertex 224.379 -8.27081 5
+      vertex 224.122 -8.09017 5
+    endloop
+  endfacet
+  facet normal -0.575004 -0.818151 -0
+    outer loop
+      vertex 224.379 -8.27081 5
+      vertex 224.122 -8.09017 -5
+      vertex 224.379 -8.27081 -5
+    endloop
+  endfacet
+  facet normal -0.439949 -0.898023 0
+    outer loop
+      vertex 225.46 -8.91006 -5
+      vertex 225.742 -9.04827 5
+      vertex 225.46 -8.91006 5
+    endloop
+  endfacet
+  facet normal -0.439949 -0.898023 -0
+    outer loop
+      vertex 225.742 -9.04827 5
+      vertex 225.46 -8.91006 -5
+      vertex 225.742 -9.04827 -5
+    endloop
+  endfacet
+  facet normal -0.600418 -0.799687 0
+    outer loop
+      vertex 223.871 -7.90155 -5
+      vertex 224.122 -8.09017 5
+      vertex 223.871 -7.90155 5
+    endloop
+  endfacet
+  facet normal -0.600418 -0.799687 -0
+    outer loop
+      vertex 224.122 -8.09017 5
+      vertex 223.871 -7.90155 -5
+      vertex 224.122 -8.09017 -5
+    endloop
+  endfacet
+  facet normal -0.263862 -0.96456 0
+    outer loop
+      vertex 227.21 -9.60294 -5
+      vertex 227.513 -9.68583 5
+      vertex 227.21 -9.60294 5
+    endloop
+  endfacet
+  facet normal -0.263862 -0.96456 -0
+    outer loop
+      vertex 227.513 -9.68583 5
+      vertex 227.21 -9.60294 -5
+      vertex 227.513 -9.68583 -5
+    endloop
+  endfacet
+  facet normal 0.0157104 -0.999877 0
+    outer loop
+      vertex 230 -10 -5
+      vertex 230.314 -9.99506 5
+      vertex 230 -10 5
+    endloop
+  endfacet
+  facet normal 0.0157104 -0.999877 0
+    outer loop
+      vertex 230.314 -9.99506 5
+      vertex 230 -10 -5
+      vertex 230.314 -9.99506 -5
+    endloop
+  endfacet
+  facet normal -0.898016 -0.439962 0
+    outer loop
+      vertex 221.09 -4.5399 -5
+      vertex 220.952 -4.25779 5
+      vertex 220.952 -4.25779 -5
+    endloop
+  endfacet
+  facet normal -0.898016 -0.439962 0
+    outer loop
+      vertex 220.952 -4.25779 5
+      vertex 221.09 -4.5399 -5
+      vertex 221.09 -4.5399 5
+    endloop
+  endfacet
+  facet normal -0.799694 -0.600408 0
+    outer loop
+      vertex 222.098 -6.12907 -5
+      vertex 221.91 -5.87785 5
+      vertex 221.91 -5.87785 -5
+    endloop
+  endfacet
+  facet normal -0.799694 -0.600408 0
+    outer loop
+      vertex 221.91 -5.87785 5
+      vertex 222.098 -6.12907 -5
+      vertex 222.098 -6.12907 5
+    endloop
+  endfacet
+  facet normal -0.835812 -0.549016 0
+    outer loop
+      vertex 221.729 -5.62083 -5
+      vertex 221.557 -5.35827 5
+      vertex 221.557 -5.35827 -5
+    endloop
+  endfacet
+  facet normal -0.835812 -0.549016 0
+    outer loop
+      vertex 221.557 -5.35827 5
+      vertex 221.729 -5.62083 -5
+      vertex 221.729 -5.62083 5
+    endloop
+  endfacet
+  facet normal -0.868641 -0.495442 0
+    outer loop
+      vertex 221.393 -5.09041 -5
+      vertex 221.237 -4.81754 5
+      vertex 221.237 -4.81754 -5
+    endloop
+  endfacet
+  facet normal -0.868641 -0.495442 0
+    outer loop
+      vertex 221.237 -4.81754 5
+      vertex 221.393 -5.09041 -5
+      vertex 221.393 -5.09041 5
+    endloop
+  endfacet
+  facet normal -0.979222 -0.202789 0
+    outer loop
+      vertex 220.241 -2.18143 -5
+      vertex 220.177 -1.87381 5
+      vertex 220.177 -1.87381 -5
+    endloop
+  endfacet
+  facet normal -0.979222 -0.202789 0
+    outer loop
+      vertex 220.177 -1.87381 5
+      vertex 220.241 -2.18143 -5
+      vertex 220.241 -2.18143 5
+    endloop
+  endfacet
+  facet normal -0.946097 -0.323884 0
+    outer loop
+      vertex 220.591 -3.38738 -5
+      vertex 220.489 -3.09017 5
+      vertex 220.489 -3.09017 -5
+    endloop
+  endfacet
+  facet normal -0.946097 -0.323884 0
+    outer loop
+      vertex 220.489 -3.09017 5
+      vertex 220.591 -3.38738 -5
+      vertex 220.591 -3.38738 5
+    endloop
+  endfacet
+  facet normal -0.923891 -0.382656 0
+    outer loop
+      vertex 220.822 -3.97148 -5
+      vertex 220.702 -3.68124 5
+      vertex 220.702 -3.68124 -5
+    endloop
+  endfacet
+  facet normal -0.923891 -0.382656 0
+    outer loop
+      vertex 220.702 -3.68124 5
+      vertex 220.822 -3.97148 -5
+      vertex 220.822 -3.97148 5
+    endloop
+  endfacet
+  facet normal -0.935433 -0.353505 0
+    outer loop
+      vertex 220.702 -3.68124 -5
+      vertex 220.591 -3.38738 5
+      vertex 220.591 -3.38738 -5
+    endloop
+  endfacet
+  facet normal -0.935433 -0.353505 0
+    outer loop
+      vertex 220.591 -3.38738 5
+      vertex 220.702 -3.68124 -5
+      vertex 220.702 -3.68124 5
+    endloop
+  endfacet
+  facet normal -0.911407 -0.411506 0
+    outer loop
+      vertex 220.952 -4.25779 -5
+      vertex 220.822 -3.97148 5
+      vertex 220.822 -3.97148 -5
+    endloop
+  endfacet
+  facet normal -0.911407 -0.411506 0
+    outer loop
+      vertex 220.822 -3.97148 5
+      vertex 220.952 -4.25779 -5
+      vertex 220.952 -4.25779 5
+    endloop
+  endfacet
+  facet normal 0.109737 -0.993961 0
+    outer loop
+      vertex 230.941 -9.95562 -5
+      vertex 231.253 -9.92115 5
+      vertex 230.941 -9.95562 5
+    endloop
+  endfacet
+  facet normal 0.109737 -0.993961 0
+    outer loop
+      vertex 231.253 -9.92115 5
+      vertex 230.941 -9.95562 -5
+      vertex 231.253 -9.92115 -5
+    endloop
+  endfacet
+  facet normal 0.0784572 -0.996917 0
+    outer loop
+      vertex 230.628 -9.98027 -5
+      vertex 230.941 -9.95562 5
+      vertex 230.628 -9.98027 5
+    endloop
+  endfacet
+  facet normal 0.0784572 -0.996917 0
+    outer loop
+      vertex 230.941 -9.95562 5
+      vertex 230.628 -9.98027 -5
+      vertex 230.941 -9.95562 -5
+    endloop
+  endfacet
+  facet normal 0.35347 -0.935446 0
+    outer loop
+      vertex 233.387 -9.40881 -5
+      vertex 233.681 -9.29776 5
+      vertex 233.387 -9.40881 5
+    endloop
+  endfacet
+  facet normal 0.35347 -0.935446 0
+    outer loop
+      vertex 233.681 -9.29776 5
+      vertex 233.387 -9.40881 -5
+      vertex 233.681 -9.29776 -5
+    endloop
+  endfacet
+  facet normal 0.946097 -0.323884 0
+    outer loop
+      vertex 239.409 -3.38738 5
+      vertex 239.511 -3.09017 -5
+      vertex 239.511 -3.09017 5
+    endloop
+  endfacet
+  facet normal 0.946097 -0.323884 0
+    outer loop
+      vertex 239.511 -3.09017 -5
+      vertex 239.409 -3.38738 5
+      vertex 239.409 -3.38738 -5
+    endloop
+  endfacet
+  facet normal 0.955789 -0.294054 0
+    outer loop
+      vertex 239.511 -3.09017 5
+      vertex 239.603 -2.78991 -5
+      vertex 239.603 -2.78991 5
+    endloop
+  endfacet
+  facet normal 0.955789 -0.294054 0
+    outer loop
+      vertex 239.603 -2.78991 -5
+      vertex 239.511 -3.09017 5
+      vertex 239.511 -3.09017 -5
+    endloop
+  endfacet
+  facet normal 0.718136 -0.695902 0
+    outer loop
+      vertex 237.071 -7.07107 5
+      vertex 237.29 -6.84547 -5
+      vertex 237.29 -6.84547 5
+    endloop
+  endfacet
+  facet normal 0.718136 -0.695902 0
+    outer loop
+      vertex 237.29 -6.84547 -5
+      vertex 237.071 -7.07107 5
+      vertex 237.071 -7.07107 -5
+    endloop
+  endfacet
+  facet normal 0.672998 -0.739644 0
+    outer loop
+      vertex 236.613 -7.50111 -5
+      vertex 236.845 -7.28969 5
+      vertex 236.613 -7.50111 5
+    endloop
+  endfacet
+  facet normal 0.672998 -0.739644 0
+    outer loop
+      vertex 236.845 -7.28969 5
+      vertex 236.613 -7.50111 -5
+      vertex 236.845 -7.28969 -5
+    endloop
+  endfacet
+  facet normal 0.625253 -0.780422 0
+    outer loop
+      vertex 236.129 -7.90155 -5
+      vertex 236.374 -7.70513 5
+      vertex 236.129 -7.90155 5
+    endloop
+  endfacet
+  facet normal 0.625253 -0.780422 0
+    outer loop
+      vertex 236.374 -7.70513 5
+      vertex 236.129 -7.90155 -5
+      vertex 236.374 -7.70513 -5
+    endloop
+  endfacet
+  facet normal 0.600418 -0.799687 0
+    outer loop
+      vertex 235.878 -8.09017 -5
+      vertex 236.129 -7.90155 5
+      vertex 235.878 -8.09017 5
+    endloop
+  endfacet
+  facet normal 0.600418 -0.799687 0
+    outer loop
+      vertex 236.129 -7.90155 5
+      vertex 235.878 -8.09017 -5
+      vertex 236.129 -7.90155 -5
+    endloop
+  endfacet
+  facet normal 0.575004 -0.818151 0
+    outer loop
+      vertex 235.621 -8.27081 -5
+      vertex 235.878 -8.09017 5
+      vertex 235.621 -8.27081 5
+    endloop
+  endfacet
+  facet normal 0.575004 -0.818151 0
+    outer loop
+      vertex 235.878 -8.09017 5
+      vertex 235.621 -8.27081 -5
+      vertex 235.878 -8.09017 -5
+    endloop
+  endfacet
+  facet normal 0.78044 -0.625231 0
+    outer loop
+      vertex 237.705 -6.37424 5
+      vertex 237.902 -6.12907 -5
+      vertex 237.902 -6.12907 5
+    endloop
+  endfacet
+  facet normal 0.78044 -0.625231 0
+    outer loop
+      vertex 237.902 -6.12907 -5
+      vertex 237.705 -6.37424 5
+      vertex 237.705 -6.37424 -5
+    endloop
+  endfacet
+  facet normal 0.799694 -0.600408 0
+    outer loop
+      vertex 237.902 -6.12907 5
+      vertex 238.09 -5.87785 -5
+      vertex 238.09 -5.87785 5
+    endloop
+  endfacet
+  facet normal 0.799694 -0.600408 0
+    outer loop
+      vertex 238.09 -5.87785 -5
+      vertex 237.902 -6.12907 5
+      vertex 237.902 -6.12907 -5
+    endloop
+  endfacet
+  facet normal 0.760401 -0.649454 0
+    outer loop
+      vertex 237.501 -6.61312 5
+      vertex 237.705 -6.37424 -5
+      vertex 237.705 -6.37424 5
+    endloop
+  endfacet
+  facet normal 0.760401 -0.649454 0
+    outer loop
+      vertex 237.705 -6.37424 -5
+      vertex 237.501 -6.61312 5
+      vertex 237.501 -6.61312 -5
+    endloop
+  endfacet
+  facet normal -0.672998 -0.739644 0
+    outer loop
+      vertex 223.155 -7.28969 -5
+      vertex 223.387 -7.50111 5
+      vertex 223.155 -7.28969 5
+    endloop
+  endfacet
+  facet normal -0.672998 -0.739644 -0
+    outer loop
+      vertex 223.387 -7.50111 5
+      vertex 223.155 -7.28969 -5
+      vertex 223.387 -7.50111 -5
+    endloop
+  endfacet
+  facet normal -0.52248 -0.852652 0
+    outer loop
+      vertex 224.642 -8.44328 -5
+      vertex 224.91 -8.60742 5
+      vertex 224.642 -8.44328 5
+    endloop
+  endfacet
+  facet normal -0.52248 -0.852652 -0
+    outer loop
+      vertex 224.91 -8.60742 5
+      vertex 224.642 -8.44328 -5
+      vertex 224.91 -8.60742 -5
+    endloop
+  endfacet
+  facet normal -0.047106 -0.99889 0
+    outer loop
+      vertex 229.372 -9.98027 -5
+      vertex 229.686 -9.99506 5
+      vertex 229.372 -9.98027 5
+    endloop
+  endfacet
+  facet normal -0.047106 -0.99889 -0
+    outer loop
+      vertex 229.686 -9.99506 5
+      vertex 229.372 -9.98027 -5
+      vertex 229.686 -9.99506 -5
+    endloop
+  endfacet
+  facet normal -0.0157104 -0.999877 0
+    outer loop
+      vertex 229.686 -9.99506 -5
+      vertex 230 -10 5
+      vertex 229.686 -9.99506 5
+    endloop
+  endfacet
+  facet normal -0.0157104 -0.999877 -0
+    outer loop
+      vertex 230 -10 5
+      vertex 229.686 -9.99506 -5
+      vertex 230 -10 -5
+    endloop
+  endfacet
+  facet normal -0.990023 -0.140908 0
+    outer loop
+      vertex 220.123 -1.56434 -5
+      vertex 220.079 -1.25333 5
+      vertex 220.079 -1.25333 -5
+    endloop
+  endfacet
+  facet normal -0.990023 -0.140908 0
+    outer loop
+      vertex 220.079 -1.25333 5
+      vertex 220.123 -1.56434 -5
+      vertex 220.123 -1.56434 5
+    endloop
+  endfacet
+  facet normal -0.883759 -0.467942 0
+    outer loop
+      vertex 221.237 -4.81754 -5
+      vertex 221.09 -4.5399 5
+      vertex 221.09 -4.5399 -5
+    endloop
+  endfacet
+  facet normal -0.883759 -0.467942 0
+    outer loop
+      vertex 221.09 -4.5399 5
+      vertex 221.237 -4.81754 -5
+      vertex 221.237 -4.81754 5
+    endloop
+  endfacet
+  facet normal -0.818131 -0.575033 0
+    outer loop
+      vertex 221.91 -5.87785 -5
+      vertex 221.729 -5.62083 5
+      vertex 221.729 -5.62083 -5
+    endloop
+  endfacet
+  facet normal -0.818131 -0.575033 0
+    outer loop
+      vertex 221.729 -5.62083 5
+      vertex 221.91 -5.87785 -5
+      vertex 221.91 -5.87785 5
+    endloop
+  endfacet
+  facet normal -0.985115 -0.171898 0
+    outer loop
+      vertex 220.177 -1.87381 -5
+      vertex 220.123 -1.56434 5
+      vertex 220.123 -1.56434 -5
+    endloop
+  endfacet
+  facet normal -0.985115 -0.171898 0
+    outer loop
+      vertex 220.123 -1.56434 5
+      vertex 220.177 -1.87381 -5
+      vertex 220.177 -1.87381 5
+    endloop
+  endfacet
+  facet normal 0.233445 -0.97237 0
+    outer loop
+      vertex 232.181 -9.75917 -5
+      vertex 232.487 -9.68583 5
+      vertex 232.181 -9.75917 5
+    endloop
+  endfacet
+  facet normal 0.233445 -0.97237 0
+    outer loop
+      vertex 232.487 -9.68583 5
+      vertex 232.181 -9.75917 -5
+      vertex 232.487 -9.68583 -5
+    endloop
+  endfacet
+  facet normal 0.294052 -0.95579 0
+    outer loop
+      vertex 232.79 -9.60294 -5
+      vertex 233.09 -9.51056 5
+      vertex 232.79 -9.60294 5
+    endloop
+  endfacet
+  facet normal 0.294052 -0.95579 0
+    outer loop
+      vertex 233.09 -9.51056 5
+      vertex 232.79 -9.60294 -5
+      vertex 233.09 -9.51056 -5
+    endloop
+  endfacet
+  facet normal 0.263862 -0.96456 0
+    outer loop
+      vertex 232.487 -9.68583 -5
+      vertex 232.79 -9.60294 5
+      vertex 232.487 -9.68583 5
+    endloop
+  endfacet
+  facet normal 0.263862 -0.96456 0
+    outer loop
+      vertex 232.79 -9.60294 5
+      vertex 232.487 -9.68583 -5
+      vertex 232.79 -9.60294 -5
+    endloop
+  endfacet
+  facet normal 0.17193 -0.985109 0
+    outer loop
+      vertex 231.564 -9.87688 -5
+      vertex 231.874 -9.82287 5
+      vertex 231.564 -9.87688 5
+    endloop
+  endfacet
+  facet normal 0.17193 -0.985109 0
+    outer loop
+      vertex 231.874 -9.82287 5
+      vertex 231.564 -9.87688 -5
+      vertex 231.874 -9.82287 -5
+    endloop
+  endfacet
+  facet normal 0.140899 -0.990024 0
+    outer loop
+      vertex 231.253 -9.92115 -5
+      vertex 231.564 -9.87688 5
+      vertex 231.253 -9.92115 5
+    endloop
+  endfacet
+  facet normal 0.140899 -0.990024 0
+    outer loop
+      vertex 231.564 -9.87688 5
+      vertex 231.253 -9.92115 -5
+      vertex 231.564 -9.87688 -5
+    endloop
+  endfacet
+  facet normal 0.495464 -0.868628 0
+    outer loop
+      vertex 234.818 -8.76307 -5
+      vertex 235.09 -8.60742 5
+      vertex 234.818 -8.76307 5
+    endloop
+  endfacet
+  facet normal 0.495464 -0.868628 0
+    outer loop
+      vertex 235.09 -8.60742 5
+      vertex 234.818 -8.76307 -5
+      vertex 235.09 -8.60742 -5
+    endloop
+  endfacet
+  facet normal 0.467927 -0.883767 0
+    outer loop
+      vertex 234.54 -8.91006 -5
+      vertex 234.818 -8.76307 5
+      vertex 234.54 -8.91006 5
+    endloop
+  endfacet
+  facet normal 0.467927 -0.883767 0
+    outer loop
+      vertex 234.818 -8.76307 5
+      vertex 234.54 -8.91006 -5
+      vertex 234.818 -8.76307 -5
+    endloop
+  endfacet
+  facet normal 0.695906 -0.718133 0
+    outer loop
+      vertex 236.845 -7.28969 -5
+      vertex 237.071 -7.07107 5
+      vertex 236.845 -7.28969 5
+    endloop
+  endfacet
+  facet normal 0.695906 -0.718133 0
+    outer loop
+      vertex 237.071 -7.07107 5
+      vertex 236.845 -7.28969 -5
+      vertex 237.071 -7.07107 -5
+    endloop
+  endfacet
+  facet normal 0.835812 -0.549016 0
+    outer loop
+      vertex 238.271 -5.62083 5
+      vertex 238.443 -5.35827 -5
+      vertex 238.443 -5.35827 5
+    endloop
+  endfacet
+  facet normal 0.835812 -0.549016 0
+    outer loop
+      vertex 238.443 -5.35827 -5
+      vertex 238.271 -5.62083 5
+      vertex 238.271 -5.62083 -5
+    endloop
+  endfacet
+  facet normal 0.818131 -0.575033 0
+    outer loop
+      vertex 238.09 -5.87785 5
+      vertex 238.271 -5.62083 -5
+      vertex 238.271 -5.62083 5
+    endloop
+  endfacet
+  facet normal 0.818131 -0.575033 0
+    outer loop
+      vertex 238.271 -5.62083 -5
+      vertex 238.09 -5.87785 5
+      vertex 238.09 -5.87785 -5
+    endloop
+  endfacet
+  facet normal -0.467927 -0.883767 0
+    outer loop
+      vertex 225.182 -8.76307 -5
+      vertex 225.46 -8.91006 5
+      vertex 225.182 -8.76307 5
+    endloop
+  endfacet
+  facet normal -0.467927 -0.883767 -0
+    outer loop
+      vertex 225.46 -8.91006 5
+      vertex 225.182 -8.76307 -5
+      vertex 225.46 -8.91006 -5
+    endloop
+  endfacet
+  facet normal -0.549033 -0.835801 0
+    outer loop
+      vertex 224.379 -8.27081 -5
+      vertex 224.642 -8.44328 5
+      vertex 224.379 -8.27081 5
+    endloop
+  endfacet
+  facet normal -0.549033 -0.835801 -0
+    outer loop
+      vertex 224.642 -8.44328 5
+      vertex 224.379 -8.27081 -5
+      vertex 224.642 -8.44328 -5
+    endloop
+  endfacet
+  facet normal -0.625253 -0.780422 0
+    outer loop
+      vertex 223.626 -7.70513 -5
+      vertex 223.871 -7.90155 5
+      vertex 223.626 -7.70513 5
+    endloop
+  endfacet
+  facet normal -0.625253 -0.780422 -0
+    outer loop
+      vertex 223.871 -7.90155 5
+      vertex 223.626 -7.70513 -5
+      vertex 223.871 -7.90155 -5
+    endloop
+  endfacet
+  facet normal -0.649451 -0.760403 0
+    outer loop
+      vertex 223.387 -7.50111 -5
+      vertex 223.626 -7.70513 5
+      vertex 223.387 -7.50111 5
+    endloop
+  endfacet
+  facet normal -0.649451 -0.760403 -0
+    outer loop
+      vertex 223.626 -7.70513 5
+      vertex 223.387 -7.50111 -5
+      vertex 223.626 -7.70513 -5
+    endloop
+  endfacet
+  facet normal -0.323918 -0.946085 0
+    outer loop
+      vertex 226.613 -9.40881 -5
+      vertex 226.91 -9.51056 5
+      vertex 226.613 -9.40881 5
+    endloop
+  endfacet
+  facet normal -0.323918 -0.946085 -0
+    outer loop
+      vertex 226.91 -9.51056 5
+      vertex 226.613 -9.40881 -5
+      vertex 226.91 -9.51056 -5
+    endloop
+  endfacet
+  facet normal -0.233445 -0.97237 0
+    outer loop
+      vertex 227.513 -9.68583 -5
+      vertex 227.819 -9.75917 5
+      vertex 227.513 -9.68583 5
+    endloop
+  endfacet
+  facet normal -0.233445 -0.97237 -0
+    outer loop
+      vertex 227.819 -9.75917 5
+      vertex 227.513 -9.68583 -5
+      vertex 227.819 -9.75917 -5
+    endloop
+  endfacet
+  facet normal -0.294052 -0.95579 0
+    outer loop
+      vertex 226.91 -9.51056 -5
+      vertex 227.21 -9.60294 5
+      vertex 226.91 -9.51056 5
+    endloop
+  endfacet
+  facet normal -0.294052 -0.95579 -0
+    outer loop
+      vertex 227.21 -9.60294 5
+      vertex 226.91 -9.51056 -5
+      vertex 227.21 -9.60294 -5
+    endloop
+  endfacet
+  facet normal -0.78044 -0.625231 0
+    outer loop
+      vertex 222.295 -6.37424 -5
+      vertex 222.098 -6.12907 5
+      vertex 222.098 -6.12907 -5
+    endloop
+  endfacet
+  facet normal -0.78044 -0.625231 0
+    outer loop
+      vertex 222.098 -6.12907 5
+      vertex 222.295 -6.37424 -5
+      vertex 222.295 -6.37424 5
+    endloop
+  endfacet
+  facet normal -0.695906 -0.718133 0
+    outer loop
+      vertex 222.929 -7.07107 -5
+      vertex 223.155 -7.28969 5
+      vertex 222.929 -7.07107 5
+    endloop
+  endfacet
+  facet normal -0.695906 -0.718133 -0
+    outer loop
+      vertex 223.155 -7.28969 5
+      vertex 222.929 -7.07107 -5
+      vertex 223.155 -7.28969 -5
+    endloop
+  endfacet
+  facet normal -0.852643 -0.522494 0
+    outer loop
+      vertex 221.557 -5.35827 -5
+      vertex 221.393 -5.09041 5
+      vertex 221.393 -5.09041 -5
+    endloop
+  endfacet
+  facet normal -0.852643 -0.522494 0
+    outer loop
+      vertex 221.393 -5.09041 5
+      vertex 221.557 -5.35827 -5
+      vertex 221.557 -5.35827 5
+    endloop
+  endfacet
+  facet normal -0.964552 -0.263892 0
+    outer loop
+      vertex 220.397 -2.78991 -5
+      vertex 220.314 -2.4869 5
+      vertex 220.314 -2.4869 -5
+    endloop
+  endfacet
+  facet normal -0.964552 -0.263892 0
+    outer loop
+      vertex 220.314 -2.4869 5
+      vertex 220.397 -2.78991 -5
+      vertex 220.397 -2.78991 5
+    endloop
+  endfacet
+  facet normal -0.972372 -0.233438 0
+    outer loop
+      vertex 220.314 -2.4869 -5
+      vertex 220.241 -2.18143 5
+      vertex 220.241 -2.18143 -5
+    endloop
+  endfacet
+  facet normal -0.972372 -0.233438 0
+    outer loop
+      vertex 220.241 -2.18143 5
+      vertex 220.314 -2.4869 -5
+      vertex 220.314 -2.4869 5
+    endloop
+  endfacet
+  facet normal -0.955789 -0.294054 0
+    outer loop
+      vertex 220.489 -3.09017 -5
+      vertex 220.397 -2.78991 5
+      vertex 220.397 -2.78991 -5
+    endloop
+  endfacet
+  facet normal -0.955789 -0.294054 0
+    outer loop
+      vertex 220.397 -2.78991 5
+      vertex 220.489 -3.09017 -5
+      vertex 220.489 -3.09017 5
+    endloop
+  endfacet
+  facet normal -0.411511 -0.911405 0
+    outer loop
+      vertex 225.742 -9.04827 -5
+      vertex 226.029 -9.17755 5
+      vertex 225.742 -9.04827 5
+    endloop
+  endfacet
+  facet normal -0.411511 -0.911405 -0
+    outer loop
+      vertex 226.029 -9.17755 5
+      vertex 225.742 -9.04827 -5
+      vertex 226.029 -9.17755 -5
+    endloop
+  endfacet
+  facet normal -0.495464 -0.868628 0
+    outer loop
+      vertex 224.91 -8.60742 -5
+      vertex 225.182 -8.76307 5
+      vertex 224.91 -8.60742 5
+    endloop
+  endfacet
+  facet normal -0.495464 -0.868628 -0
+    outer loop
+      vertex 225.182 -8.76307 5
+      vertex 224.91 -8.60742 -5
+      vertex 225.182 -8.76307 -5
+    endloop
+  endfacet
+  facet normal -0.140899 -0.990024 0
+    outer loop
+      vertex 228.436 -9.87688 -5
+      vertex 228.747 -9.92115 5
+      vertex 228.436 -9.87688 5
+    endloop
+  endfacet
+  facet normal -0.140899 -0.990024 -0
+    outer loop
+      vertex 228.747 -9.92115 5
+      vertex 228.436 -9.87688 -5
+      vertex 228.747 -9.92115 -5
+    endloop
+  endfacet
+  facet normal -0.17193 -0.985109 0
+    outer loop
+      vertex 228.126 -9.82287 -5
+      vertex 228.436 -9.87688 5
+      vertex 228.126 -9.82287 5
+    endloop
+  endfacet
+  facet normal -0.17193 -0.985109 -0
+    outer loop
+      vertex 228.436 -9.87688 5
+      vertex 228.126 -9.82287 -5
+      vertex 228.436 -9.87688 -5
+    endloop
+  endfacet
+  facet normal -0.109737 -0.993961 0
+    outer loop
+      vertex 228.747 -9.92115 -5
+      vertex 229.059 -9.95562 5
+      vertex 228.747 -9.92115 5
+    endloop
+  endfacet
+  facet normal -0.109737 -0.993961 -0
+    outer loop
+      vertex 229.059 -9.95562 5
+      vertex 228.747 -9.92115 -5
+      vertex 229.059 -9.95562 -5
+    endloop
+  endfacet
+  facet normal -0.0784572 -0.996917 0
+    outer loop
+      vertex 229.059 -9.95562 -5
+      vertex 229.372 -9.98027 5
+      vertex 229.059 -9.95562 5
+    endloop
+  endfacet
+  facet normal -0.0784572 -0.996917 -0
+    outer loop
+      vertex 229.372 -9.98027 5
+      vertex 229.059 -9.95562 -5
+      vertex 229.372 -9.98027 -5
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 0
+    outer loop
+      vertex 227.819 -9.75917 -5
+      vertex 228.126 -9.82287 5
+      vertex 227.819 -9.75917 5
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 -0
+    outer loop
+      vertex 228.126 -9.82287 5
+      vertex 227.819 -9.75917 -5
+      vertex 228.126 -9.82287 -5
+    endloop
+  endfacet
+  facet normal -0.382681 -0.923881 0
+    outer loop
+      vertex 226.029 -9.17755 -5
+      vertex 226.319 -9.29776 5
+      vertex 226.029 -9.17755 5
+    endloop
+  endfacet
+  facet normal -0.382681 -0.923881 -0
+    outer loop
+      vertex 226.319 -9.29776 5
+      vertex 226.029 -9.17755 -5
+      vertex 226.319 -9.29776 -5
+    endloop
+  endfacet
+  facet normal -0.760401 -0.649454 0
+    outer loop
+      vertex 222.499 -6.61312 -5
+      vertex 222.295 -6.37424 5
+      vertex 222.295 -6.37424 -5
+    endloop
+  endfacet
+  facet normal -0.760401 -0.649454 0
+    outer loop
+      vertex 222.295 -6.37424 5
+      vertex 222.499 -6.61312 -5
+      vertex 222.499 -6.61312 5
+    endloop
+  endfacet
+  facet normal -0.718136 -0.695902 0
+    outer loop
+      vertex 222.929 -7.07107 -5
+      vertex 222.71 -6.84547 5
+      vertex 222.71 -6.84547 -5
+    endloop
+  endfacet
+  facet normal -0.718136 -0.695902 0
+    outer loop
+      vertex 222.71 -6.84547 5
+      vertex 222.929 -7.07107 -5
+      vertex 222.929 -7.07107 5
+    endloop
+  endfacet
+  facet normal -0.739629 -0.673015 0
+    outer loop
+      vertex 222.71 -6.84547 -5
+      vertex 222.499 -6.61312 5
+      vertex 222.499 -6.61312 -5
+    endloop
+  endfacet
+  facet normal -0.739629 -0.673015 0
+    outer loop
+      vertex 222.499 -6.61312 5
+      vertex 222.71 -6.84547 -5
+      vertex 222.71 -6.84547 5
+    endloop
+  endfacet
+  facet normal -0.0157131 0.999877 0
+    outer loop
+      vertex 0 30 -5
+      vertex -0.314107 29.9951 5
+      vertex 0 30 5
+    endloop
+  endfacet
+  facet normal -0.0157131 0.999877 0
+    outer loop
+      vertex -0.314107 29.9951 5
+      vertex 0 30 -5
+      vertex -0.314107 29.9951 -5
+    endloop
+  endfacet
+  facet normal -0.718127 0.695912 0
+    outer loop
+      vertex -7.28969 26.8455 -5
+      vertex -7.07107 27.0711 5
+      vertex -7.07107 27.0711 -5
+    endloop
+  endfacet
+  facet normal -0.718127 0.695912 0
+    outer loop
+      vertex -7.07107 27.0711 5
+      vertex -7.28969 26.8455 -5
+      vertex -7.28969 26.8455 5
+    endloop
+  endfacet
+  facet normal -0.964557 0.263873 0
+    outer loop
+      vertex -9.68583 22.4869 -5
+      vertex -9.60294 22.7899 5
+      vertex -9.60294 22.7899 -5
+    endloop
+  endfacet
+  facet normal -0.964557 0.263873 0
+    outer loop
+      vertex -9.60294 22.7899 5
+      vertex -9.68583 22.4869 -5
+      vertex -9.68583 22.4869 5
+    endloop
+  endfacet
+  facet normal -0.799682 0.600423 0
+    outer loop
+      vertex -8.09017 25.8779 -5
+      vertex -7.90155 26.1291 5
+      vertex -7.90155 26.1291 -5
+    endloop
+  endfacet
+  facet normal -0.799682 0.600423 0
+    outer loop
+      vertex -7.90155 26.1291 5
+      vertex -8.09017 25.8779 -5
+      vertex -8.09017 25.8779 5
+    endloop
+  endfacet
+  facet normal -0.955793 0.29404 0
+    outer loop
+      vertex -9.60294 22.7899 -5
+      vertex -9.51056 23.0902 5
+      vertex -9.51056 23.0902 -5
+    endloop
+  endfacet
+  facet normal -0.955793 0.29404 0
+    outer loop
+      vertex -9.51056 23.0902 5
+      vertex -9.60294 22.7899 -5
+      vertex -9.60294 22.7899 5
+    endloop
+  endfacet
+  facet normal -0.467932 0.883764 0
+    outer loop
+      vertex -4.5399 28.9101 -5
+      vertex -4.81754 28.7631 5
+      vertex -4.5399 28.9101 5
+    endloop
+  endfacet
+  facet normal -0.467932 0.883764 0
+    outer loop
+      vertex -4.81754 28.7631 5
+      vertex -4.5399 28.9101 -5
+      vertex -4.81754 28.7631 -5
+    endloop
+  endfacet
+  facet normal -0.990024 0.140902 0
+    outer loop
+      vertex -9.92115 21.2533 -5
+      vertex -9.87688 21.5643 5
+      vertex -9.87688 21.5643 -5
+    endloop
+  endfacet
+  facet normal -0.990024 0.140902 0
+    outer loop
+      vertex -9.87688 21.5643 5
+      vertex -9.92115 21.2533 -5
+      vertex -9.92115 21.2533 5
+    endloop
+  endfacet
+  facet normal -0.739633 0.67301 0
+    outer loop
+      vertex -7.50111 26.6131 -5
+      vertex -7.28969 26.8455 5
+      vertex -7.28969 26.8455 -5
+    endloop
+  endfacet
+  facet normal -0.739633 0.67301 0
+    outer loop
+      vertex -7.28969 26.8455 5
+      vertex -7.50111 26.6131 -5
+      vertex -7.50111 26.6131 5
+    endloop
+  endfacet
+  facet normal -0.911405 0.411511 0
+    outer loop
+      vertex -9.17755 23.9715 -5
+      vertex -9.04827 24.2578 5
+      vertex -9.04827 24.2578 -5
+    endloop
+  endfacet
+  facet normal -0.911405 0.411511 0
+    outer loop
+      vertex -9.04827 24.2578 5
+      vertex -9.17755 23.9715 -5
+      vertex -9.17755 23.9715 5
+    endloop
+  endfacet
+  facet normal -0.868633 0.495456 0
+    outer loop
+      vertex -8.76307 24.8175 -5
+      vertex -8.60742 25.0904 5
+      vertex -8.60742 25.0904 -5
+    endloop
+  endfacet
+  facet normal -0.868633 0.495456 0
+    outer loop
+      vertex -8.60742 25.0904 5
+      vertex -8.76307 24.8175 -5
+      vertex -8.76307 24.8175 5
+    endloop
+  endfacet
+  facet normal -0.946085 0.323919 0
+    outer loop
+      vertex -9.51056 23.0902 -5
+      vertex -9.40881 23.3874 5
+      vertex -9.40881 23.3874 -5
+    endloop
+  endfacet
+  facet normal -0.946085 0.323919 0
+    outer loop
+      vertex -9.40881 23.3874 5
+      vertex -9.51056 23.0902 -5
+      vertex -9.51056 23.0902 5
+    endloop
+  endfacet
+  facet normal -0.993961 0.109733 0
+    outer loop
+      vertex -9.95562 20.9411 -5
+      vertex -9.92115 21.2533 5
+      vertex -9.92115 21.2533 -5
+    endloop
+  endfacet
+  facet normal -0.993961 0.109733 0
+    outer loop
+      vertex -9.92115 21.2533 5
+      vertex -9.95562 20.9411 -5
+      vertex -9.95562 20.9411 5
+    endloop
+  endfacet
+  facet normal -0.439942 0.898026 0
+    outer loop
+      vertex -4.25779 29.0483 -5
+      vertex -4.5399 28.9101 5
+      vertex -4.25779 29.0483 5
+    endloop
+  endfacet
+  facet normal -0.439942 0.898026 0
+    outer loop
+      vertex -4.5399 28.9101 5
+      vertex -4.25779 29.0483 -5
+      vertex -4.5399 28.9101 -5
+    endloop
+  endfacet
+  facet normal -0.60042 0.799685 0
+    outer loop
+      vertex -5.87785 28.0902 -5
+      vertex -6.12907 27.9016 5
+      vertex -5.87785 28.0902 5
+    endloop
+  endfacet
+  facet normal -0.60042 0.799685 0
+    outer loop
+      vertex -6.12907 27.9016 5
+      vertex -5.87785 28.0902 -5
+      vertex -6.12907 27.9016 -5
+    endloop
+  endfacet
+  facet normal -0.575004 0.818151 0
+    outer loop
+      vertex -5.62083 28.2708 -5
+      vertex -5.87785 28.0902 5
+      vertex -5.62083 28.2708 5
+    endloop
+  endfacet
+  facet normal -0.575004 0.818151 0
+    outer loop
+      vertex -5.87785 28.0902 5
+      vertex -5.62083 28.2708 -5
+      vertex -5.87785 28.0902 -5
+    endloop
+  endfacet
+  facet normal -0.549024 0.835807 0
+    outer loop
+      vertex -5.35827 28.4433 -5
+      vertex -5.62083 28.2708 5
+      vertex -5.35827 28.4433 5
+    endloop
+  endfacet
+  facet normal -0.549024 0.835807 0
+    outer loop
+      vertex -5.62083 28.2708 5
+      vertex -5.35827 28.4433 -5
+      vertex -5.62083 28.2708 -5
+    endloop
+  endfacet
+  facet normal -0.625246 0.780428 0
+    outer loop
+      vertex -6.12907 27.9016 -5
+      vertex -6.37424 27.7051 5
+      vertex -6.12907 27.9016 5
+    endloop
+  endfacet
+  facet normal -0.625246 0.780428 0
+    outer loop
+      vertex -6.37424 27.7051 5
+      vertex -6.12907 27.9016 -5
+      vertex -6.37424 27.7051 -5
+    endloop
+  endfacet
+  facet normal -0.294038 0.955794 0
+    outer loop
+      vertex -2.78991 29.6029 -5
+      vertex -3.09017 29.5106 5
+      vertex -2.78991 29.6029 5
+    endloop
+  endfacet
+  facet normal -0.294038 0.955794 0
+    outer loop
+      vertex -3.09017 29.5106 5
+      vertex -2.78991 29.6029 -5
+      vertex -3.09017 29.5106 -5
+    endloop
+  endfacet
+  facet normal -0.323922 0.946084 0
+    outer loop
+      vertex -3.09017 29.5106 -5
+      vertex -3.38738 29.4088 5
+      vertex -3.09017 29.5106 5
+    endloop
+  endfacet
+  facet normal -0.323922 0.946084 0
+    outer loop
+      vertex -3.38738 29.4088 5
+      vertex -3.09017 29.5106 -5
+      vertex -3.38738 29.4088 -5
+    endloop
+  endfacet
+  facet normal -0.353473 0.935445 0
+    outer loop
+      vertex -3.38738 29.4088 -5
+      vertex -3.68124 29.2978 5
+      vertex -3.38738 29.4088 5
+    endloop
+  endfacet
+  facet normal -0.353473 0.935445 0
+    outer loop
+      vertex -3.68124 29.2978 5
+      vertex -3.38738 29.4088 -5
+      vertex -3.68124 29.2978 -5
+    endloop
+  endfacet
+  facet normal -0.0471029 0.99889 0
+    outer loop
+      vertex -0.314107 29.9951 -5
+      vertex -0.627905 29.9803 5
+      vertex -0.314107 29.9951 5
+    endloop
+  endfacet
+  facet normal -0.0471029 0.99889 0
+    outer loop
+      vertex -0.627905 29.9803 5
+      vertex -0.314107 29.9951 -5
+      vertex -0.627905 29.9803 -5
+    endloop
+  endfacet
+  facet normal -0.0784563 0.996918 0
+    outer loop
+      vertex -0.627905 29.9803 -5
+      vertex -0.941083 29.9556 5
+      vertex -0.627905 29.9803 5
+    endloop
+  endfacet
+  facet normal -0.0784563 0.996918 0
+    outer loop
+      vertex -0.941083 29.9556 5
+      vertex -0.627905 29.9803 -5
+      vertex -0.941083 29.9556 -5
+    endloop
+  endfacet
+  facet normal -0.835808 0.549022 0
+    outer loop
+      vertex -8.44328 25.3583 -5
+      vertex -8.27081 25.6208 5
+      vertex -8.27081 25.6208 -5
+    endloop
+  endfacet
+  facet normal -0.835808 0.549022 0
+    outer loop
+      vertex -8.27081 25.6208 5
+      vertex -8.44328 25.3583 -5
+      vertex -8.44328 25.3583 5
+    endloop
+  endfacet
+  facet normal -0.923879 0.382685 0
+    outer loop
+      vertex -9.29776 23.6812 -5
+      vertex -9.17755 23.9715 5
+      vertex -9.17755 23.9715 -5
+    endloop
+  endfacet
+  facet normal -0.923879 0.382685 0
+    outer loop
+      vertex -9.17755 23.9715 5
+      vertex -9.29776 23.6812 -5
+      vertex -9.29776 23.6812 5
+    endloop
+  endfacet
+  facet normal -0.883764 0.467932 0
+    outer loop
+      vertex -8.91006 24.5399 -5
+      vertex -8.76307 24.8175 5
+      vertex -8.76307 24.8175 -5
+    endloop
+  endfacet
+  facet normal -0.883764 0.467932 0
+    outer loop
+      vertex -8.76307 24.8175 5
+      vertex -8.91006 24.5399 -5
+      vertex -8.91006 24.5399 5
+    endloop
+  endfacet
+  facet normal -0.898027 0.43994 0
+    outer loop
+      vertex -9.04827 24.2578 -5
+      vertex -8.91006 24.5399 5
+      vertex -8.91006 24.5399 -5
+    endloop
+  endfacet
+  facet normal -0.898027 0.43994 0
+    outer loop
+      vertex -8.91006 24.5399 5
+      vertex -9.04827 24.2578 -5
+      vertex -9.04827 24.2578 5
+    endloop
+  endfacet
+  facet normal -0.85264 0.522499 0
+    outer loop
+      vertex -8.60742 25.0904 -5
+      vertex -8.44328 25.3583 5
+      vertex -8.44328 25.3583 -5
+    endloop
+  endfacet
+  facet normal -0.85264 0.522499 0
+    outer loop
+      vertex -8.44328 25.3583 5
+      vertex -8.60742 25.0904 -5
+      vertex -8.60742 25.0904 5
+    endloop
+  endfacet
+  facet normal -0.935444 0.353474 0
+    outer loop
+      vertex -9.40881 23.3874 -5
+      vertex -9.29776 23.6812 5
+      vertex -9.29776 23.6812 -5
+    endloop
+  endfacet
+  facet normal -0.935444 0.353474 0
+    outer loop
+      vertex -9.29776 23.6812 5
+      vertex -9.40881 23.3874 -5
+      vertex -9.40881 23.3874 5
+    endloop
+  endfacet
+  facet normal -0.979222 0.20279 0
+    outer loop
+      vertex -9.82287 21.8738 -5
+      vertex -9.75917 22.1814 5
+      vertex -9.75917 22.1814 -5
+    endloop
+  endfacet
+  facet normal -0.979222 0.20279 0
+    outer loop
+      vertex -9.75917 22.1814 5
+      vertex -9.82287 21.8738 -5
+      vertex -9.82287 21.8738 5
+    endloop
+  endfacet
+  facet normal -0.98511 0.171927 0
+    outer loop
+      vertex -9.87688 21.5643 -5
+      vertex -9.82287 21.8738 5
+      vertex -9.82287 21.8738 -5
+    endloop
+  endfacet
+  facet normal -0.98511 0.171927 0
+    outer loop
+      vertex -9.82287 21.8738 5
+      vertex -9.87688 21.5643 -5
+      vertex -9.87688 21.5643 5
+    endloop
+  endfacet
+  facet normal -0.99889 0.0471058 0
+    outer loop
+      vertex -9.99506 20.3141 -5
+      vertex -9.98027 20.6279 5
+      vertex -9.98027 20.6279 -5
+    endloop
+  endfacet
+  facet normal -0.99889 0.0471058 0
+    outer loop
+      vertex -9.98027 20.6279 5
+      vertex -9.99506 20.3141 -5
+      vertex -9.99506 20.3141 5
+    endloop
+  endfacet
+  facet normal -0.996917 0.0784595 0
+    outer loop
+      vertex -9.98027 20.6279 -5
+      vertex -9.95562 20.9411 5
+      vertex -9.95562 20.9411 -5
+    endloop
+  endfacet
+  facet normal -0.996917 0.0784595 0
+    outer loop
+      vertex -9.95562 20.9411 5
+      vertex -9.98027 20.6279 -5
+      vertex -9.98027 20.6279 5
+    endloop
+  endfacet
+  facet normal -0.999877 0.0157102 0
+    outer loop
+      vertex -10 20 -5
+      vertex -9.99506 20.3141 5
+      vertex -9.99506 20.3141 -5
+    endloop
+  endfacet
+  facet normal -0.999877 0.0157102 0
+    outer loop
+      vertex -9.99506 20.3141 5
+      vertex -10 20 -5
+      vertex -10 20 5
+    endloop
+  endfacet
+  facet normal -0.673012 0.739632 0
+    outer loop
+      vertex -6.61312 27.5011 -5
+      vertex -6.84547 27.2897 5
+      vertex -6.61312 27.5011 5
+    endloop
+  endfacet
+  facet normal -0.673012 0.739632 0
+    outer loop
+      vertex -6.84547 27.2897 5
+      vertex -6.61312 27.5011 -5
+      vertex -6.84547 27.2897 -5
+    endloop
+  endfacet
+  facet normal -0.695912 0.718127 0
+    outer loop
+      vertex -6.84547 27.2897 -5
+      vertex -7.07107 27.0711 5
+      vertex -6.84547 27.2897 5
+    endloop
+  endfacet
+  facet normal -0.695912 0.718127 0
+    outer loop
+      vertex -7.07107 27.0711 5
+      vertex -6.84547 27.2897 -5
+      vertex -7.07107 27.0711 -5
+    endloop
+  endfacet
+  facet normal -0.649447 0.760407 0
+    outer loop
+      vertex -6.37424 27.7051 -5
+      vertex -6.61312 27.5011 5
+      vertex -6.37424 27.7051 5
+    endloop
+  endfacet
+  facet normal -0.649447 0.760407 0
+    outer loop
+      vertex -6.61312 27.5011 5
+      vertex -6.37424 27.7051 -5
+      vertex -6.61312 27.5011 -5
+    endloop
+  endfacet
+  facet normal -0.411511 0.911405 0
+    outer loop
+      vertex -3.97148 29.1775 -5
+      vertex -4.25779 29.0483 5
+      vertex -3.97148 29.1775 5
+    endloop
+  endfacet
+  facet normal -0.411511 0.911405 0
+    outer loop
+      vertex -4.25779 29.0483 5
+      vertex -3.97148 29.1775 -5
+      vertex -4.25779 29.0483 -5
+    endloop
+  endfacet
+  facet normal -0.263875 0.964557 0
+    outer loop
+      vertex -2.4869 29.6858 -5
+      vertex -2.78991 29.6029 5
+      vertex -2.4869 29.6858 5
+    endloop
+  endfacet
+  facet normal -0.263875 0.964557 0
+    outer loop
+      vertex -2.78991 29.6029 5
+      vertex -2.4869 29.6858 -5
+      vertex -2.78991 29.6029 -5
+    endloop
+  endfacet
+  facet normal -0.233444 0.97237 0
+    outer loop
+      vertex -2.18143 29.7592 -5
+      vertex -2.4869 29.6858 5
+      vertex -2.18143 29.7592 5
+    endloop
+  endfacet
+  facet normal -0.233444 0.97237 0
+    outer loop
+      vertex -2.4869 29.6858 5
+      vertex -2.18143 29.7592 -5
+      vertex -2.4869 29.6858 -5
+    endloop
+  endfacet
+  facet normal -0.140902 0.990024 0
+    outer loop
+      vertex -1.25333 29.9211 -5
+      vertex -1.56434 29.8769 5
+      vertex -1.25333 29.9211 5
+    endloop
+  endfacet
+  facet normal -0.140902 0.990024 0
+    outer loop
+      vertex -1.56434 29.8769 5
+      vertex -1.25333 29.9211 -5
+      vertex -1.56434 29.8769 -5
+    endloop
+  endfacet
+  facet normal -0.202789 0.979222 0
+    outer loop
+      vertex -1.87381 29.8229 -5
+      vertex -2.18143 29.7592 5
+      vertex -1.87381 29.8229 5
+    endloop
+  endfacet
+  facet normal -0.202789 0.979222 0
+    outer loop
+      vertex -2.18143 29.7592 5
+      vertex -1.87381 29.8229 -5
+      vertex -2.18143 29.7592 -5
+    endloop
+  endfacet
+  facet normal -0.171928 0.98511 0
+    outer loop
+      vertex -1.56434 29.8769 -5
+      vertex -1.87381 29.8229 5
+      vertex -1.56434 29.8769 5
+    endloop
+  endfacet
+  facet normal -0.171928 0.98511 0
+    outer loop
+      vertex -1.87381 29.8229 5
+      vertex -1.56434 29.8769 -5
+      vertex -1.87381 29.8229 -5
+    endloop
+  endfacet
+  facet normal -0.109737 0.993961 0
+    outer loop
+      vertex -0.941083 29.9556 -5
+      vertex -1.25333 29.9211 5
+      vertex -0.941083 29.9556 5
+    endloop
+  endfacet
+  facet normal -0.109737 0.993961 0
+    outer loop
+      vertex -1.25333 29.9211 5
+      vertex -0.941083 29.9556 -5
+      vertex -1.25333 29.9211 -5
+    endloop
+  endfacet
+  facet normal -0.780429 0.625244 0
+    outer loop
+      vertex -7.90155 26.1291 -5
+      vertex -7.70513 26.3742 5
+      vertex -7.70513 26.3742 -5
+    endloop
+  endfacet
+  facet normal -0.780429 0.625244 0
+    outer loop
+      vertex -7.70513 26.3742 5
+      vertex -7.90155 26.1291 -5
+      vertex -7.90155 26.1291 5
+    endloop
+  endfacet
+  facet normal -0.760406 0.649448 0
+    outer loop
+      vertex -7.70513 26.3742 -5
+      vertex -7.50111 26.6131 5
+      vertex -7.50111 26.6131 -5
+    endloop
+  endfacet
+  facet normal -0.760406 0.649448 0
+    outer loop
+      vertex -7.50111 26.6131 5
+      vertex -7.70513 26.3742 -5
+      vertex -7.70513 26.3742 5
+    endloop
+  endfacet
+  facet normal -0.818151 0.575004 0
+    outer loop
+      vertex -8.27081 25.6208 -5
+      vertex -8.09017 25.8779 5
+      vertex -8.09017 25.8779 -5
+    endloop
+  endfacet
+  facet normal -0.818151 0.575004 0
+    outer loop
+      vertex -8.09017 25.8779 5
+      vertex -8.27081 25.6208 -5
+      vertex -8.27081 25.6208 5
+    endloop
+  endfacet
+  facet normal -0.97237 0.233443 0
+    outer loop
+      vertex -9.75917 22.1814 -5
+      vertex -9.68583 22.4869 5
+      vertex -9.68583 22.4869 -5
+    endloop
+  endfacet
+  facet normal -0.97237 0.233443 0
+    outer loop
+      vertex -9.68583 22.4869 5
+      vertex -9.75917 22.1814 -5
+      vertex -9.75917 22.1814 5
+    endloop
+  endfacet
+  facet normal -0.495456 0.868633 0
+    outer loop
+      vertex -4.81754 28.7631 -5
+      vertex -5.09041 28.6074 5
+      vertex -4.81754 28.7631 5
+    endloop
+  endfacet
+  facet normal -0.495456 0.868633 0
+    outer loop
+      vertex -5.09041 28.6074 5
+      vertex -4.81754 28.7631 -5
+      vertex -5.09041 28.6074 -5
+    endloop
+  endfacet
+  facet normal -0.522498 0.852641 0
+    outer loop
+      vertex -5.09041 28.6074 -5
+      vertex -5.35827 28.4433 5
+      vertex -5.09041 28.6074 5
+    endloop
+  endfacet
+  facet normal -0.522498 0.852641 0
+    outer loop
+      vertex -5.35827 28.4433 5
+      vertex -5.09041 28.6074 -5
+      vertex -5.35827 28.4433 -5
+    endloop
+  endfacet
+  facet normal -0.382682 0.92388 0
+    outer loop
+      vertex -3.68124 29.2978 -5
+      vertex -3.97148 29.1775 5
+      vertex -3.68124 29.2978 5
+    endloop
+  endfacet
+  facet normal -0.382682 0.92388 0
+    outer loop
+      vertex -3.97148 29.1775 5
+      vertex -3.68124 29.2978 -5
+      vertex -3.97148 29.1775 -5
+    endloop
+  endfacet
+  facet normal 0.999877 0.0156889 0
+    outer loop
+      vertex 240 20 5
+      vertex 239.995 20.3141 -5
+      vertex 239.995 20.3141 5
+    endloop
+  endfacet
+  facet normal 0.999877 0.0156889 0
+    outer loop
+      vertex 239.995 20.3141 -5
+      vertex 240 20 5
+      vertex 240 20 -5
+    endloop
+  endfacet
+  facet normal 0.695906 0.718133 -0
+    outer loop
+      vertex 237.071 27.0711 -5
+      vertex 236.845 27.2897 5
+      vertex 237.071 27.0711 5
+    endloop
+  endfacet
+  facet normal 0.695906 0.718133 0
+    outer loop
+      vertex 236.845 27.2897 5
+      vertex 237.071 27.0711 -5
+      vertex 236.845 27.2897 -5
+    endloop
+  endfacet
+  facet normal 0.91139 0.411544 0
+    outer loop
+      vertex 239.178 23.9715 5
+      vertex 239.048 24.2578 -5
+      vertex 239.048 24.2578 5
+    endloop
+  endfacet
+  facet normal 0.91139 0.411544 0
+    outer loop
+      vertex 239.048 24.2578 -5
+      vertex 239.178 23.9715 5
+      vertex 239.178 23.9715 -5
+    endloop
+  endfacet
+  facet normal 0.990023 0.140908 0
+    outer loop
+      vertex 239.921 21.2533 5
+      vertex 239.877 21.5643 -5
+      vertex 239.877 21.5643 5
+    endloop
+  endfacet
+  facet normal 0.990023 0.140908 0
+    outer loop
+      vertex 239.877 21.5643 -5
+      vertex 239.921 21.2533 5
+      vertex 239.921 21.2533 -5
+    endloop
+  endfacet
+  facet normal 0.263865 0.96456 -0
+    outer loop
+      vertex 232.79 29.6029 -5
+      vertex 232.487 29.6858 5
+      vertex 232.79 29.6029 5
+    endloop
+  endfacet
+  facet normal 0.263865 0.96456 0
+    outer loop
+      vertex 232.487 29.6858 5
+      vertex 232.79 29.6029 -5
+      vertex 232.487 29.6858 -5
+    endloop
+  endfacet
+  facet normal 0.294049 0.95579 -0
+    outer loop
+      vertex 233.09 29.5106 -5
+      vertex 232.79 29.6029 5
+      vertex 233.09 29.5106 5
+    endloop
+  endfacet
+  facet normal 0.294049 0.95579 0
+    outer loop
+      vertex 232.79 29.6029 5
+      vertex 233.09 29.5106 -5
+      vertex 232.79 29.6029 -5
+    endloop
+  endfacet
+  facet normal 0.140899 0.990024 -0
+    outer loop
+      vertex 231.564 29.8769 -5
+      vertex 231.253 29.9211 5
+      vertex 231.564 29.8769 5
+    endloop
+  endfacet
+  facet normal 0.140899 0.990024 0
+    outer loop
+      vertex 231.253 29.9211 5
+      vertex 231.564 29.8769 -5
+      vertex 231.253 29.9211 -5
+    endloop
+  endfacet
+  facet normal 0.996915 0.0784927 0
+    outer loop
+      vertex 239.98 20.6279 5
+      vertex 239.956 20.9411 -5
+      vertex 239.956 20.9411 5
+    endloop
+  endfacet
+  facet normal 0.996915 0.0784927 0
+    outer loop
+      vertex 239.956 20.9411 -5
+      vertex 239.98 20.6279 5
+      vertex 239.98 20.6279 -5
+    endloop
+  endfacet
+  facet normal 0.998889 0.0471149 0
+    outer loop
+      vertex 239.995 20.3141 5
+      vertex 239.98 20.6279 -5
+      vertex 239.98 20.6279 5
+    endloop
+  endfacet
+  facet normal 0.998889 0.0471149 0
+    outer loop
+      vertex 239.98 20.6279 -5
+      vertex 239.995 20.3141 5
+      vertex 239.995 20.3141 -5
+    endloop
+  endfacet
+  facet normal 0.985115 0.171898 0
+    outer loop
+      vertex 239.877 21.5643 5
+      vertex 239.823 21.8738 -5
+      vertex 239.823 21.8738 5
+    endloop
+  endfacet
+  facet normal 0.985115 0.171898 0
+    outer loop
+      vertex 239.823 21.8738 -5
+      vertex 239.877 21.5643 5
+      vertex 239.877 21.5643 -5
+    endloop
+  endfacet
+  facet normal 0.935432 0.353506 0
+    outer loop
+      vertex 239.409 23.3874 5
+      vertex 239.298 23.6812 -5
+      vertex 239.298 23.6812 5
+    endloop
+  endfacet
+  facet normal 0.935432 0.353506 0
+    outer loop
+      vertex 239.298 23.6812 -5
+      vertex 239.409 23.3874 5
+      vertex 239.409 23.3874 -5
+    endloop
+  endfacet
+  facet normal 0.946097 0.323884 0
+    outer loop
+      vertex 239.511 23.0902 5
+      vertex 239.409 23.3874 -5
+      vertex 239.409 23.3874 5
+    endloop
+  endfacet
+  facet normal 0.946097 0.323884 0
+    outer loop
+      vertex 239.409 23.3874 -5
+      vertex 239.511 23.0902 5
+      vertex 239.511 23.0902 -5
+    endloop
+  endfacet
+  facet normal 0.799692 0.60041 0
+    outer loop
+      vertex 238.09 25.8779 5
+      vertex 237.902 26.1291 -5
+      vertex 237.902 26.1291 5
+    endloop
+  endfacet
+  facet normal 0.799692 0.60041 0
+    outer loop
+      vertex 237.902 26.1291 -5
+      vertex 238.09 25.8779 5
+      vertex 238.09 25.8779 -5
+    endloop
+  endfacet
+  facet normal 0.78044 0.625231 0
+    outer loop
+      vertex 237.902 26.1291 5
+      vertex 237.705 26.3742 -5
+      vertex 237.705 26.3742 5
+    endloop
+  endfacet
+  facet normal 0.78044 0.625231 0
+    outer loop
+      vertex 237.705 26.3742 -5
+      vertex 237.902 26.1291 5
+      vertex 237.902 26.1291 -5
+    endloop
+  endfacet
+  facet normal 0.818131 0.575033 0
+    outer loop
+      vertex 238.271 25.6208 5
+      vertex 238.09 25.8779 -5
+      vertex 238.09 25.8779 5
+    endloop
+  endfacet
+  facet normal 0.818131 0.575033 0
+    outer loop
+      vertex 238.09 25.8779 -5
+      vertex 238.271 25.6208 5
+      vertex 238.271 25.6208 -5
+    endloop
+  endfacet
+  facet normal 0.898036 0.439923 0
+    outer loop
+      vertex 239.048 24.2578 5
+      vertex 238.91 24.5399 -5
+      vertex 238.91 24.5399 5
+    endloop
+  endfacet
+  facet normal 0.898036 0.439923 0
+    outer loop
+      vertex 238.91 24.5399 -5
+      vertex 239.048 24.2578 5
+      vertex 239.048 24.2578 -5
+    endloop
+  endfacet
+  facet normal 0.10974 0.99396 -0
+    outer loop
+      vertex 231.253 29.9211 -5
+      vertex 230.941 29.9556 5
+      vertex 231.253 29.9211 5
+    endloop
+  endfacet
+  facet normal 0.10974 0.99396 0
+    outer loop
+      vertex 230.941 29.9556 5
+      vertex 231.253 29.9211 -5
+      vertex 230.941 29.9556 -5
+    endloop
+  endfacet
+  facet normal 0.32392 0.946084 -0
+    outer loop
+      vertex 233.387 29.4088 -5
+      vertex 233.09 29.5106 5
+      vertex 233.387 29.4088 5
+    endloop
+  endfacet
+  facet normal 0.32392 0.946084 0
+    outer loop
+      vertex 233.09 29.5106 5
+      vertex 233.387 29.4088 -5
+      vertex 233.09 29.5106 -5
+    endloop
+  endfacet
+  facet normal 0.522499 0.85264 -0
+    outer loop
+      vertex 235.358 28.4433 -5
+      vertex 235.09 28.6074 5
+      vertex 235.358 28.4433 5
+    endloop
+  endfacet
+  facet normal 0.522499 0.85264 0
+    outer loop
+      vertex 235.09 28.6074 5
+      vertex 235.358 28.4433 -5
+      vertex 235.09 28.6074 -5
+    endloop
+  endfacet
+  facet normal 0.439952 0.898021 -0
+    outer loop
+      vertex 234.54 28.9101 -5
+      vertex 234.258 29.0483 5
+      vertex 234.54 28.9101 5
+    endloop
+  endfacet
+  facet normal 0.439952 0.898021 0
+    outer loop
+      vertex 234.258 29.0483 5
+      vertex 234.54 28.9101 -5
+      vertex 234.258 29.0483 -5
+    endloop
+  endfacet
+  facet normal 0.495462 0.86863 -0
+    outer loop
+      vertex 235.09 28.6074 -5
+      vertex 234.818 28.7631 5
+      vertex 235.09 28.6074 5
+    endloop
+  endfacet
+  facet normal 0.495462 0.86863 0
+    outer loop
+      vertex 234.818 28.7631 5
+      vertex 235.09 28.6074 -5
+      vertex 234.818 28.7631 -5
+    endloop
+  endfacet
+  facet normal 0.600416 0.799688 -0
+    outer loop
+      vertex 236.129 27.9016 -5
+      vertex 235.878 28.0902 5
+      vertex 236.129 27.9016 5
+    endloop
+  endfacet
+  facet normal 0.600416 0.799688 0
+    outer loop
+      vertex 235.878 28.0902 5
+      vertex 236.129 27.9016 -5
+      vertex 235.878 28.0902 -5
+    endloop
+  endfacet
+  facet normal 0.672998 0.739644 -0
+    outer loop
+      vertex 236.845 27.2897 -5
+      vertex 236.613 27.5011 5
+      vertex 236.845 27.2897 5
+    endloop
+  endfacet
+  facet normal 0.672998 0.739644 0
+    outer loop
+      vertex 236.613 27.5011 5
+      vertex 236.845 27.2897 -5
+      vertex 236.613 27.5011 -5
+    endloop
+  endfacet
+  facet normal 0.993962 0.109724 0
+    outer loop
+      vertex 239.956 20.9411 5
+      vertex 239.921 21.2533 -5
+      vertex 239.921 21.2533 5
+    endloop
+  endfacet
+  facet normal 0.993962 0.109724 0
+    outer loop
+      vertex 239.921 21.2533 -5
+      vertex 239.956 20.9411 5
+      vertex 239.956 20.9411 -5
+    endloop
+  endfacet
+  facet normal 0.972372 0.233438 0
+    outer loop
+      vertex 239.759 22.1814 5
+      vertex 239.686 22.4869 -5
+      vertex 239.686 22.4869 5
+    endloop
+  endfacet
+  facet normal 0.972372 0.233438 0
+    outer loop
+      vertex 239.686 22.4869 -5
+      vertex 239.759 22.1814 5
+      vertex 239.759 22.1814 -5
+    endloop
+  endfacet
+  facet normal 0.964552 0.263893 0
+    outer loop
+      vertex 239.686 22.4869 5
+      vertex 239.603 22.7899 -5
+      vertex 239.603 22.7899 5
+    endloop
+  endfacet
+  facet normal 0.964552 0.263893 0
+    outer loop
+      vertex 239.603 22.7899 -5
+      vertex 239.686 22.4869 5
+      vertex 239.686 22.4869 -5
+    endloop
+  endfacet
+  facet normal 0.955789 0.294053 0
+    outer loop
+      vertex 239.603 22.7899 5
+      vertex 239.511 23.0902 -5
+      vertex 239.511 23.0902 5
+    endloop
+  endfacet
+  facet normal 0.955789 0.294053 0
+    outer loop
+      vertex 239.511 23.0902 -5
+      vertex 239.603 22.7899 5
+      vertex 239.603 22.7899 -5
+    endloop
+  endfacet
+  facet normal 0.73963 0.673014 0
+    outer loop
+      vertex 237.501 26.6131 5
+      vertex 237.29 26.8455 -5
+      vertex 237.29 26.8455 5
+    endloop
+  endfacet
+  facet normal 0.73963 0.673014 0
+    outer loop
+      vertex 237.29 26.8455 -5
+      vertex 237.501 26.6131 5
+      vertex 237.501 26.6131 -5
+    endloop
+  endfacet
+  facet normal 0.718136 0.695902 0
+    outer loop
+      vertex 237.29 26.8455 5
+      vertex 237.071 27.0711 -5
+      vertex 237.071 27.0711 5
+    endloop
+  endfacet
+  facet normal 0.718136 0.695902 0
+    outer loop
+      vertex 237.071 27.0711 -5
+      vertex 237.29 26.8455 5
+      vertex 237.29 26.8455 -5
+    endloop
+  endfacet
+  facet normal 0.7604 0.649455 0
+    outer loop
+      vertex 237.705 26.3742 5
+      vertex 237.501 26.6131 -5
+      vertex 237.501 26.6131 5
+    endloop
+  endfacet
+  facet normal 0.7604 0.649455 0
+    outer loop
+      vertex 237.501 26.6131 -5
+      vertex 237.705 26.3742 5
+      vertex 237.705 26.3742 -5
+    endloop
+  endfacet
+  facet normal 0.852644 0.522492 0
+    outer loop
+      vertex 238.607 25.0904 5
+      vertex 238.443 25.3583 -5
+      vertex 238.443 25.3583 5
+    endloop
+  endfacet
+  facet normal 0.852644 0.522492 0
+    outer loop
+      vertex 238.443 25.3583 -5
+      vertex 238.607 25.0904 5
+      vertex 238.607 25.0904 -5
+    endloop
+  endfacet
+  facet normal 0.835812 0.549016 0
+    outer loop
+      vertex 238.443 25.3583 5
+      vertex 238.271 25.6208 -5
+      vertex 238.271 25.6208 5
+    endloop
+  endfacet
+  facet normal 0.835812 0.549016 0
+    outer loop
+      vertex 238.271 25.6208 -5
+      vertex 238.443 25.3583 5
+      vertex 238.443 25.3583 -5
+    endloop
+  endfacet
+  facet normal 0.868642 0.49544 0
+    outer loop
+      vertex 238.763 24.8175 5
+      vertex 238.607 25.0904 -5
+      vertex 238.607 25.0904 5
+    endloop
+  endfacet
+  facet normal 0.868642 0.49544 0
+    outer loop
+      vertex 238.607 25.0904 -5
+      vertex 238.763 24.8175 5
+      vertex 238.763 24.8175 -5
+    endloop
+  endfacet
+  facet normal 0.883758 0.467944 0
+    outer loop
+      vertex 238.91 24.5399 5
+      vertex 238.763 24.8175 -5
+      vertex 238.763 24.8175 5
+    endloop
+  endfacet
+  facet normal 0.883758 0.467944 0
+    outer loop
+      vertex 238.763 24.8175 -5
+      vertex 238.91 24.5399 5
+      vertex 238.91 24.5399 -5
+    endloop
+  endfacet
+  facet normal 0.35347 0.935446 -0
+    outer loop
+      vertex 233.681 29.2978 -5
+      vertex 233.387 29.4088 5
+      vertex 233.681 29.2978 5
+    endloop
+  endfacet
+  facet normal 0.35347 0.935446 0
+    outer loop
+      vertex 233.387 29.4088 5
+      vertex 233.681 29.2978 -5
+      vertex 233.387 29.4088 -5
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 -0
+    outer loop
+      vertex 232.181 29.7592 -5
+      vertex 231.874 29.8229 5
+      vertex 232.181 29.7592 5
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 0
+    outer loop
+      vertex 231.874 29.8229 5
+      vertex 232.181 29.7592 -5
+      vertex 231.874 29.8229 -5
+    endloop
+  endfacet
+  facet normal 0.233445 0.97237 -0
+    outer loop
+      vertex 232.487 29.6858 -5
+      vertex 232.181 29.7592 5
+      vertex 232.487 29.6858 5
+    endloop
+  endfacet
+  facet normal 0.233445 0.97237 0
+    outer loop
+      vertex 232.181 29.7592 5
+      vertex 232.487 29.6858 -5
+      vertex 232.181 29.7592 -5
+    endloop
+  endfacet
+  facet normal 0.17193 0.985109 -0
+    outer loop
+      vertex 231.874 29.8229 -5
+      vertex 231.564 29.8769 5
+      vertex 231.874 29.8229 5
+    endloop
+  endfacet
+  facet normal 0.17193 0.985109 0
+    outer loop
+      vertex 231.564 29.8769 5
+      vertex 231.874 29.8229 -5
+      vertex 231.564 29.8769 -5
+    endloop
+  endfacet
+  facet normal 0.0784541 0.996918 -0
+    outer loop
+      vertex 230.941 29.9556 -5
+      vertex 230.628 29.9803 5
+      vertex 230.941 29.9556 5
+    endloop
+  endfacet
+  facet normal 0.0784541 0.996918 0
+    outer loop
+      vertex 230.628 29.9803 5
+      vertex 230.941 29.9556 -5
+      vertex 230.628 29.9803 -5
+    endloop
+  endfacet
+  facet normal 0.047103 0.99889 -0
+    outer loop
+      vertex 230.628 29.9803 -5
+      vertex 230.314 29.9951 5
+      vertex 230.628 29.9803 5
+    endloop
+  endfacet
+  facet normal 0.047103 0.99889 0
+    outer loop
+      vertex 230.314 29.9951 5
+      vertex 230.628 29.9803 -5
+      vertex 230.314 29.9951 -5
+    endloop
+  endfacet
+  facet normal 0.0157134 0.999877 -0
+    outer loop
+      vertex 230.314 29.9951 -5
+      vertex 230 30 5
+      vertex 230.314 29.9951 5
+    endloop
+  endfacet
+  facet normal 0.0157134 0.999877 0
+    outer loop
+      vertex 230 30 5
+      vertex 230.314 29.9951 -5
+      vertex 230 30 -5
+    endloop
+  endfacet
+  facet normal 0.382678 0.923882 -0
+    outer loop
+      vertex 233.971 29.1775 -5
+      vertex 233.681 29.2978 5
+      vertex 233.971 29.1775 5
+    endloop
+  endfacet
+  facet normal 0.382678 0.923882 0
+    outer loop
+      vertex 233.681 29.2978 5
+      vertex 233.971 29.1775 -5
+      vertex 233.681 29.2978 -5
+    endloop
+  endfacet
+  facet normal 0.46793 0.883766 -0
+    outer loop
+      vertex 234.818 28.7631 -5
+      vertex 234.54 28.9101 5
+      vertex 234.818 28.7631 5
+    endloop
+  endfacet
+  facet normal 0.46793 0.883766 0
+    outer loop
+      vertex 234.54 28.9101 5
+      vertex 234.818 28.7631 -5
+      vertex 234.54 28.9101 -5
+    endloop
+  endfacet
+  facet normal 0.549013 0.835814 -0
+    outer loop
+      vertex 235.621 28.2708 -5
+      vertex 235.358 28.4433 5
+      vertex 235.621 28.2708 5
+    endloop
+  endfacet
+  facet normal 0.549013 0.835814 0
+    outer loop
+      vertex 235.358 28.4433 5
+      vertex 235.621 28.2708 -5
+      vertex 235.358 28.4433 -5
+    endloop
+  endfacet
+  facet normal 0.575004 0.818151 -0
+    outer loop
+      vertex 235.878 28.0902 -5
+      vertex 235.621 28.2708 5
+      vertex 235.878 28.0902 5
+    endloop
+  endfacet
+  facet normal 0.575004 0.818151 0
+    outer loop
+      vertex 235.621 28.2708 5
+      vertex 235.878 28.0902 -5
+      vertex 235.621 28.2708 -5
+    endloop
+  endfacet
+  facet normal 0.625255 0.780421 -0
+    outer loop
+      vertex 236.374 27.7051 -5
+      vertex 236.129 27.9016 5
+      vertex 236.374 27.7051 5
+    endloop
+  endfacet
+  facet normal 0.625255 0.780421 0
+    outer loop
+      vertex 236.129 27.9016 5
+      vertex 236.374 27.7051 -5
+      vertex 236.129 27.9016 -5
+    endloop
+  endfacet
+  facet normal 0.649451 0.760403 -0
+    outer loop
+      vertex 236.613 27.5011 -5
+      vertex 236.374 27.7051 5
+      vertex 236.613 27.5011 5
+    endloop
+  endfacet
+  facet normal 0.649451 0.760403 0
+    outer loop
+      vertex 236.374 27.7051 5
+      vertex 236.613 27.5011 -5
+      vertex 236.374 27.7051 -5
+    endloop
+  endfacet
+  facet normal 0.979222 0.20279 0
+    outer loop
+      vertex 239.823 21.8738 5
+      vertex 239.759 22.1814 -5
+      vertex 239.759 22.1814 5
+    endloop
+  endfacet
+  facet normal 0.979222 0.20279 0
+    outer loop
+      vertex 239.759 22.1814 -5
+      vertex 239.823 21.8738 5
+      vertex 239.823 21.8738 -5
+    endloop
+  endfacet
+  facet normal 0.923891 0.382656 0
+    outer loop
+      vertex 239.298 23.6812 5
+      vertex 239.178 23.9715 -5
+      vertex 239.178 23.9715 5
+    endloop
+  endfacet
+  facet normal 0.923891 0.382656 0
+    outer loop
+      vertex 239.178 23.9715 -5
+      vertex 239.298 23.6812 5
+      vertex 239.298 23.6812 -5
+    endloop
+  endfacet
+  facet normal 0.411508 0.911406 -0
+    outer loop
+      vertex 234.258 29.0483 -5
+      vertex 233.971 29.1775 5
+      vertex 234.258 29.0483 5
+    endloop
+  endfacet
+  facet normal 0.411508 0.911406 0
+    outer loop
+      vertex 233.971 29.1775 5
+      vertex 234.258 29.0483 -5
+      vertex 233.971 29.1775 -5
+    endloop
+  endfacet
+  facet normal 0 1 -0
+    outer loop
+      vertex 230 30 -5
+      vertex 0 30 5
+      vertex 230 30 5
+    endloop
+  endfacet
+  facet normal 0 1 0
+    outer loop
+      vertex 0 30 5
+      vertex 230 30 -5
+      vertex 0 30 -5
+    endloop
+  endfacet
+  facet normal 0 -1 0
+    outer loop
+      vertex 10 10 -5
+      vertex 220 10 5
+      vertex 10 10 5
+    endloop
+  endfacet
+  facet normal 0 -1 -0
+    outer loop
+      vertex 220 10 5
+      vertex 10 10 -5
+      vertex 220 10 -5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex -10 0 -5
+      vertex -10 20 5
+      vertex -10 20 -5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex -10 20 5
+      vertex -10 0 -5
+      vertex -10 0 5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 10 0 5
+      vertex 10 10 -5
+      vertex 10 10 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 10 10 -5
+      vertex 10 0 5
+      vertex 10 0 -5
+    endloop
+  endfacet
+  facet normal -1 0 0
+    outer loop
+      vertex 220 0 -5
+      vertex 220 10 5
+      vertex 220 10 -5
+    endloop
+  endfacet
+  facet normal -1 -0 0
+    outer loop
+      vertex 220 10 5
+      vertex 220 0 -5
+      vertex 220 0 5
+    endloop
+  endfacet
+  facet normal 1 -0 0
+    outer loop
+      vertex 240 0 5
+      vertex 240 20 -5
+      vertex 240 20 5
+    endloop
+  endfacet
+  facet normal 1 0 0
+    outer loop
+      vertex 240 20 -5
+      vertex 240 0 5
+      vertex 240 0 -5
+    endloop
+  endfacet
+  facet normal -0.999876 -0.0157255 0
+    outer loop
+      vertex 1.5 0 -5
+      vertex 1.49926 0.0471153 0
+      vertex 1.49926 0.0471153 -5
+    endloop
+  endfacet
+  facet normal -0.999876 -0.0157255 0
+    outer loop
+      vertex 1.49926 0.0471153 0
+      vertex 1.5 0 -5
+      vertex 1.5 0 0
+    endloop
+  endfacet
+  facet normal 0.999876 -0.0157255 0
+    outer loop
+      vertex -1.5 0 0
+      vertex -1.49926 0.0471153 -5
+      vertex -1.49926 0.0471153 0
+    endloop
+  endfacet
+  facet normal 0.999876 -0.0157255 0
+    outer loop
+      vertex -1.49926 0.0471153 -5
+      vertex -1.5 0 0
+      vertex -1.5 0 -5
+    endloop
+  endfacet
+  facet normal -0.0157255 -0.999876 0
+    outer loop
+      vertex 0 1.5 -5
+      vertex 0.0471153 1.49926 0
+      vertex 0 1.5 0
+    endloop
+  endfacet
+  facet normal -0.0157255 -0.999876 -0
+    outer loop
+      vertex 0.0471153 1.49926 0
+      vertex 0 1.5 -5
+      vertex 0.0471153 1.49926 -5
+    endloop
+  endfacet
+  facet normal 0.0157255 0.999876 -0
+    outer loop
+      vertex 0 -1.5 -5
+      vertex -0.0471153 -1.49926 0
+      vertex 0 -1.5 0
+    endloop
+  endfacet
+  facet normal 0.0157255 0.999876 0
+    outer loop
+      vertex -0.0471153 -1.49926 0
+      vertex 0 -1.5 -5
+      vertex -0.0471153 -1.49926 -5
+    endloop
+  endfacet
+  facet normal -0.695919 -0.71812 0
+    outer loop
+      vertex 1.02682 1.09345 -5
+      vertex 1.06066 1.06066 0
+      vertex 1.02682 1.09345 0
+    endloop
+  endfacet
+  facet normal -0.695919 -0.71812 -0
+    outer loop
+      vertex 1.06066 1.06066 0
+      vertex 1.02682 1.09345 -5
+      vertex 1.06066 1.06066 -5
+    endloop
+  endfacet
+  facet normal 0.695919 -0.71812 0
+    outer loop
+      vertex -1.06066 1.06066 -5
+      vertex -1.02682 1.09345 0
+      vertex -1.06066 1.06066 0
+    endloop
+  endfacet
+  facet normal 0.695919 -0.71812 0
+    outer loop
+      vertex -1.02682 1.09345 0
+      vertex -1.06066 1.06066 -5
+      vertex -1.02682 1.09345 -5
+    endloop
+  endfacet
+  facet normal -0.923886 -0.382669 0
+    outer loop
+      vertex 1.39466 0.552186 -5
+      vertex 1.37663 0.595721 0
+      vertex 1.37663 0.595721 -5
+    endloop
+  endfacet
+  facet normal -0.923886 -0.382669 0
+    outer loop
+      vertex 1.37663 0.595721 0
+      vertex 1.39466 0.552186 -5
+      vertex 1.39466 0.552186 0
+    endloop
+  endfacet
+  facet normal 0.835814 -0.549013 0
+    outer loop
+      vertex -1.26649 0.80374 0
+      vertex -1.24062 0.843124 -5
+      vertex -1.24062 0.843124 0
+    endloop
+  endfacet
+  facet normal 0.835814 -0.549013 0
+    outer loop
+      vertex -1.24062 0.843124 -5
+      vertex -1.26649 0.80374 0
+      vertex -1.26649 0.80374 -5
+    endloop
+  endfacet
+  facet normal 0.109732 -0.993961 0
+    outer loop
+      vertex -0.188 1.48817 -5
+      vertex -0.141162 1.49334 0
+      vertex -0.188 1.48817 0
+    endloop
+  endfacet
+  facet normal 0.109732 -0.993961 0
+    outer loop
+      vertex -0.141162 1.49334 0
+      vertex -0.188 1.48817 -5
+      vertex -0.141162 1.49334 -5
+    endloop
+  endfacet
+  facet normal -0.868628 0.495465 0
+    outer loop
+      vertex 1.29111 -0.763561 -5
+      vertex 1.31446 -0.722631 0
+      vertex 1.31446 -0.722631 -5
+    endloop
+  endfacet
+  facet normal -0.868628 0.495465 0
+    outer loop
+      vertex 1.31446 -0.722631 0
+      vertex 1.29111 -0.763561 -5
+      vertex 1.29111 -0.763561 0
+    endloop
+  endfacet
+  facet normal -0.20279 0.979222 0
+    outer loop
+      vertex 0.327214 -1.46387 -5
+      vertex 0.281072 -1.47343 0
+      vertex 0.327214 -1.46387 0
+    endloop
+  endfacet
+  facet normal -0.20279 0.979222 0
+    outer loop
+      vertex 0.281072 -1.47343 0
+      vertex 0.327214 -1.46387 -5
+      vertex 0.281072 -1.47343 -5
+    endloop
+  endfacet
+  facet normal 0.382669 0.923886 -0
+    outer loop
+      vertex -0.552186 -1.39466 -5
+      vertex -0.595721 -1.37663 0
+      vertex -0.552186 -1.39466 0
+    endloop
+  endfacet
+  facet normal 0.382669 0.923886 0
+    outer loop
+      vertex -0.595721 -1.37663 0
+      vertex -0.552186 -1.39466 -5
+      vertex -0.595721 -1.37663 -5
+    endloop
+  endfacet
+  facet normal 0.98511 0.171926 0
+    outer loop
+      vertex -1.47343 -0.281072 0
+      vertex -1.48153 -0.234652 -5
+      vertex -1.48153 -0.234652 0
+    endloop
+  endfacet
+  facet normal 0.98511 0.171926 0
+    outer loop
+      vertex -1.48153 -0.234652 -5
+      vertex -1.47343 -0.281072 0
+      vertex -1.47343 -0.281072 -5
+    endloop
+  endfacet
+  facet normal -0.972369 -0.233449 0
+    outer loop
+      vertex 1.46387 0.327214 -5
+      vertex 1.45287 0.373034 0
+      vertex 1.45287 0.373034 -5
+    endloop
+  endfacet
+  facet normal -0.972369 -0.233449 0
+    outer loop
+      vertex 1.45287 0.373034 0
+      vertex 1.46387 0.327214 -5
+      vertex 1.46387 0.327214 0
+    endloop
+  endfacet
+  facet normal -0.883766 -0.46793 0
+    outer loop
+      vertex 1.33651 0.680985 -5
+      vertex 1.31446 0.722631 0
+      vertex 1.31446 0.722631 -5
+    endloop
+  endfacet
+  facet normal -0.883766 -0.46793 0
+    outer loop
+      vertex 1.31446 0.722631 0
+      vertex 1.33651 0.680985 -5
+      vertex 1.33651 0.680985 0
+    endloop
+  endfacet
+  facet normal -0.78043 -0.625243 0
+    outer loop
+      vertex 1.18523 0.91936 -5
+      vertex 1.15577 0.956136 0
+      vertex 1.15577 0.956136 -5
+    endloop
+  endfacet
+  facet normal -0.78043 -0.625243 0
+    outer loop
+      vertex 1.15577 0.956136 0
+      vertex 1.18523 0.91936 -5
+      vertex 1.18523 0.91936 0
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 0
+    outer loop
+      vertex 0.281072 1.47343 -5
+      vertex 0.327214 1.46387 0
+      vertex 0.281072 1.47343 0
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 -0
+    outer loop
+      vertex 0.327214 1.46387 0
+      vertex 0.281072 1.47343 -5
+      vertex 0.327214 1.46387 -5
+    endloop
+  endfacet
+  facet normal -0.625243 -0.78043 0
+    outer loop
+      vertex 0.91936 1.18523 -5
+      vertex 0.956136 1.15577 0
+      vertex 0.91936 1.18523 0
+    endloop
+  endfacet
+  facet normal -0.625243 -0.78043 -0
+    outer loop
+      vertex 0.956136 1.15577 0
+      vertex 0.91936 1.18523 -5
+      vertex 0.956136 1.15577 -5
+    endloop
+  endfacet
+  facet normal -0.46793 -0.883766 0
+    outer loop
+      vertex 0.680985 1.33651 -5
+      vertex 0.722631 1.31446 0
+      vertex 0.680985 1.33651 0
+    endloop
+  endfacet
+  facet normal -0.46793 -0.883766 -0
+    outer loop
+      vertex 0.722631 1.31446 0
+      vertex 0.680985 1.33651 -5
+      vertex 0.722631 1.31446 -5
+    endloop
+  endfacet
+  facet normal 0.979222 -0.20279 0
+    outer loop
+      vertex -1.47343 0.281072 0
+      vertex -1.46387 0.327214 -5
+      vertex -1.46387 0.327214 0
+    endloop
+  endfacet
+  facet normal 0.979222 -0.20279 0
+    outer loop
+      vertex -1.46387 0.327214 -5
+      vertex -1.47343 0.281072 0
+      vertex -1.47343 0.281072 -5
+    endloop
+  endfacet
+  facet normal 0.495465 -0.868628 0
+    outer loop
+      vertex -0.763561 1.29111 -5
+      vertex -0.722631 1.31446 0
+      vertex -0.763561 1.29111 0
+    endloop
+  endfacet
+  facet normal 0.495465 -0.868628 0
+    outer loop
+      vertex -0.722631 1.31446 0
+      vertex -0.763561 1.29111 -5
+      vertex -0.722631 1.31446 -5
+    endloop
+  endfacet
+  facet normal 0.625243 -0.78043 0
+    outer loop
+      vertex -0.956136 1.15577 -5
+      vertex -0.91936 1.18523 0
+      vertex -0.956136 1.15577 0
+    endloop
+  endfacet
+  facet normal 0.625243 -0.78043 0
+    outer loop
+      vertex -0.91936 1.18523 0
+      vertex -0.956136 1.15577 -5
+      vertex -0.91936 1.18523 -5
+    endloop
+  endfacet
+  facet normal 0.353484 -0.93544 0
+    outer loop
+      vertex -0.552186 1.39466 -5
+      vertex -0.508106 1.41132 0
+      vertex -0.552186 1.39466 0
+    endloop
+  endfacet
+  facet normal 0.353484 -0.93544 0
+    outer loop
+      vertex -0.508106 1.41132 0
+      vertex -0.552186 1.39466 -5
+      vertex -0.508106 1.41132 -5
+    endloop
+  endfacet
+  facet normal 0.0784638 -0.996917 0
+    outer loop
+      vertex -0.141162 1.49334 -5
+      vertex -0.0941849 1.49704 0
+      vertex -0.141162 1.49334 0
+    endloop
+  endfacet
+  facet normal 0.0784638 -0.996917 0
+    outer loop
+      vertex -0.0941849 1.49704 0
+      vertex -0.141162 1.49334 -5
+      vertex -0.0941849 1.49704 -5
+    endloop
+  endfacet
+  facet normal -0.98511 0.171926 0
+    outer loop
+      vertex 1.47343 -0.281072 -5
+      vertex 1.48153 -0.234652 0
+      vertex 1.48153 -0.234652 -5
+    endloop
+  endfacet
+  facet normal -0.98511 0.171926 0
+    outer loop
+      vertex 1.48153 -0.234652 0
+      vertex 1.47343 -0.281072 -5
+      vertex 1.47343 -0.281072 0
+    endloop
+  endfacet
+  facet normal -0.990024 0.1409 0
+    outer loop
+      vertex 1.48153 -0.234652 -5
+      vertex 1.48817 -0.188 0
+      vertex 1.48817 -0.188 -5
+    endloop
+  endfacet
+  facet normal -0.990024 0.1409 0
+    outer loop
+      vertex 1.48817 -0.188 0
+      vertex 1.48153 -0.234652 -5
+      vertex 1.48153 -0.234652 0
+    endloop
+  endfacet
+  facet normal 0.911397 0.411528 0
+    outer loop
+      vertex -1.35724 -0.638668 0
+      vertex -1.37663 -0.595721 -5
+      vertex -1.37663 -0.595721 0
+    endloop
+  endfacet
+  facet normal 0.911397 0.411528 0
+    outer loop
+      vertex -1.37663 -0.595721 -5
+      vertex -1.35724 -0.638668 0
+      vertex -1.35724 -0.638668 -5
+    endloop
+  endfacet
+  facet normal 0.835814 0.549013 0
+    outer loop
+      vertex -1.24062 -0.843124 0
+      vertex -1.26649 -0.80374 -5
+      vertex -1.26649 -0.80374 0
+    endloop
+  endfacet
+  facet normal 0.835814 0.549013 0
+    outer loop
+      vertex -1.26649 -0.80374 -5
+      vertex -1.24062 -0.843124 0
+      vertex -1.24062 -0.843124 -5
+    endloop
+  endfacet
+  facet normal 0.964559 0.263867 0
+    outer loop
+      vertex -1.44044 -0.418487 0
+      vertex -1.45287 -0.373034 -5
+      vertex -1.45287 -0.373034 0
+    endloop
+  endfacet
+  facet normal 0.964559 0.263867 0
+    outer loop
+      vertex -1.45287 -0.373034 -5
+      vertex -1.44044 -0.418487 0
+      vertex -1.44044 -0.418487 -5
+    endloop
+  endfacet
+  facet normal -0.993961 -0.109732 0
+    outer loop
+      vertex 1.49334 0.141162 -5
+      vertex 1.48817 0.188 0
+      vertex 1.48817 0.188 -5
+    endloop
+  endfacet
+  facet normal -0.993961 -0.109732 0
+    outer loop
+      vertex 1.48817 0.188 0
+      vertex 1.49334 0.141162 -5
+      vertex 1.49334 0.141162 0
+    endloop
+  endfacet
+  facet normal -0.99889 -0.0470949 0
+    outer loop
+      vertex 1.49926 0.0471153 -5
+      vertex 1.49704 0.0941849 0
+      vertex 1.49704 0.0941849 -5
+    endloop
+  endfacet
+  facet normal -0.99889 -0.0470949 0
+    outer loop
+      vertex 1.49704 0.0941849 0
+      vertex 1.49926 0.0471153 -5
+      vertex 1.49926 0.0471153 0
+    endloop
+  endfacet
+  facet normal -0.979222 -0.20279 0
+    outer loop
+      vertex 1.47343 0.281072 -5
+      vertex 1.46387 0.327214 0
+      vertex 1.46387 0.327214 -5
+    endloop
+  endfacet
+  facet normal -0.979222 -0.20279 0
+    outer loop
+      vertex 1.46387 0.327214 0
+      vertex 1.47343 0.281072 -5
+      vertex 1.47343 0.281072 0
+    endloop
+  endfacet
+  facet normal -0.93544 -0.353484 0
+    outer loop
+      vertex 1.41132 0.508106 -5
+      vertex 1.39466 0.552186 0
+      vertex 1.39466 0.552186 -5
+    endloop
+  endfacet
+  facet normal -0.93544 -0.353484 0
+    outer loop
+      vertex 1.39466 0.552186 0
+      vertex 1.41132 0.508106 -5
+      vertex 1.41132 0.508106 0
+    endloop
+  endfacet
+  facet normal -0.955791 -0.294047 0
+    outer loop
+      vertex 1.44044 0.418487 -5
+      vertex 1.42658 0.463525 0
+      vertex 1.42658 0.463525 -5
+    endloop
+  endfacet
+  facet normal -0.955791 -0.294047 0
+    outer loop
+      vertex 1.42658 0.463525 0
+      vertex 1.44044 0.418487 -5
+      vertex 1.44044 0.418487 0
+    endloop
+  endfacet
+  facet normal -0.71812 -0.695919 0
+    outer loop
+      vertex 1.09345 1.02682 -5
+      vertex 1.06066 1.06066 0
+      vertex 1.06066 1.06066 -5
+    endloop
+  endfacet
+  facet normal -0.71812 -0.695919 0
+    outer loop
+      vertex 1.06066 1.06066 0
+      vertex 1.09345 1.02682 -5
+      vertex 1.09345 1.02682 0
+    endloop
+  endfacet
+  facet normal -0.818148 -0.575007 0
+    outer loop
+      vertex 1.24062 0.843124 -5
+      vertex 1.21352 0.881678 0
+      vertex 1.21352 0.881678 -5
+    endloop
+  endfacet
+  facet normal -0.818148 -0.575007 0
+    outer loop
+      vertex 1.21352 0.881678 0
+      vertex 1.24062 0.843124 -5
+      vertex 1.24062 0.843124 0
+    endloop
+  endfacet
+  facet normal -0.868628 -0.495465 0
+    outer loop
+      vertex 1.31446 0.722631 -5
+      vertex 1.29111 0.763561 0
+      vertex 1.29111 0.763561 -5
+    endloop
+  endfacet
+  facet normal -0.868628 -0.495465 0
+    outer loop
+      vertex 1.29111 0.763561 0
+      vertex 1.31446 0.722631 -5
+      vertex 1.31446 0.722631 0
+    endloop
+  endfacet
+  facet normal -0.109732 -0.993961 0
+    outer loop
+      vertex 0.141162 1.49334 -5
+      vertex 0.188 1.48817 0
+      vertex 0.141162 1.49334 0
+    endloop
+  endfacet
+  facet normal -0.109732 -0.993961 -0
+    outer loop
+      vertex 0.188 1.48817 0
+      vertex 0.141162 1.49334 -5
+      vertex 0.188 1.48817 -5
+    endloop
+  endfacet
+  facet normal -0.353484 -0.93544 0
+    outer loop
+      vertex 0.508106 1.41132 -5
+      vertex 0.552186 1.39466 0
+      vertex 0.508106 1.41132 0
+    endloop
+  endfacet
+  facet normal -0.353484 -0.93544 -0
+    outer loop
+      vertex 0.552186 1.39466 0
+      vertex 0.508106 1.41132 -5
+      vertex 0.552186 1.39466 -5
+    endloop
+  endfacet
+  facet normal -0.294047 -0.955791 0
+    outer loop
+      vertex 0.418487 1.44044 -5
+      vertex 0.463525 1.42658 0
+      vertex 0.418487 1.44044 0
+    endloop
+  endfacet
+  facet normal -0.294047 -0.955791 -0
+    outer loop
+      vertex 0.463525 1.42658 0
+      vertex 0.418487 1.44044 -5
+      vertex 0.463525 1.42658 -5
+    endloop
+  endfacet
+  facet normal -0.171926 -0.98511 0
+    outer loop
+      vertex 0.234652 1.48153 -5
+      vertex 0.281072 1.47343 0
+      vertex 0.234652 1.48153 0
+    endloop
+  endfacet
+  facet normal -0.171926 -0.98511 -0
+    outer loop
+      vertex 0.281072 1.47343 0
+      vertex 0.234652 1.48153 -5
+      vertex 0.281072 1.47343 -5
+    endloop
+  endfacet
+  facet normal -0.0784638 -0.996917 0
+    outer loop
+      vertex 0.0941849 1.49704 -5
+      vertex 0.141162 1.49334 0
+      vertex 0.0941849 1.49704 0
+    endloop
+  endfacet
+  facet normal -0.0784638 -0.996917 -0
+    outer loop
+      vertex 0.141162 1.49334 0
+      vertex 0.0941849 1.49704 -5
+      vertex 0.141162 1.49334 -5
+    endloop
+  endfacet
+  facet normal -0.382669 -0.923886 0
+    outer loop
+      vertex 0.552186 1.39466 -5
+      vertex 0.595721 1.37663 0
+      vertex 0.552186 1.39466 0
+    endloop
+  endfacet
+  facet normal -0.382669 -0.923886 -0
+    outer loop
+      vertex 0.595721 1.37663 0
+      vertex 0.552186 1.39466 -5
+      vertex 0.595721 1.37663 -5
+    endloop
+  endfacet
+  facet normal -0.522509 -0.852634 0
+    outer loop
+      vertex 0.763561 1.29111 -5
+      vertex 0.80374 1.26649 0
+      vertex 0.763561 1.29111 0
+    endloop
+  endfacet
+  facet normal -0.522509 -0.852634 -0
+    outer loop
+      vertex 0.80374 1.26649 0
+      vertex 0.763561 1.29111 -5
+      vertex 0.80374 1.26649 -5
+    endloop
+  endfacet
+  facet normal -0.549013 -0.835814 0
+    outer loop
+      vertex 0.80374 1.26649 -5
+      vertex 0.843124 1.24062 0
+      vertex 0.80374 1.26649 0
+    endloop
+  endfacet
+  facet normal -0.549013 -0.835814 -0
+    outer loop
+      vertex 0.843124 1.24062 0
+      vertex 0.80374 1.26649 -5
+      vertex 0.843124 1.24062 -5
+    endloop
+  endfacet
+  facet normal 0.993961 -0.109732 0
+    outer loop
+      vertex -1.49334 0.141162 0
+      vertex -1.48817 0.188 -5
+      vertex -1.48817 0.188 0
+    endloop
+  endfacet
+  facet normal 0.993961 -0.109732 0
+    outer loop
+      vertex -1.48817 0.188 -5
+      vertex -1.49334 0.141162 0
+      vertex -1.49334 0.141162 -5
+    endloop
+  endfacet
+  facet normal 0.71812 -0.695919 0
+    outer loop
+      vertex -1.09345 1.02682 0
+      vertex -1.06066 1.06066 -5
+      vertex -1.06066 1.06066 0
+    endloop
+  endfacet
+  facet normal 0.71812 -0.695919 0
+    outer loop
+      vertex -1.06066 1.06066 -5
+      vertex -1.09345 1.02682 0
+      vertex -1.09345 1.02682 -5
+    endloop
+  endfacet
+  facet normal 0.868628 -0.495465 0
+    outer loop
+      vertex -1.31446 0.722631 0
+      vertex -1.29111 0.763561 -5
+      vertex -1.29111 0.763561 0
+    endloop
+  endfacet
+  facet normal 0.868628 -0.495465 0
+    outer loop
+      vertex -1.29111 0.763561 -5
+      vertex -1.31446 0.722631 0
+      vertex -1.31446 0.722631 -5
+    endloop
+  endfacet
+  facet normal 0.898036 -0.439921 0
+    outer loop
+      vertex -1.35724 0.638668 0
+      vertex -1.33651 0.680985 -5
+      vertex -1.33651 0.680985 0
+    endloop
+  endfacet
+  facet normal 0.898036 -0.439921 0
+    outer loop
+      vertex -1.33651 0.680985 -5
+      vertex -1.35724 0.638668 0
+      vertex -1.35724 0.638668 -5
+    endloop
+  endfacet
+  facet normal 0.955791 -0.294047 0
+    outer loop
+      vertex -1.44044 0.418487 0
+      vertex -1.42658 0.463525 -5
+      vertex -1.42658 0.463525 0
+    endloop
+  endfacet
+  facet normal 0.955791 -0.294047 0
+    outer loop
+      vertex -1.42658 0.463525 -5
+      vertex -1.44044 0.418487 0
+      vertex -1.44044 0.418487 -5
+    endloop
+  endfacet
+  facet normal 0.98511 -0.171926 0
+    outer loop
+      vertex -1.48153 0.234652 0
+      vertex -1.47343 0.281072 -5
+      vertex -1.47343 0.281072 0
+    endloop
+  endfacet
+  facet normal 0.98511 -0.171926 0
+    outer loop
+      vertex -1.47343 0.281072 -5
+      vertex -1.48153 0.234652 0
+      vertex -1.48153 0.234652 -5
+    endloop
+  endfacet
+  facet normal 0.996917 -0.0784638 0
+    outer loop
+      vertex -1.49704 0.0941849 0
+      vertex -1.49334 0.141162 -5
+      vertex -1.49334 0.141162 0
+    endloop
+  endfacet
+  facet normal 0.996917 -0.0784638 0
+    outer loop
+      vertex -1.49334 0.141162 -5
+      vertex -1.49704 0.0941849 0
+      vertex -1.49704 0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0.46793 -0.883766 0
+    outer loop
+      vertex -0.722631 1.31446 -5
+      vertex -0.680985 1.33651 0
+      vertex -0.722631 1.31446 0
+    endloop
+  endfacet
+  facet normal 0.46793 -0.883766 0
+    outer loop
+      vertex -0.680985 1.33651 0
+      vertex -0.722631 1.31446 -5
+      vertex -0.680985 1.33651 -5
+    endloop
+  endfacet
+  facet normal 0.575007 -0.818148 0
+    outer loop
+      vertex -0.881678 1.21352 -5
+      vertex -0.843124 1.24062 0
+      vertex -0.881678 1.21352 0
+    endloop
+  endfacet
+  facet normal 0.575007 -0.818148 0
+    outer loop
+      vertex -0.843124 1.24062 0
+      vertex -0.881678 1.21352 -5
+      vertex -0.843124 1.24062 -5
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex -0.327214 1.46387 -5
+      vertex -0.281072 1.47343 0
+      vertex -0.327214 1.46387 0
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex -0.281072 1.47343 0
+      vertex -0.327214 1.46387 -5
+      vertex -0.281072 1.47343 -5
+    endloop
+  endfacet
+  facet normal 0.263867 -0.964559 0
+    outer loop
+      vertex -0.418487 1.44044 -5
+      vertex -0.373034 1.45287 0
+      vertex -0.418487 1.44044 0
+    endloop
+  endfacet
+  facet normal 0.263867 -0.964559 0
+    outer loop
+      vertex -0.373034 1.45287 0
+      vertex -0.418487 1.44044 -5
+      vertex -0.373034 1.45287 -5
+    endloop
+  endfacet
+  facet normal 0.0470949 -0.99889 0
+    outer loop
+      vertex -0.0941849 1.49704 -5
+      vertex -0.0471153 1.49926 0
+      vertex -0.0941849 1.49704 0
+    endloop
+  endfacet
+  facet normal 0.0470949 -0.99889 0
+    outer loop
+      vertex -0.0471153 1.49926 0
+      vertex -0.0941849 1.49704 -5
+      vertex -0.0471153 1.49926 -5
+    endloop
+  endfacet
+  facet normal -0.996917 0.0784638 0
+    outer loop
+      vertex 1.49334 -0.141162 -5
+      vertex 1.49704 -0.0941849 0
+      vertex 1.49704 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal -0.996917 0.0784638 0
+    outer loop
+      vertex 1.49704 -0.0941849 0
+      vertex 1.49334 -0.141162 -5
+      vertex 1.49334 -0.141162 0
+    endloop
+  endfacet
+  facet normal -0.109732 0.993961 0
+    outer loop
+      vertex 0.188 -1.48817 -5
+      vertex 0.141162 -1.49334 0
+      vertex 0.188 -1.48817 0
+    endloop
+  endfacet
+  facet normal -0.109732 0.993961 0
+    outer loop
+      vertex 0.141162 -1.49334 0
+      vertex 0.188 -1.48817 -5
+      vertex 0.141162 -1.49334 -5
+    endloop
+  endfacet
+  facet normal -0.353484 0.93544 0
+    outer loop
+      vertex 0.552186 -1.39466 -5
+      vertex 0.508106 -1.41132 0
+      vertex 0.552186 -1.39466 0
+    endloop
+  endfacet
+  facet normal -0.353484 0.93544 0
+    outer loop
+      vertex 0.508106 -1.41132 0
+      vertex 0.552186 -1.39466 -5
+      vertex 0.508106 -1.41132 -5
+    endloop
+  endfacet
+  facet normal -0.695919 0.71812 0
+    outer loop
+      vertex 1.06066 -1.06066 -5
+      vertex 1.02682 -1.09345 0
+      vertex 1.06066 -1.06066 0
+    endloop
+  endfacet
+  facet normal -0.695919 0.71812 0
+    outer loop
+      vertex 1.02682 -1.09345 0
+      vertex 1.06066 -1.06066 -5
+      vertex 1.02682 -1.09345 -5
+    endloop
+  endfacet
+  facet normal -0.575007 0.818148 0
+    outer loop
+      vertex 0.881678 -1.21352 -5
+      vertex 0.843124 -1.24062 0
+      vertex 0.881678 -1.21352 0
+    endloop
+  endfacet
+  facet normal -0.575007 0.818148 0
+    outer loop
+      vertex 0.843124 -1.24062 0
+      vertex 0.881678 -1.21352 -5
+      vertex 0.843124 -1.24062 -5
+    endloop
+  endfacet
+  facet normal -0.495465 0.868628 0
+    outer loop
+      vertex 0.763561 -1.29111 -5
+      vertex 0.722631 -1.31446 0
+      vertex 0.763561 -1.29111 0
+    endloop
+  endfacet
+  facet normal -0.495465 0.868628 0
+    outer loop
+      vertex 0.722631 -1.31446 0
+      vertex 0.763561 -1.29111 -5
+      vertex 0.722631 -1.31446 -5
+    endloop
+  endfacet
+  facet normal -0.799687 0.600418 0
+    outer loop
+      vertex 1.18523 -0.91936 -5
+      vertex 1.21352 -0.881678 0
+      vertex 1.21352 -0.881678 -5
+    endloop
+  endfacet
+  facet normal -0.799687 0.600418 0
+    outer loop
+      vertex 1.21352 -0.881678 0
+      vertex 1.18523 -0.91936 -5
+      vertex 1.18523 -0.91936 0
+    endloop
+  endfacet
+  facet normal -0.911397 0.411528 0
+    outer loop
+      vertex 1.35724 -0.638668 -5
+      vertex 1.37663 -0.595721 0
+      vertex 1.37663 -0.595721 -5
+    endloop
+  endfacet
+  facet normal -0.911397 0.411528 0
+    outer loop
+      vertex 1.37663 -0.595721 0
+      vertex 1.35724 -0.638668 -5
+      vertex 1.35724 -0.638668 0
+    endloop
+  endfacet
+  facet normal 0.695919 0.71812 -0
+    outer loop
+      vertex -1.02682 -1.09345 -5
+      vertex -1.06066 -1.06066 0
+      vertex -1.02682 -1.09345 0
+    endloop
+  endfacet
+  facet normal 0.695919 0.71812 0
+    outer loop
+      vertex -1.06066 -1.06066 0
+      vertex -1.02682 -1.09345 -5
+      vertex -1.06066 -1.06066 -5
+    endloop
+  endfacet
+  facet normal 0.625243 0.78043 -0
+    outer loop
+      vertex -0.91936 -1.18523 -5
+      vertex -0.956136 -1.15577 0
+      vertex -0.91936 -1.18523 0
+    endloop
+  endfacet
+  facet normal 0.625243 0.78043 0
+    outer loop
+      vertex -0.956136 -1.15577 0
+      vertex -0.91936 -1.18523 -5
+      vertex -0.956136 -1.15577 -5
+    endloop
+  endfacet
+  facet normal 0.46793 0.883766 -0
+    outer loop
+      vertex -0.680985 -1.33651 -5
+      vertex -0.722631 -1.31446 0
+      vertex -0.680985 -1.33651 0
+    endloop
+  endfacet
+  facet normal 0.46793 0.883766 0
+    outer loop
+      vertex -0.722631 -1.31446 0
+      vertex -0.680985 -1.33651 -5
+      vertex -0.722631 -1.31446 -5
+    endloop
+  endfacet
+  facet normal 0.171926 0.98511 -0
+    outer loop
+      vertex -0.234652 -1.48153 -5
+      vertex -0.281072 -1.47343 0
+      vertex -0.234652 -1.48153 0
+    endloop
+  endfacet
+  facet normal 0.171926 0.98511 0
+    outer loop
+      vertex -0.281072 -1.47343 0
+      vertex -0.234652 -1.48153 -5
+      vertex -0.281072 -1.47343 -5
+    endloop
+  endfacet
+  facet normal 0.0784638 0.996917 -0
+    outer loop
+      vertex -0.0941849 -1.49704 -5
+      vertex -0.141162 -1.49334 0
+      vertex -0.0941849 -1.49704 0
+    endloop
+  endfacet
+  facet normal 0.0784638 0.996917 0
+    outer loop
+      vertex -0.141162 -1.49334 0
+      vertex -0.0941849 -1.49704 -5
+      vertex -0.141162 -1.49334 -5
+    endloop
+  endfacet
+  facet normal 0.868628 0.495465 0
+    outer loop
+      vertex -1.29111 -0.763561 0
+      vertex -1.31446 -0.722631 -5
+      vertex -1.31446 -0.722631 0
+    endloop
+  endfacet
+  facet normal 0.868628 0.495465 0
+    outer loop
+      vertex -1.31446 -0.722631 -5
+      vertex -1.29111 -0.763561 0
+      vertex -1.29111 -0.763561 -5
+    endloop
+  endfacet
+  facet normal 0.979222 0.20279 0
+    outer loop
+      vertex -1.46387 -0.327214 0
+      vertex -1.47343 -0.281072 -5
+      vertex -1.47343 -0.281072 0
+    endloop
+  endfacet
+  facet normal 0.979222 0.20279 0
+    outer loop
+      vertex -1.47343 -0.281072 -5
+      vertex -1.46387 -0.327214 0
+      vertex -1.46387 -0.327214 -5
+    endloop
+  endfacet
+  facet normal 0.955791 0.294047 0
+    outer loop
+      vertex -1.42658 -0.463525 0
+      vertex -1.44044 -0.418487 -5
+      vertex -1.44044 -0.418487 0
+    endloop
+  endfacet
+  facet normal 0.955791 0.294047 0
+    outer loop
+      vertex -1.44044 -0.418487 -5
+      vertex -1.42658 -0.463525 0
+      vertex -1.42658 -0.463525 -5
+    endloop
+  endfacet
+  facet normal 0.993961 0.109732 0
+    outer loop
+      vertex -1.48817 -0.188 0
+      vertex -1.49334 -0.141162 -5
+      vertex -1.49334 -0.141162 0
+    endloop
+  endfacet
+  facet normal 0.993961 0.109732 0
+    outer loop
+      vertex -1.49334 -0.141162 -5
+      vertex -1.48817 -0.188 0
+      vertex -1.48817 -0.188 -5
+    endloop
+  endfacet
+  facet normal -0.996917 -0.0784638 0
+    outer loop
+      vertex 1.49704 0.0941849 -5
+      vertex 1.49334 0.141162 0
+      vertex 1.49334 0.141162 -5
+    endloop
+  endfacet
+  facet normal -0.996917 -0.0784638 0
+    outer loop
+      vertex 1.49334 0.141162 0
+      vertex 1.49704 0.0941849 -5
+      vertex 1.49704 0.0941849 0
+    endloop
+  endfacet
+  facet normal -0.98511 -0.171926 0
+    outer loop
+      vertex 1.48153 0.234652 -5
+      vertex 1.47343 0.281072 0
+      vertex 1.47343 0.281072 -5
+    endloop
+  endfacet
+  facet normal -0.98511 -0.171926 0
+    outer loop
+      vertex 1.47343 0.281072 0
+      vertex 1.48153 0.234652 -5
+      vertex 1.48153 0.234652 0
+    endloop
+  endfacet
+  facet normal -0.990024 -0.1409 0
+    outer loop
+      vertex 1.48817 0.188 -5
+      vertex 1.48153 0.234652 0
+      vertex 1.48153 0.234652 -5
+    endloop
+  endfacet
+  facet normal -0.990024 -0.1409 0
+    outer loop
+      vertex 1.48153 0.234652 0
+      vertex 1.48817 0.188 -5
+      vertex 1.48817 0.188 0
+    endloop
+  endfacet
+  facet normal -0.946086 -0.323916 0
+    outer loop
+      vertex 1.42658 0.463525 -5
+      vertex 1.41132 0.508106 0
+      vertex 1.41132 0.508106 -5
+    endloop
+  endfacet
+  facet normal -0.946086 -0.323916 0
+    outer loop
+      vertex 1.41132 0.508106 0
+      vertex 1.42658 0.463525 -5
+      vertex 1.42658 0.463525 0
+    endloop
+  endfacet
+  facet normal -0.964559 -0.263867 0
+    outer loop
+      vertex 1.45287 0.373034 -5
+      vertex 1.44044 0.418487 0
+      vertex 1.44044 0.418487 -5
+    endloop
+  endfacet
+  facet normal -0.964559 -0.263867 0
+    outer loop
+      vertex 1.44044 0.418487 0
+      vertex 1.45287 0.373034 -5
+      vertex 1.45287 0.373034 0
+    endloop
+  endfacet
+  facet normal -0.760401 -0.649454 0
+    outer loop
+      vertex 1.15577 0.956136 -5
+      vertex 1.12517 0.991967 0
+      vertex 1.12517 0.991967 -5
+    endloop
+  endfacet
+  facet normal -0.760401 -0.649454 0
+    outer loop
+      vertex 1.12517 0.991967 0
+      vertex 1.15577 0.956136 -5
+      vertex 1.15577 0.956136 0
+    endloop
+  endfacet
+  facet normal -0.739634 -0.673009 0
+    outer loop
+      vertex 1.12517 0.991967 -5
+      vertex 1.09345 1.02682 0
+      vertex 1.09345 1.02682 -5
+    endloop
+  endfacet
+  facet normal -0.739634 -0.673009 0
+    outer loop
+      vertex 1.09345 1.02682 0
+      vertex 1.12517 0.991967 -5
+      vertex 1.12517 0.991967 0
+    endloop
+  endfacet
+  facet normal -0.799687 -0.600418 0
+    outer loop
+      vertex 1.21352 0.881678 -5
+      vertex 1.18523 0.91936 0
+      vertex 1.18523 0.91936 -5
+    endloop
+  endfacet
+  facet normal -0.799687 -0.600418 0
+    outer loop
+      vertex 1.18523 0.91936 0
+      vertex 1.21352 0.881678 -5
+      vertex 1.21352 0.881678 0
+    endloop
+  endfacet
+  facet normal -0.835814 -0.549013 0
+    outer loop
+      vertex 1.26649 0.80374 -5
+      vertex 1.24062 0.843124 0
+      vertex 1.24062 0.843124 -5
+    endloop
+  endfacet
+  facet normal -0.835814 -0.549013 0
+    outer loop
+      vertex 1.24062 0.843124 0
+      vertex 1.26649 0.80374 -5
+      vertex 1.26649 0.80374 0
+    endloop
+  endfacet
+  facet normal -0.852634 -0.522509 0
+    outer loop
+      vertex 1.29111 0.763561 -5
+      vertex 1.26649 0.80374 0
+      vertex 1.26649 0.80374 -5
+    endloop
+  endfacet
+  facet normal -0.852634 -0.522509 0
+    outer loop
+      vertex 1.26649 0.80374 0
+      vertex 1.29111 0.763561 -5
+      vertex 1.29111 0.763561 0
+    endloop
+  endfacet
+  facet normal -0.898036 -0.439921 0
+    outer loop
+      vertex 1.35724 0.638668 -5
+      vertex 1.33651 0.680985 0
+      vertex 1.33651 0.680985 -5
+    endloop
+  endfacet
+  facet normal -0.898036 -0.439921 0
+    outer loop
+      vertex 1.33651 0.680985 0
+      vertex 1.35724 0.638668 -5
+      vertex 1.35724 0.638668 0
+    endloop
+  endfacet
+  facet normal -0.911397 -0.411528 0
+    outer loop
+      vertex 1.37663 0.595721 -5
+      vertex 1.35724 0.638668 0
+      vertex 1.35724 0.638668 -5
+    endloop
+  endfacet
+  facet normal -0.911397 -0.411528 0
+    outer loop
+      vertex 1.35724 0.638668 0
+      vertex 1.37663 0.595721 -5
+      vertex 1.37663 0.595721 0
+    endloop
+  endfacet
+  facet normal -0.323916 -0.946086 0
+    outer loop
+      vertex 0.463525 1.42658 -5
+      vertex 0.508106 1.41132 0
+      vertex 0.463525 1.42658 0
+    endloop
+  endfacet
+  facet normal -0.323916 -0.946086 -0
+    outer loop
+      vertex 0.508106 1.41132 0
+      vertex 0.463525 1.42658 -5
+      vertex 0.508106 1.41132 -5
+    endloop
+  endfacet
+  facet normal -0.233449 -0.972369 0
+    outer loop
+      vertex 0.327214 1.46387 -5
+      vertex 0.373034 1.45287 0
+      vertex 0.327214 1.46387 0
+    endloop
+  endfacet
+  facet normal -0.233449 -0.972369 -0
+    outer loop
+      vertex 0.373034 1.45287 0
+      vertex 0.327214 1.46387 -5
+      vertex 0.373034 1.45287 -5
+    endloop
+  endfacet
+  facet normal -0.263867 -0.964559 0
+    outer loop
+      vertex 0.373034 1.45287 -5
+      vertex 0.418487 1.44044 0
+      vertex 0.373034 1.45287 0
+    endloop
+  endfacet
+  facet normal -0.263867 -0.964559 -0
+    outer loop
+      vertex 0.418487 1.44044 0
+      vertex 0.373034 1.45287 -5
+      vertex 0.418487 1.44044 -5
+    endloop
+  endfacet
+  facet normal -0.1409 -0.990024 0
+    outer loop
+      vertex 0.188 1.48817 -5
+      vertex 0.234652 1.48153 0
+      vertex 0.188 1.48817 0
+    endloop
+  endfacet
+  facet normal -0.1409 -0.990024 -0
+    outer loop
+      vertex 0.234652 1.48153 0
+      vertex 0.188 1.48817 -5
+      vertex 0.234652 1.48153 -5
+    endloop
+  endfacet
+  facet normal -0.0470949 -0.99889 0
+    outer loop
+      vertex 0.0471153 1.49926 -5
+      vertex 0.0941849 1.49704 0
+      vertex 0.0471153 1.49926 0
+    endloop
+  endfacet
+  facet normal -0.0470949 -0.99889 -0
+    outer loop
+      vertex 0.0941849 1.49704 0
+      vertex 0.0471153 1.49926 -5
+      vertex 0.0941849 1.49704 -5
+    endloop
+  endfacet
+  facet normal -0.439921 -0.898036 0
+    outer loop
+      vertex 0.638668 1.35724 -5
+      vertex 0.680985 1.33651 0
+      vertex 0.638668 1.35724 0
+    endloop
+  endfacet
+  facet normal -0.439921 -0.898036 -0
+    outer loop
+      vertex 0.680985 1.33651 0
+      vertex 0.638668 1.35724 -5
+      vertex 0.680985 1.33651 -5
+    endloop
+  endfacet
+  facet normal -0.411528 -0.911397 0
+    outer loop
+      vertex 0.595721 1.37663 -5
+      vertex 0.638668 1.35724 0
+      vertex 0.595721 1.37663 0
+    endloop
+  endfacet
+  facet normal -0.411528 -0.911397 -0
+    outer loop
+      vertex 0.638668 1.35724 0
+      vertex 0.595721 1.37663 -5
+      vertex 0.638668 1.35724 -5
+    endloop
+  endfacet
+  facet normal -0.495465 -0.868628 0
+    outer loop
+      vertex 0.722631 1.31446 -5
+      vertex 0.763561 1.29111 0
+      vertex 0.722631 1.31446 0
+    endloop
+  endfacet
+  facet normal -0.495465 -0.868628 -0
+    outer loop
+      vertex 0.763561 1.29111 0
+      vertex 0.722631 1.31446 -5
+      vertex 0.763561 1.29111 -5
+    endloop
+  endfacet
+  facet normal -0.600418 -0.799687 0
+    outer loop
+      vertex 0.881678 1.21352 -5
+      vertex 0.91936 1.18523 0
+      vertex 0.881678 1.21352 0
+    endloop
+  endfacet
+  facet normal -0.600418 -0.799687 -0
+    outer loop
+      vertex 0.91936 1.18523 0
+      vertex 0.881678 1.21352 -5
+      vertex 0.91936 1.18523 -5
+    endloop
+  endfacet
+  facet normal -0.575007 -0.818148 0
+    outer loop
+      vertex 0.843124 1.24062 -5
+      vertex 0.881678 1.21352 0
+      vertex 0.843124 1.24062 0
+    endloop
+  endfacet
+  facet normal -0.575007 -0.818148 -0
+    outer loop
+      vertex 0.881678 1.21352 0
+      vertex 0.843124 1.24062 -5
+      vertex 0.881678 1.21352 -5
+    endloop
+  endfacet
+  facet normal -0.649454 -0.760401 0
+    outer loop
+      vertex 0.956136 1.15577 -5
+      vertex 0.991967 1.12517 0
+      vertex 0.956136 1.15577 0
+    endloop
+  endfacet
+  facet normal -0.649454 -0.760401 -0
+    outer loop
+      vertex 0.991967 1.12517 0
+      vertex 0.956136 1.15577 -5
+      vertex 0.991967 1.12517 -5
+    endloop
+  endfacet
+  facet normal -0.673009 -0.739634 0
+    outer loop
+      vertex 0.991967 1.12517 -5
+      vertex 1.02682 1.09345 0
+      vertex 0.991967 1.12517 0
+    endloop
+  endfacet
+  facet normal -0.673009 -0.739634 -0
+    outer loop
+      vertex 1.02682 1.09345 0
+      vertex 0.991967 1.12517 -5
+      vertex 1.02682 1.09345 -5
+    endloop
+  endfacet
+  facet normal 0.78043 -0.625243 0
+    outer loop
+      vertex -1.18523 0.91936 0
+      vertex -1.15577 0.956136 -5
+      vertex -1.15577 0.956136 0
+    endloop
+  endfacet
+  facet normal 0.78043 -0.625243 0
+    outer loop
+      vertex -1.15577 0.956136 -5
+      vertex -1.18523 0.91936 0
+      vertex -1.18523 0.91936 -5
+    endloop
+  endfacet
+  facet normal 0.818148 -0.575007 0
+    outer loop
+      vertex -1.24062 0.843124 0
+      vertex -1.21352 0.881678 -5
+      vertex -1.21352 0.881678 0
+    endloop
+  endfacet
+  facet normal 0.818148 -0.575007 0
+    outer loop
+      vertex -1.21352 0.881678 -5
+      vertex -1.24062 0.843124 0
+      vertex -1.24062 0.843124 -5
+    endloop
+  endfacet
+  facet normal 0.760401 -0.649454 0
+    outer loop
+      vertex -1.15577 0.956136 0
+      vertex -1.12517 0.991967 -5
+      vertex -1.12517 0.991967 0
+    endloop
+  endfacet
+  facet normal 0.760401 -0.649454 0
+    outer loop
+      vertex -1.12517 0.991967 -5
+      vertex -1.15577 0.956136 0
+      vertex -1.15577 0.956136 -5
+    endloop
+  endfacet
+  facet normal 0.852634 -0.522509 0
+    outer loop
+      vertex -1.29111 0.763561 0
+      vertex -1.26649 0.80374 -5
+      vertex -1.26649 0.80374 0
+    endloop
+  endfacet
+  facet normal 0.852634 -0.522509 0
+    outer loop
+      vertex -1.26649 0.80374 -5
+      vertex -1.29111 0.763561 0
+      vertex -1.29111 0.763561 -5
+    endloop
+  endfacet
+  facet normal 0.911397 -0.411528 0
+    outer loop
+      vertex -1.37663 0.595721 0
+      vertex -1.35724 0.638668 -5
+      vertex -1.35724 0.638668 0
+    endloop
+  endfacet
+  facet normal 0.911397 -0.411528 0
+    outer loop
+      vertex -1.35724 0.638668 -5
+      vertex -1.37663 0.595721 0
+      vertex -1.37663 0.595721 -5
+    endloop
+  endfacet
+  facet normal 0.883766 -0.46793 0
+    outer loop
+      vertex -1.33651 0.680985 0
+      vertex -1.31446 0.722631 -5
+      vertex -1.31446 0.722631 0
+    endloop
+  endfacet
+  facet normal 0.883766 -0.46793 0
+    outer loop
+      vertex -1.31446 0.722631 -5
+      vertex -1.33651 0.680985 0
+      vertex -1.33651 0.680985 -5
+    endloop
+  endfacet
+  facet normal 0.923886 -0.382669 0
+    outer loop
+      vertex -1.39466 0.552186 0
+      vertex -1.37663 0.595721 -5
+      vertex -1.37663 0.595721 0
+    endloop
+  endfacet
+  facet normal 0.923886 -0.382669 0
+    outer loop
+      vertex -1.37663 0.595721 -5
+      vertex -1.39466 0.552186 0
+      vertex -1.39466 0.552186 -5
+    endloop
+  endfacet
+  facet normal 0.93544 -0.353484 0
+    outer loop
+      vertex -1.41132 0.508106 0
+      vertex -1.39466 0.552186 -5
+      vertex -1.39466 0.552186 0
+    endloop
+  endfacet
+  facet normal 0.93544 -0.353484 0
+    outer loop
+      vertex -1.39466 0.552186 -5
+      vertex -1.41132 0.508106 0
+      vertex -1.41132 0.508106 -5
+    endloop
+  endfacet
+  facet normal 0.946086 -0.323916 0
+    outer loop
+      vertex -1.42658 0.463525 0
+      vertex -1.41132 0.508106 -5
+      vertex -1.41132 0.508106 0
+    endloop
+  endfacet
+  facet normal 0.946086 -0.323916 0
+    outer loop
+      vertex -1.41132 0.508106 -5
+      vertex -1.42658 0.463525 0
+      vertex -1.42658 0.463525 -5
+    endloop
+  endfacet
+  facet normal 0.972369 -0.233449 0
+    outer loop
+      vertex -1.46387 0.327214 0
+      vertex -1.45287 0.373034 -5
+      vertex -1.45287 0.373034 0
+    endloop
+  endfacet
+  facet normal 0.972369 -0.233449 0
+    outer loop
+      vertex -1.45287 0.373034 -5
+      vertex -1.46387 0.327214 0
+      vertex -1.46387 0.327214 -5
+    endloop
+  endfacet
+  facet normal 0.964559 -0.263867 0
+    outer loop
+      vertex -1.45287 0.373034 0
+      vertex -1.44044 0.418487 -5
+      vertex -1.44044 0.418487 0
+    endloop
+  endfacet
+  facet normal 0.964559 -0.263867 0
+    outer loop
+      vertex -1.44044 0.418487 -5
+      vertex -1.45287 0.373034 0
+      vertex -1.45287 0.373034 -5
+    endloop
+  endfacet
+  facet normal 0.990024 -0.1409 0
+    outer loop
+      vertex -1.48817 0.188 0
+      vertex -1.48153 0.234652 -5
+      vertex -1.48153 0.234652 0
+    endloop
+  endfacet
+  facet normal 0.990024 -0.1409 0
+    outer loop
+      vertex -1.48153 0.234652 -5
+      vertex -1.48817 0.188 0
+      vertex -1.48817 0.188 -5
+    endloop
+  endfacet
+  facet normal 0.99889 -0.0470949 0
+    outer loop
+      vertex -1.49926 0.0471153 0
+      vertex -1.49704 0.0941849 -5
+      vertex -1.49704 0.0941849 0
+    endloop
+  endfacet
+  facet normal 0.99889 -0.0470949 0
+    outer loop
+      vertex -1.49704 0.0941849 -5
+      vertex -1.49926 0.0471153 0
+      vertex -1.49926 0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0.411528 -0.911397 0
+    outer loop
+      vertex -0.638668 1.35724 -5
+      vertex -0.595721 1.37663 0
+      vertex -0.638668 1.35724 0
+    endloop
+  endfacet
+  facet normal 0.411528 -0.911397 0
+    outer loop
+      vertex -0.595721 1.37663 0
+      vertex -0.638668 1.35724 -5
+      vertex -0.595721 1.37663 -5
+    endloop
+  endfacet
+  facet normal 0.649454 -0.760401 0
+    outer loop
+      vertex -0.991967 1.12517 -5
+      vertex -0.956136 1.15577 0
+      vertex -0.991967 1.12517 0
+    endloop
+  endfacet
+  facet normal 0.649454 -0.760401 0
+    outer loop
+      vertex -0.956136 1.15577 0
+      vertex -0.991967 1.12517 -5
+      vertex -0.956136 1.15577 -5
+    endloop
+  endfacet
+  facet normal 0.673009 -0.739634 0
+    outer loop
+      vertex -1.02682 1.09345 -5
+      vertex -0.991967 1.12517 0
+      vertex -1.02682 1.09345 0
+    endloop
+  endfacet
+  facet normal 0.673009 -0.739634 0
+    outer loop
+      vertex -0.991967 1.12517 0
+      vertex -1.02682 1.09345 -5
+      vertex -0.991967 1.12517 -5
+    endloop
+  endfacet
+  facet normal 0.439921 -0.898036 0
+    outer loop
+      vertex -0.680985 1.33651 -5
+      vertex -0.638668 1.35724 0
+      vertex -0.680985 1.33651 0
+    endloop
+  endfacet
+  facet normal 0.439921 -0.898036 0
+    outer loop
+      vertex -0.638668 1.35724 0
+      vertex -0.680985 1.33651 -5
+      vertex -0.638668 1.35724 -5
+    endloop
+  endfacet
+  facet normal 0.549013 -0.835814 0
+    outer loop
+      vertex -0.843124 1.24062 -5
+      vertex -0.80374 1.26649 0
+      vertex -0.843124 1.24062 0
+    endloop
+  endfacet
+  facet normal 0.549013 -0.835814 0
+    outer loop
+      vertex -0.80374 1.26649 0
+      vertex -0.843124 1.24062 -5
+      vertex -0.80374 1.26649 -5
+    endloop
+  endfacet
+  facet normal 0.522509 -0.852634 0
+    outer loop
+      vertex -0.80374 1.26649 -5
+      vertex -0.763561 1.29111 0
+      vertex -0.80374 1.26649 0
+    endloop
+  endfacet
+  facet normal 0.522509 -0.852634 0
+    outer loop
+      vertex -0.763561 1.29111 0
+      vertex -0.80374 1.26649 -5
+      vertex -0.763561 1.29111 -5
+    endloop
+  endfacet
+  facet normal 0.600418 -0.799687 0
+    outer loop
+      vertex -0.91936 1.18523 -5
+      vertex -0.881678 1.21352 0
+      vertex -0.91936 1.18523 0
+    endloop
+  endfacet
+  facet normal 0.600418 -0.799687 0
+    outer loop
+      vertex -0.881678 1.21352 0
+      vertex -0.91936 1.18523 -5
+      vertex -0.881678 1.21352 -5
+    endloop
+  endfacet
+  facet normal 0.382669 -0.923886 0
+    outer loop
+      vertex -0.595721 1.37663 -5
+      vertex -0.552186 1.39466 0
+      vertex -0.595721 1.37663 0
+    endloop
+  endfacet
+  facet normal 0.382669 -0.923886 0
+    outer loop
+      vertex -0.552186 1.39466 0
+      vertex -0.595721 1.37663 -5
+      vertex -0.552186 1.39466 -5
+    endloop
+  endfacet
+  facet normal 0.294047 -0.955791 0
+    outer loop
+      vertex -0.463525 1.42658 -5
+      vertex -0.418487 1.44044 0
+      vertex -0.463525 1.42658 0
+    endloop
+  endfacet
+  facet normal 0.294047 -0.955791 0
+    outer loop
+      vertex -0.418487 1.44044 0
+      vertex -0.463525 1.42658 -5
+      vertex -0.418487 1.44044 -5
+    endloop
+  endfacet
+  facet normal 0.323916 -0.946086 0
+    outer loop
+      vertex -0.508106 1.41132 -5
+      vertex -0.463525 1.42658 0
+      vertex -0.508106 1.41132 0
+    endloop
+  endfacet
+  facet normal 0.323916 -0.946086 0
+    outer loop
+      vertex -0.463525 1.42658 0
+      vertex -0.508106 1.41132 -5
+      vertex -0.463525 1.42658 -5
+    endloop
+  endfacet
+  facet normal 0.233449 -0.972369 0
+    outer loop
+      vertex -0.373034 1.45287 -5
+      vertex -0.327214 1.46387 0
+      vertex -0.373034 1.45287 0
+    endloop
+  endfacet
+  facet normal 0.233449 -0.972369 0
+    outer loop
+      vertex -0.327214 1.46387 0
+      vertex -0.373034 1.45287 -5
+      vertex -0.327214 1.46387 -5
+    endloop
+  endfacet
+  facet normal 0.171926 -0.98511 0
+    outer loop
+      vertex -0.281072 1.47343 -5
+      vertex -0.234652 1.48153 0
+      vertex -0.281072 1.47343 0
+    endloop
+  endfacet
+  facet normal 0.171926 -0.98511 0
+    outer loop
+      vertex -0.234652 1.48153 0
+      vertex -0.281072 1.47343 -5
+      vertex -0.234652 1.48153 -5
+    endloop
+  endfacet
+  facet normal 0.1409 -0.990024 0
+    outer loop
+      vertex -0.234652 1.48153 -5
+      vertex -0.188 1.48817 0
+      vertex -0.234652 1.48153 0
+    endloop
+  endfacet
+  facet normal 0.1409 -0.990024 0
+    outer loop
+      vertex -0.188 1.48817 0
+      vertex -0.234652 1.48153 -5
+      vertex -0.188 1.48817 -5
+    endloop
+  endfacet
+  facet normal 0.0157255 -0.999876 0
+    outer loop
+      vertex -0.0471153 1.49926 -5
+      vertex 0 1.5 0
+      vertex -0.0471153 1.49926 0
+    endloop
+  endfacet
+  facet normal 0.0157255 -0.999876 0
+    outer loop
+      vertex 0 1.5 0
+      vertex -0.0471153 1.49926 -5
+      vertex 0 1.5 -5
+    endloop
+  endfacet
+  facet normal -0.999876 0.0157255 0
+    outer loop
+      vertex 1.49926 -0.0471153 -5
+      vertex 1.5 0 0
+      vertex 1.5 0 -5
+    endloop
+  endfacet
+  facet normal -0.999876 0.0157255 0
+    outer loop
+      vertex 1.5 0 0
+      vertex 1.49926 -0.0471153 -5
+      vertex 1.49926 -0.0471153 0
+    endloop
+  endfacet
+  facet normal -0.0157255 0.999876 0
+    outer loop
+      vertex 0.0471153 -1.49926 -5
+      vertex 0 -1.5 0
+      vertex 0.0471153 -1.49926 0
+    endloop
+  endfacet
+  facet normal -0.0157255 0.999876 0
+    outer loop
+      vertex 0 -1.5 0
+      vertex 0.0471153 -1.49926 -5
+      vertex 0 -1.5 -5
+    endloop
+  endfacet
+  facet normal -0.0784638 0.996917 0
+    outer loop
+      vertex 0.141162 -1.49334 -5
+      vertex 0.0941849 -1.49704 0
+      vertex 0.141162 -1.49334 0
+    endloop
+  endfacet
+  facet normal -0.0784638 0.996917 0
+    outer loop
+      vertex 0.0941849 -1.49704 0
+      vertex 0.141162 -1.49334 -5
+      vertex 0.0941849 -1.49704 -5
+    endloop
+  endfacet
+  facet normal -0.171926 0.98511 0
+    outer loop
+      vertex 0.281072 -1.47343 -5
+      vertex 0.234652 -1.48153 0
+      vertex 0.281072 -1.47343 0
+    endloop
+  endfacet
+  facet normal -0.171926 0.98511 0
+    outer loop
+      vertex 0.234652 -1.48153 0
+      vertex 0.281072 -1.47343 -5
+      vertex 0.234652 -1.48153 -5
+    endloop
+  endfacet
+  facet normal -0.1409 0.990024 0
+    outer loop
+      vertex 0.234652 -1.48153 -5
+      vertex 0.188 -1.48817 0
+      vertex 0.234652 -1.48153 0
+    endloop
+  endfacet
+  facet normal -0.1409 0.990024 0
+    outer loop
+      vertex 0.188 -1.48817 0
+      vertex 0.234652 -1.48153 -5
+      vertex 0.188 -1.48817 -5
+    endloop
+  endfacet
+  facet normal -0.233449 0.972369 0
+    outer loop
+      vertex 0.373034 -1.45287 -5
+      vertex 0.327214 -1.46387 0
+      vertex 0.373034 -1.45287 0
+    endloop
+  endfacet
+  facet normal -0.233449 0.972369 0
+    outer loop
+      vertex 0.327214 -1.46387 0
+      vertex 0.373034 -1.45287 -5
+      vertex 0.327214 -1.46387 -5
+    endloop
+  endfacet
+  facet normal -0.294047 0.955791 0
+    outer loop
+      vertex 0.463525 -1.42658 -5
+      vertex 0.418487 -1.44044 0
+      vertex 0.463525 -1.42658 0
+    endloop
+  endfacet
+  facet normal -0.294047 0.955791 0
+    outer loop
+      vertex 0.418487 -1.44044 0
+      vertex 0.463525 -1.42658 -5
+      vertex 0.418487 -1.44044 -5
+    endloop
+  endfacet
+  facet normal -0.649454 0.760401 0
+    outer loop
+      vertex 0.991967 -1.12517 -5
+      vertex 0.956136 -1.15577 0
+      vertex 0.991967 -1.12517 0
+    endloop
+  endfacet
+  facet normal -0.649454 0.760401 0
+    outer loop
+      vertex 0.956136 -1.15577 0
+      vertex 0.991967 -1.12517 -5
+      vertex 0.956136 -1.15577 -5
+    endloop
+  endfacet
+  facet normal -0.625243 0.78043 0
+    outer loop
+      vertex 0.956136 -1.15577 -5
+      vertex 0.91936 -1.18523 0
+      vertex 0.956136 -1.15577 0
+    endloop
+  endfacet
+  facet normal -0.625243 0.78043 0
+    outer loop
+      vertex 0.91936 -1.18523 0
+      vertex 0.956136 -1.15577 -5
+      vertex 0.91936 -1.18523 -5
+    endloop
+  endfacet
+  facet normal -0.46793 0.883766 0
+    outer loop
+      vertex 0.722631 -1.31446 -5
+      vertex 0.680985 -1.33651 0
+      vertex 0.722631 -1.31446 0
+    endloop
+  endfacet
+  facet normal -0.46793 0.883766 0
+    outer loop
+      vertex 0.680985 -1.33651 0
+      vertex 0.722631 -1.31446 -5
+      vertex 0.680985 -1.33651 -5
+    endloop
+  endfacet
+  facet normal -0.411528 0.911397 0
+    outer loop
+      vertex 0.638668 -1.35724 -5
+      vertex 0.595721 -1.37663 0
+      vertex 0.638668 -1.35724 0
+    endloop
+  endfacet
+  facet normal -0.411528 0.911397 0
+    outer loop
+      vertex 0.595721 -1.37663 0
+      vertex 0.638668 -1.35724 -5
+      vertex 0.595721 -1.37663 -5
+    endloop
+  endfacet
+  facet normal -0.522509 0.852634 0
+    outer loop
+      vertex 0.80374 -1.26649 -5
+      vertex 0.763561 -1.29111 0
+      vertex 0.80374 -1.26649 0
+    endloop
+  endfacet
+  facet normal -0.522509 0.852634 0
+    outer loop
+      vertex 0.763561 -1.29111 0
+      vertex 0.80374 -1.26649 -5
+      vertex 0.763561 -1.29111 -5
+    endloop
+  endfacet
+  facet normal -0.549013 0.835814 0
+    outer loop
+      vertex 0.843124 -1.24062 -5
+      vertex 0.80374 -1.26649 0
+      vertex 0.843124 -1.24062 0
+    endloop
+  endfacet
+  facet normal -0.549013 0.835814 0
+    outer loop
+      vertex 0.80374 -1.26649 0
+      vertex 0.843124 -1.24062 -5
+      vertex 0.80374 -1.26649 -5
+    endloop
+  endfacet
+  facet normal -0.739634 0.673009 0
+    outer loop
+      vertex 1.09345 -1.02682 -5
+      vertex 1.12517 -0.991967 0
+      vertex 1.12517 -0.991967 -5
+    endloop
+  endfacet
+  facet normal -0.739634 0.673009 0
+    outer loop
+      vertex 1.12517 -0.991967 0
+      vertex 1.09345 -1.02682 -5
+      vertex 1.09345 -1.02682 0
+    endloop
+  endfacet
+  facet normal -0.835814 0.549013 0
+    outer loop
+      vertex 1.24062 -0.843124 -5
+      vertex 1.26649 -0.80374 0
+      vertex 1.26649 -0.80374 -5
+    endloop
+  endfacet
+  facet normal -0.835814 0.549013 0
+    outer loop
+      vertex 1.26649 -0.80374 0
+      vertex 1.24062 -0.843124 -5
+      vertex 1.24062 -0.843124 0
+    endloop
+  endfacet
+  facet normal -0.852634 0.522509 0
+    outer loop
+      vertex 1.26649 -0.80374 -5
+      vertex 1.29111 -0.763561 0
+      vertex 1.29111 -0.763561 -5
+    endloop
+  endfacet
+  facet normal -0.852634 0.522509 0
+    outer loop
+      vertex 1.29111 -0.763561 0
+      vertex 1.26649 -0.80374 -5
+      vertex 1.26649 -0.80374 0
+    endloop
+  endfacet
+  facet normal -0.78043 0.625243 0
+    outer loop
+      vertex 1.15577 -0.956136 -5
+      vertex 1.18523 -0.91936 0
+      vertex 1.18523 -0.91936 -5
+    endloop
+  endfacet
+  facet normal -0.78043 0.625243 0
+    outer loop
+      vertex 1.18523 -0.91936 0
+      vertex 1.15577 -0.956136 -5
+      vertex 1.15577 -0.956136 0
+    endloop
+  endfacet
+  facet normal -0.898036 0.439921 0
+    outer loop
+      vertex 1.33651 -0.680985 -5
+      vertex 1.35724 -0.638668 0
+      vertex 1.35724 -0.638668 -5
+    endloop
+  endfacet
+  facet normal -0.898036 0.439921 0
+    outer loop
+      vertex 1.35724 -0.638668 0
+      vertex 1.33651 -0.680985 -5
+      vertex 1.33651 -0.680985 0
+    endloop
+  endfacet
+  facet normal -0.923886 0.382669 0
+    outer loop
+      vertex 1.37663 -0.595721 -5
+      vertex 1.39466 -0.552186 0
+      vertex 1.39466 -0.552186 -5
+    endloop
+  endfacet
+  facet normal -0.923886 0.382669 0
+    outer loop
+      vertex 1.39466 -0.552186 0
+      vertex 1.37663 -0.595721 -5
+      vertex 1.37663 -0.595721 0
+    endloop
+  endfacet
+  facet normal -0.946086 0.323916 0
+    outer loop
+      vertex 1.41132 -0.508106 -5
+      vertex 1.42658 -0.463525 0
+      vertex 1.42658 -0.463525 -5
+    endloop
+  endfacet
+  facet normal -0.946086 0.323916 0
+    outer loop
+      vertex 1.42658 -0.463525 0
+      vertex 1.41132 -0.508106 -5
+      vertex 1.41132 -0.508106 0
+    endloop
+  endfacet
+  facet normal -0.964559 0.263867 0
+    outer loop
+      vertex 1.44044 -0.418487 -5
+      vertex 1.45287 -0.373034 0
+      vertex 1.45287 -0.373034 -5
+    endloop
+  endfacet
+  facet normal -0.964559 0.263867 0
+    outer loop
+      vertex 1.45287 -0.373034 0
+      vertex 1.44044 -0.418487 -5
+      vertex 1.44044 -0.418487 0
+    endloop
+  endfacet
+  facet normal -0.972369 0.233449 0
+    outer loop
+      vertex 1.45287 -0.373034 -5
+      vertex 1.46387 -0.327214 0
+      vertex 1.46387 -0.327214 -5
+    endloop
+  endfacet
+  facet normal -0.972369 0.233449 0
+    outer loop
+      vertex 1.46387 -0.327214 0
+      vertex 1.45287 -0.373034 -5
+      vertex 1.45287 -0.373034 0
+    endloop
+  endfacet
+  facet normal -0.99889 0.0470949 0
+    outer loop
+      vertex 1.49704 -0.0941849 -5
+      vertex 1.49926 -0.0471153 0
+      vertex 1.49926 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal -0.99889 0.0470949 0
+    outer loop
+      vertex 1.49926 -0.0471153 0
+      vertex 1.49704 -0.0941849 -5
+      vertex 1.49704 -0.0941849 0
+    endloop
+  endfacet
+  facet normal 0.673009 0.739634 -0
+    outer loop
+      vertex -0.991967 -1.12517 -5
+      vertex -1.02682 -1.09345 0
+      vertex -0.991967 -1.12517 0
+    endloop
+  endfacet
+  facet normal 0.673009 0.739634 0
+    outer loop
+      vertex -1.02682 -1.09345 0
+      vertex -0.991967 -1.12517 -5
+      vertex -1.02682 -1.09345 -5
+    endloop
+  endfacet
+  facet normal 0.600418 0.799687 -0
+    outer loop
+      vertex -0.881678 -1.21352 -5
+      vertex -0.91936 -1.18523 0
+      vertex -0.881678 -1.21352 0
+    endloop
+  endfacet
+  facet normal 0.600418 0.799687 0
+    outer loop
+      vertex -0.91936 -1.18523 0
+      vertex -0.881678 -1.21352 -5
+      vertex -0.91936 -1.18523 -5
+    endloop
+  endfacet
+  facet normal 0.439921 0.898036 -0
+    outer loop
+      vertex -0.638668 -1.35724 -5
+      vertex -0.680985 -1.33651 0
+      vertex -0.638668 -1.35724 0
+    endloop
+  endfacet
+  facet normal 0.439921 0.898036 0
+    outer loop
+      vertex -0.680985 -1.33651 0
+      vertex -0.638668 -1.35724 -5
+      vertex -0.680985 -1.33651 -5
+    endloop
+  endfacet
+  facet normal 0.495465 0.868628 -0
+    outer loop
+      vertex -0.722631 -1.31446 -5
+      vertex -0.763561 -1.29111 0
+      vertex -0.722631 -1.31446 0
+    endloop
+  endfacet
+  facet normal 0.495465 0.868628 0
+    outer loop
+      vertex -0.763561 -1.29111 0
+      vertex -0.722631 -1.31446 -5
+      vertex -0.763561 -1.29111 -5
+    endloop
+  endfacet
+  facet normal 0.549013 0.835814 -0
+    outer loop
+      vertex -0.80374 -1.26649 -5
+      vertex -0.843124 -1.24062 0
+      vertex -0.80374 -1.26649 0
+    endloop
+  endfacet
+  facet normal 0.549013 0.835814 0
+    outer loop
+      vertex -0.843124 -1.24062 0
+      vertex -0.80374 -1.26649 -5
+      vertex -0.843124 -1.24062 -5
+    endloop
+  endfacet
+  facet normal 0.323916 0.946086 -0
+    outer loop
+      vertex -0.463525 -1.42658 -5
+      vertex -0.508106 -1.41132 0
+      vertex -0.463525 -1.42658 0
+    endloop
+  endfacet
+  facet normal 0.323916 0.946086 0
+    outer loop
+      vertex -0.508106 -1.41132 0
+      vertex -0.463525 -1.42658 -5
+      vertex -0.508106 -1.41132 -5
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 -0
+    outer loop
+      vertex -0.281072 -1.47343 -5
+      vertex -0.327214 -1.46387 0
+      vertex -0.281072 -1.47343 0
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 0
+    outer loop
+      vertex -0.327214 -1.46387 0
+      vertex -0.281072 -1.47343 -5
+      vertex -0.327214 -1.46387 -5
+    endloop
+  endfacet
+  facet normal 0.263867 0.964559 -0
+    outer loop
+      vertex -0.373034 -1.45287 -5
+      vertex -0.418487 -1.44044 0
+      vertex -0.373034 -1.45287 0
+    endloop
+  endfacet
+  facet normal 0.263867 0.964559 0
+    outer loop
+      vertex -0.418487 -1.44044 0
+      vertex -0.373034 -1.45287 -5
+      vertex -0.418487 -1.44044 -5
+    endloop
+  endfacet
+  facet normal 0.109732 0.993961 -0
+    outer loop
+      vertex -0.141162 -1.49334 -5
+      vertex -0.188 -1.48817 0
+      vertex -0.141162 -1.49334 0
+    endloop
+  endfacet
+  facet normal 0.109732 0.993961 0
+    outer loop
+      vertex -0.188 -1.48817 0
+      vertex -0.141162 -1.49334 -5
+      vertex -0.188 -1.48817 -5
+    endloop
+  endfacet
+  facet normal 0.0470949 0.99889 -0
+    outer loop
+      vertex -0.0471153 -1.49926 -5
+      vertex -0.0941849 -1.49704 0
+      vertex -0.0471153 -1.49926 0
+    endloop
+  endfacet
+  facet normal 0.0470949 0.99889 0
+    outer loop
+      vertex -0.0941849 -1.49704 0
+      vertex -0.0471153 -1.49926 -5
+      vertex -0.0941849 -1.49704 -5
+    endloop
+  endfacet
+  facet normal 0.818148 0.575007 0
+    outer loop
+      vertex -1.21352 -0.881678 0
+      vertex -1.24062 -0.843124 -5
+      vertex -1.24062 -0.843124 0
+    endloop
+  endfacet
+  facet normal 0.818148 0.575007 0
+    outer loop
+      vertex -1.24062 -0.843124 -5
+      vertex -1.21352 -0.881678 0
+      vertex -1.21352 -0.881678 -5
+    endloop
+  endfacet
+  facet normal 0.760401 0.649454 0
+    outer loop
+      vertex -1.12517 -0.991967 0
+      vertex -1.15577 -0.956136 -5
+      vertex -1.15577 -0.956136 0
+    endloop
+  endfacet
+  facet normal 0.760401 0.649454 0
+    outer loop
+      vertex -1.15577 -0.956136 -5
+      vertex -1.12517 -0.991967 0
+      vertex -1.12517 -0.991967 -5
+    endloop
+  endfacet
+  facet normal 0.71812 0.695919 0
+    outer loop
+      vertex -1.06066 -1.06066 0
+      vertex -1.09345 -1.02682 -5
+      vertex -1.09345 -1.02682 0
+    endloop
+  endfacet
+  facet normal 0.71812 0.695919 0
+    outer loop
+      vertex -1.09345 -1.02682 -5
+      vertex -1.06066 -1.06066 0
+      vertex -1.06066 -1.06066 -5
+    endloop
+  endfacet
+  facet normal 0.78043 0.625243 0
+    outer loop
+      vertex -1.15577 -0.956136 0
+      vertex -1.18523 -0.91936 -5
+      vertex -1.18523 -0.91936 0
+    endloop
+  endfacet
+  facet normal 0.78043 0.625243 0
+    outer loop
+      vertex -1.18523 -0.91936 -5
+      vertex -1.15577 -0.956136 0
+      vertex -1.15577 -0.956136 -5
+    endloop
+  endfacet
+  facet normal 0.883766 0.46793 0
+    outer loop
+      vertex -1.31446 -0.722631 0
+      vertex -1.33651 -0.680985 -5
+      vertex -1.33651 -0.680985 0
+    endloop
+  endfacet
+  facet normal 0.883766 0.46793 0
+    outer loop
+      vertex -1.33651 -0.680985 -5
+      vertex -1.31446 -0.722631 0
+      vertex -1.31446 -0.722631 -5
+    endloop
+  endfacet
+  facet normal 0.852634 0.522509 0
+    outer loop
+      vertex -1.26649 -0.80374 0
+      vertex -1.29111 -0.763561 -5
+      vertex -1.29111 -0.763561 0
+    endloop
+  endfacet
+  facet normal 0.852634 0.522509 0
+    outer loop
+      vertex -1.29111 -0.763561 -5
+      vertex -1.26649 -0.80374 0
+      vertex -1.26649 -0.80374 -5
+    endloop
+  endfacet
+  facet normal 0.923886 0.382669 0
+    outer loop
+      vertex -1.37663 -0.595721 0
+      vertex -1.39466 -0.552186 -5
+      vertex -1.39466 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0.923886 0.382669 0
+    outer loop
+      vertex -1.39466 -0.552186 -5
+      vertex -1.37663 -0.595721 0
+      vertex -1.37663 -0.595721 -5
+    endloop
+  endfacet
+  facet normal 0.972369 0.233449 0
+    outer loop
+      vertex -1.45287 -0.373034 0
+      vertex -1.46387 -0.327214 -5
+      vertex -1.46387 -0.327214 0
+    endloop
+  endfacet
+  facet normal 0.972369 0.233449 0
+    outer loop
+      vertex -1.46387 -0.327214 -5
+      vertex -1.45287 -0.373034 0
+      vertex -1.45287 -0.373034 -5
+    endloop
+  endfacet
+  facet normal 0.990024 0.1409 0
+    outer loop
+      vertex -1.48153 -0.234652 0
+      vertex -1.48817 -0.188 -5
+      vertex -1.48817 -0.188 0
+    endloop
+  endfacet
+  facet normal 0.990024 0.1409 0
+    outer loop
+      vertex -1.48817 -0.188 -5
+      vertex -1.48153 -0.234652 0
+      vertex -1.48153 -0.234652 -5
+    endloop
+  endfacet
+  facet normal 0.996917 0.0784638 0
+    outer loop
+      vertex -1.49334 -0.141162 0
+      vertex -1.49704 -0.0941849 -5
+      vertex -1.49704 -0.0941849 0
+    endloop
+  endfacet
+  facet normal 0.996917 0.0784638 0
+    outer loop
+      vertex -1.49704 -0.0941849 -5
+      vertex -1.49334 -0.141162 0
+      vertex -1.49334 -0.141162 -5
+    endloop
+  endfacet
+  facet normal 0.999876 0.0157255 0
+    outer loop
+      vertex -1.49926 -0.0471153 0
+      vertex -1.5 0 -5
+      vertex -1.5 0 0
+    endloop
+  endfacet
+  facet normal 0.999876 0.0157255 0
+    outer loop
+      vertex -1.5 0 -5
+      vertex -1.49926 -0.0471153 0
+      vertex -1.49926 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0.799687 -0.600418 0
+    outer loop
+      vertex -1.21352 0.881678 0
+      vertex -1.18523 0.91936 -5
+      vertex -1.18523 0.91936 0
+    endloop
+  endfacet
+  facet normal 0.799687 -0.600418 0
+    outer loop
+      vertex -1.18523 0.91936 -5
+      vertex -1.21352 0.881678 0
+      vertex -1.21352 0.881678 -5
+    endloop
+  endfacet
+  facet normal 0.739634 -0.673009 0
+    outer loop
+      vertex -1.12517 0.991967 0
+      vertex -1.09345 1.02682 -5
+      vertex -1.09345 1.02682 0
+    endloop
+  endfacet
+  facet normal 0.739634 -0.673009 0
+    outer loop
+      vertex -1.09345 1.02682 -5
+      vertex -1.12517 0.991967 0
+      vertex -1.12517 0.991967 -5
+    endloop
+  endfacet
+  facet normal -0.0470949 0.99889 0
+    outer loop
+      vertex 0.0941849 -1.49704 -5
+      vertex 0.0471153 -1.49926 0
+      vertex 0.0941849 -1.49704 0
+    endloop
+  endfacet
+  facet normal -0.0470949 0.99889 0
+    outer loop
+      vertex 0.0471153 -1.49926 0
+      vertex 0.0941849 -1.49704 -5
+      vertex 0.0471153 -1.49926 -5
+    endloop
+  endfacet
+  facet normal -0.263867 0.964559 0
+    outer loop
+      vertex 0.418487 -1.44044 -5
+      vertex 0.373034 -1.45287 0
+      vertex 0.418487 -1.44044 0
+    endloop
+  endfacet
+  facet normal -0.263867 0.964559 0
+    outer loop
+      vertex 0.373034 -1.45287 0
+      vertex 0.418487 -1.44044 -5
+      vertex 0.373034 -1.45287 -5
+    endloop
+  endfacet
+  facet normal -0.382669 0.923886 0
+    outer loop
+      vertex 0.595721 -1.37663 -5
+      vertex 0.552186 -1.39466 0
+      vertex 0.595721 -1.37663 0
+    endloop
+  endfacet
+  facet normal -0.382669 0.923886 0
+    outer loop
+      vertex 0.552186 -1.39466 0
+      vertex 0.595721 -1.37663 -5
+      vertex 0.552186 -1.39466 -5
+    endloop
+  endfacet
+  facet normal -0.323916 0.946086 0
+    outer loop
+      vertex 0.508106 -1.41132 -5
+      vertex 0.463525 -1.42658 0
+      vertex 0.508106 -1.41132 0
+    endloop
+  endfacet
+  facet normal -0.323916 0.946086 0
+    outer loop
+      vertex 0.463525 -1.42658 0
+      vertex 0.508106 -1.41132 -5
+      vertex 0.463525 -1.42658 -5
+    endloop
+  endfacet
+  facet normal -0.71812 0.695919 0
+    outer loop
+      vertex 1.06066 -1.06066 -5
+      vertex 1.09345 -1.02682 0
+      vertex 1.09345 -1.02682 -5
+    endloop
+  endfacet
+  facet normal -0.71812 0.695919 0
+    outer loop
+      vertex 1.09345 -1.02682 0
+      vertex 1.06066 -1.06066 -5
+      vertex 1.06066 -1.06066 0
+    endloop
+  endfacet
+  facet normal -0.673009 0.739634 0
+    outer loop
+      vertex 1.02682 -1.09345 -5
+      vertex 0.991967 -1.12517 0
+      vertex 1.02682 -1.09345 0
+    endloop
+  endfacet
+  facet normal -0.673009 0.739634 0
+    outer loop
+      vertex 0.991967 -1.12517 0
+      vertex 1.02682 -1.09345 -5
+      vertex 0.991967 -1.12517 -5
+    endloop
+  endfacet
+  facet normal -0.600418 0.799687 0
+    outer loop
+      vertex 0.91936 -1.18523 -5
+      vertex 0.881678 -1.21352 0
+      vertex 0.91936 -1.18523 0
+    endloop
+  endfacet
+  facet normal -0.600418 0.799687 0
+    outer loop
+      vertex 0.881678 -1.21352 0
+      vertex 0.91936 -1.18523 -5
+      vertex 0.881678 -1.21352 -5
+    endloop
+  endfacet
+  facet normal -0.439921 0.898036 0
+    outer loop
+      vertex 0.680985 -1.33651 -5
+      vertex 0.638668 -1.35724 0
+      vertex 0.680985 -1.33651 0
+    endloop
+  endfacet
+  facet normal -0.439921 0.898036 0
+    outer loop
+      vertex 0.638668 -1.35724 0
+      vertex 0.680985 -1.33651 -5
+      vertex 0.638668 -1.35724 -5
+    endloop
+  endfacet
+  facet normal -0.818148 0.575007 0
+    outer loop
+      vertex 1.21352 -0.881678 -5
+      vertex 1.24062 -0.843124 0
+      vertex 1.24062 -0.843124 -5
+    endloop
+  endfacet
+  facet normal -0.818148 0.575007 0
+    outer loop
+      vertex 1.24062 -0.843124 0
+      vertex 1.21352 -0.881678 -5
+      vertex 1.21352 -0.881678 0
+    endloop
+  endfacet
+  facet normal -0.760401 0.649454 0
+    outer loop
+      vertex 1.12517 -0.991967 -5
+      vertex 1.15577 -0.956136 0
+      vertex 1.15577 -0.956136 -5
+    endloop
+  endfacet
+  facet normal -0.760401 0.649454 0
+    outer loop
+      vertex 1.15577 -0.956136 0
+      vertex 1.12517 -0.991967 -5
+      vertex 1.12517 -0.991967 0
+    endloop
+  endfacet
+  facet normal -0.883766 0.46793 0
+    outer loop
+      vertex 1.31446 -0.722631 -5
+      vertex 1.33651 -0.680985 0
+      vertex 1.33651 -0.680985 -5
+    endloop
+  endfacet
+  facet normal -0.883766 0.46793 0
+    outer loop
+      vertex 1.33651 -0.680985 0
+      vertex 1.31446 -0.722631 -5
+      vertex 1.31446 -0.722631 0
+    endloop
+  endfacet
+  facet normal -0.93544 0.353484 0
+    outer loop
+      vertex 1.39466 -0.552186 -5
+      vertex 1.41132 -0.508106 0
+      vertex 1.41132 -0.508106 -5
+    endloop
+  endfacet
+  facet normal -0.93544 0.353484 0
+    outer loop
+      vertex 1.41132 -0.508106 0
+      vertex 1.39466 -0.552186 -5
+      vertex 1.39466 -0.552186 0
+    endloop
+  endfacet
+  facet normal -0.955791 0.294047 0
+    outer loop
+      vertex 1.42658 -0.463525 -5
+      vertex 1.44044 -0.418487 0
+      vertex 1.44044 -0.418487 -5
+    endloop
+  endfacet
+  facet normal -0.955791 0.294047 0
+    outer loop
+      vertex 1.44044 -0.418487 0
+      vertex 1.42658 -0.463525 -5
+      vertex 1.42658 -0.463525 0
+    endloop
+  endfacet
+  facet normal -0.979222 0.20279 0
+    outer loop
+      vertex 1.46387 -0.327214 -5
+      vertex 1.47343 -0.281072 0
+      vertex 1.47343 -0.281072 -5
+    endloop
+  endfacet
+  facet normal -0.979222 0.20279 0
+    outer loop
+      vertex 1.47343 -0.281072 0
+      vertex 1.46387 -0.327214 -5
+      vertex 1.46387 -0.327214 0
+    endloop
+  endfacet
+  facet normal -0.993961 0.109732 0
+    outer loop
+      vertex 1.48817 -0.188 -5
+      vertex 1.49334 -0.141162 0
+      vertex 1.49334 -0.141162 -5
+    endloop
+  endfacet
+  facet normal -0.993961 0.109732 0
+    outer loop
+      vertex 1.49334 -0.141162 0
+      vertex 1.48817 -0.188 -5
+      vertex 1.48817 -0.188 0
+    endloop
+  endfacet
+  facet normal 0.649454 0.760401 -0
+    outer loop
+      vertex -0.956136 -1.15577 -5
+      vertex -0.991967 -1.12517 0
+      vertex -0.956136 -1.15577 0
+    endloop
+  endfacet
+  facet normal 0.649454 0.760401 0
+    outer loop
+      vertex -0.991967 -1.12517 0
+      vertex -0.956136 -1.15577 -5
+      vertex -0.991967 -1.12517 -5
+    endloop
+  endfacet
+  facet normal 0.575007 0.818148 -0
+    outer loop
+      vertex -0.843124 -1.24062 -5
+      vertex -0.881678 -1.21352 0
+      vertex -0.843124 -1.24062 0
+    endloop
+  endfacet
+  facet normal 0.575007 0.818148 0
+    outer loop
+      vertex -0.881678 -1.21352 0
+      vertex -0.843124 -1.24062 -5
+      vertex -0.881678 -1.21352 -5
+    endloop
+  endfacet
+  facet normal 0.411528 0.911397 -0
+    outer loop
+      vertex -0.595721 -1.37663 -5
+      vertex -0.638668 -1.35724 0
+      vertex -0.595721 -1.37663 0
+    endloop
+  endfacet
+  facet normal 0.411528 0.911397 0
+    outer loop
+      vertex -0.638668 -1.35724 0
+      vertex -0.595721 -1.37663 -5
+      vertex -0.638668 -1.35724 -5
+    endloop
+  endfacet
+  facet normal 0.522509 0.852634 -0
+    outer loop
+      vertex -0.763561 -1.29111 -5
+      vertex -0.80374 -1.26649 0
+      vertex -0.763561 -1.29111 0
+    endloop
+  endfacet
+  facet normal 0.522509 0.852634 0
+    outer loop
+      vertex -0.80374 -1.26649 0
+      vertex -0.763561 -1.29111 -5
+      vertex -0.80374 -1.26649 -5
+    endloop
+  endfacet
+  facet normal 0.353484 0.93544 -0
+    outer loop
+      vertex -0.508106 -1.41132 -5
+      vertex -0.552186 -1.39466 0
+      vertex -0.508106 -1.41132 0
+    endloop
+  endfacet
+  facet normal 0.353484 0.93544 0
+    outer loop
+      vertex -0.552186 -1.39466 0
+      vertex -0.508106 -1.41132 -5
+      vertex -0.552186 -1.39466 -5
+    endloop
+  endfacet
+  facet normal 0.294047 0.955791 -0
+    outer loop
+      vertex -0.418487 -1.44044 -5
+      vertex -0.463525 -1.42658 0
+      vertex -0.418487 -1.44044 0
+    endloop
+  endfacet
+  facet normal 0.294047 0.955791 0
+    outer loop
+      vertex -0.463525 -1.42658 0
+      vertex -0.418487 -1.44044 -5
+      vertex -0.463525 -1.42658 -5
+    endloop
+  endfacet
+  facet normal 0.233449 0.972369 -0
+    outer loop
+      vertex -0.327214 -1.46387 -5
+      vertex -0.373034 -1.45287 0
+      vertex -0.327214 -1.46387 0
+    endloop
+  endfacet
+  facet normal 0.233449 0.972369 0
+    outer loop
+      vertex -0.373034 -1.45287 0
+      vertex -0.327214 -1.46387 -5
+      vertex -0.373034 -1.45287 -5
+    endloop
+  endfacet
+  facet normal 0.1409 0.990024 -0
+    outer loop
+      vertex -0.188 -1.48817 -5
+      vertex -0.234652 -1.48153 0
+      vertex -0.188 -1.48817 0
+    endloop
+  endfacet
+  facet normal 0.1409 0.990024 0
+    outer loop
+      vertex -0.234652 -1.48153 0
+      vertex -0.188 -1.48817 -5
+      vertex -0.234652 -1.48153 -5
+    endloop
+  endfacet
+  facet normal 0.739634 0.673009 0
+    outer loop
+      vertex -1.09345 -1.02682 0
+      vertex -1.12517 -0.991967 -5
+      vertex -1.12517 -0.991967 0
+    endloop
+  endfacet
+  facet normal 0.739634 0.673009 0
+    outer loop
+      vertex -1.12517 -0.991967 -5
+      vertex -1.09345 -1.02682 0
+      vertex -1.09345 -1.02682 -5
+    endloop
+  endfacet
+  facet normal 0.799687 0.600418 0
+    outer loop
+      vertex -1.18523 -0.91936 0
+      vertex -1.21352 -0.881678 -5
+      vertex -1.21352 -0.881678 0
+    endloop
+  endfacet
+  facet normal 0.799687 0.600418 0
+    outer loop
+      vertex -1.21352 -0.881678 -5
+      vertex -1.18523 -0.91936 0
+      vertex -1.18523 -0.91936 -5
+    endloop
+  endfacet
+  facet normal 0.898036 0.439921 0
+    outer loop
+      vertex -1.33651 -0.680985 0
+      vertex -1.35724 -0.638668 -5
+      vertex -1.35724 -0.638668 0
+    endloop
+  endfacet
+  facet normal 0.898036 0.439921 0
+    outer loop
+      vertex -1.35724 -0.638668 -5
+      vertex -1.33651 -0.680985 0
+      vertex -1.33651 -0.680985 -5
+    endloop
+  endfacet
+  facet normal 0.946086 0.323916 0
+    outer loop
+      vertex -1.41132 -0.508106 0
+      vertex -1.42658 -0.463525 -5
+      vertex -1.42658 -0.463525 0
+    endloop
+  endfacet
+  facet normal 0.946086 0.323916 0
+    outer loop
+      vertex -1.42658 -0.463525 -5
+      vertex -1.41132 -0.508106 0
+      vertex -1.41132 -0.508106 -5
+    endloop
+  endfacet
+  facet normal 0.93544 0.353484 0
+    outer loop
+      vertex -1.39466 -0.552186 0
+      vertex -1.41132 -0.508106 -5
+      vertex -1.41132 -0.508106 0
+    endloop
+  endfacet
+  facet normal 0.93544 0.353484 0
+    outer loop
+      vertex -1.41132 -0.508106 -5
+      vertex -1.39466 -0.552186 0
+      vertex -1.39466 -0.552186 -5
+    endloop
+  endfacet
+  facet normal 0.99889 0.0470949 0
+    outer loop
+      vertex -1.49704 -0.0941849 0
+      vertex -1.49926 -0.0471153 -5
+      vertex -1.49926 -0.0471153 0
+    endloop
+  endfacet
+  facet normal 0.99889 0.0470949 0
+    outer loop
+      vertex -1.49926 -0.0471153 -5
+      vertex -1.49704 -0.0941849 0
+      vertex -1.49704 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0157153 0
+    outer loop
+      vertex 3 0 0
+      vertex 2.99852 0.0942316 5
+      vertex 2.99852 0.0942316 0
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0157153 0
+    outer loop
+      vertex 2.99852 0.0942316 5
+      vertex 3 0 0
+      vertex 3 0 5
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0157153 0
+    outer loop
+      vertex -3 0 5
+      vertex -2.99852 0.0942316 0
+      vertex -2.99852 0.0942316 5
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0157153 0
+    outer loop
+      vertex -2.99852 0.0942316 0
+      vertex -3 0 5
+      vertex -3 0 0
+    endloop
+  endfacet
+  facet normal -0.0157153 -0.999877 0
+    outer loop
+      vertex 0 3 0
+      vertex 0.0942316 2.99852 5
+      vertex 0 3 5
+    endloop
+  endfacet
+  facet normal -0.0157153 -0.999877 -0
+    outer loop
+      vertex 0.0942316 2.99852 5
+      vertex 0 3 0
+      vertex 0.0942316 2.99852 0
+    endloop
+  endfacet
+  facet normal 0.718125 0.695914 0
+    outer loop
+      vertex -2.12132 -2.12132 5
+      vertex -2.18691 -2.05364 0
+      vertex -2.18691 -2.05364 5
+    endloop
+  endfacet
+  facet normal 0.718125 0.695914 0
+    outer loop
+      vertex -2.18691 -2.05364 0
+      vertex -2.12132 -2.12132 5
+      vertex -2.12132 -2.12132 0
+    endloop
+  endfacet
+  facet normal -0.695914 -0.718125 0
+    outer loop
+      vertex 2.05364 2.18691 0
+      vertex 2.12132 2.12132 5
+      vertex 2.05364 2.18691 5
+    endloop
+  endfacet
+  facet normal -0.695914 -0.718125 -0
+    outer loop
+      vertex 2.12132 2.12132 5
+      vertex 2.05364 2.18691 0
+      vertex 2.12132 2.12132 0
+    endloop
+  endfacet
+  facet normal 0.695914 -0.718125 0
+    outer loop
+      vertex -2.12132 2.12132 0
+      vertex -2.05364 2.18691 5
+      vertex -2.12132 2.12132 5
+    endloop
+  endfacet
+  facet normal 0.695914 -0.718125 0
+    outer loop
+      vertex -2.05364 2.18691 5
+      vertex -2.12132 2.12132 0
+      vertex -2.05364 2.18691 0
+    endloop
+  endfacet
+  facet normal 0.382677 -0.923882 0
+    outer loop
+      vertex -1.19144 2.75326 0
+      vertex -1.10437 2.78933 5
+      vertex -1.19144 2.75326 5
+    endloop
+  endfacet
+  facet normal 0.382677 -0.923882 0
+    outer loop
+      vertex -1.10437 2.78933 5
+      vertex -1.19144 2.75326 0
+      vertex -1.10437 2.78933 0
+    endloop
+  endfacet
+  facet normal -0.923882 -0.382677 0
+    outer loop
+      vertex 2.78933 1.10437 0
+      vertex 2.75326 1.19144 5
+      vertex 2.75326 1.19144 0
+    endloop
+  endfacet
+  facet normal -0.923882 -0.382677 0
+    outer loop
+      vertex 2.75326 1.19144 5
+      vertex 2.78933 1.10437 0
+      vertex 2.78933 1.10437 5
+    endloop
+  endfacet
+  facet normal -0.382677 -0.923882 0
+    outer loop
+      vertex 1.10437 2.78933 0
+      vertex 1.19144 2.75326 5
+      vertex 1.10437 2.78933 5
+    endloop
+  endfacet
+  facet normal -0.382677 -0.923882 -0
+    outer loop
+      vertex 1.19144 2.75326 5
+      vertex 1.10437 2.78933 0
+      vertex 1.19144 2.75326 0
+    endloop
+  endfacet
+  facet normal -0.54902 -0.835809 0
+    outer loop
+      vertex 1.60748 2.53298 0
+      vertex 1.68625 2.48124 5
+      vertex 1.60748 2.53298 5
+    endloop
+  endfacet
+  facet normal -0.54902 -0.835809 -0
+    outer loop
+      vertex 1.68625 2.48124 5
+      vertex 1.60748 2.53298 0
+      vertex 1.68625 2.48124 0
+    endloop
+  endfacet
+  facet normal 0.911401 -0.41152 0
+    outer loop
+      vertex -2.75326 1.19144 5
+      vertex -2.71448 1.27734 0
+      vertex -2.71448 1.27734 5
+    endloop
+  endfacet
+  facet normal 0.911401 -0.41152 0
+    outer loop
+      vertex -2.71448 1.27734 0
+      vertex -2.75326 1.19144 5
+      vertex -2.75326 1.19144 0
+    endloop
+  endfacet
+  facet normal 0.73963 -0.673014 0
+    outer loop
+      vertex -2.25033 1.98394 5
+      vertex -2.18691 2.05364 0
+      vertex -2.18691 2.05364 5
+    endloop
+  endfacet
+  facet normal 0.73963 -0.673014 0
+    outer loop
+      vertex -2.18691 2.05364 0
+      vertex -2.25033 1.98394 5
+      vertex -2.25033 1.98394 0
+    endloop
+  endfacet
+  facet normal 0.171926 -0.98511 0
+    outer loop
+      vertex -0.562143 2.94686 0
+      vertex -0.469303 2.96306 5
+      vertex -0.562143 2.94686 5
+    endloop
+  endfacet
+  facet normal 0.171926 -0.98511 0
+    outer loop
+      vertex -0.469303 2.96306 5
+      vertex -0.562143 2.94686 0
+      vertex -0.469303 2.96306 0
+    endloop
+  endfacet
+  facet normal -0.979223 -0.202788 0
+    outer loop
+      vertex 2.94686 0.562143 0
+      vertex 2.92775 0.654429 5
+      vertex 2.92775 0.654429 0
+    endloop
+  endfacet
+  facet normal -0.979223 -0.202788 0
+    outer loop
+      vertex 2.92775 0.654429 5
+      vertex 2.94686 0.562143 0
+      vertex 2.94686 0.562143 5
+    endloop
+  endfacet
+  facet normal -0.81815 -0.575005 0
+    outer loop
+      vertex 2.48124 1.68625 0
+      vertex 2.42705 1.76336 5
+      vertex 2.42705 1.76336 0
+    endloop
+  endfacet
+  facet normal -0.81815 -0.575005 0
+    outer loop
+      vertex 2.42705 1.76336 5
+      vertex 2.48124 1.68625 0
+      vertex 2.48124 1.68625 5
+    endloop
+  endfacet
+  facet normal -0.883766 -0.46793 0
+    outer loop
+      vertex 2.67302 1.36197 0
+      vertex 2.62892 1.44526 5
+      vertex 2.62892 1.44526 0
+    endloop
+  endfacet
+  facet normal -0.883766 -0.46793 0
+    outer loop
+      vertex 2.62892 1.44526 5
+      vertex 2.67302 1.36197 0
+      vertex 2.67302 1.36197 5
+    endloop
+  endfacet
+  facet normal -0.202788 -0.979223 0
+    outer loop
+      vertex 0.562143 2.94686 0
+      vertex 0.654429 2.92775 5
+      vertex 0.562143 2.94686 5
+    endloop
+  endfacet
+  facet normal -0.202788 -0.979223 -0
+    outer loop
+      vertex 0.654429 2.92775 5
+      vertex 0.562143 2.94686 0
+      vertex 0.654429 2.92775 0
+    endloop
+  endfacet
+  facet normal -0.323925 -0.946083 0
+    outer loop
+      vertex 0.927051 2.85317 0
+      vertex 1.01621 2.82264 5
+      vertex 0.927051 2.85317 5
+    endloop
+  endfacet
+  facet normal -0.323925 -0.946083 -0
+    outer loop
+      vertex 1.01621 2.82264 5
+      vertex 0.927051 2.85317 0
+      vertex 1.01621 2.82264 0
+    endloop
+  endfacet
+  facet normal -0.625237 -0.780435 0
+    outer loop
+      vertex 1.83872 2.37046 0
+      vertex 1.91227 2.31154 5
+      vertex 1.83872 2.37046 5
+    endloop
+  endfacet
+  facet normal -0.625237 -0.780435 -0
+    outer loop
+      vertex 1.91227 2.31154 5
+      vertex 1.83872 2.37046 0
+      vertex 1.91227 2.31154 0
+    endloop
+  endfacet
+  facet normal 0.979223 -0.202788 0
+    outer loop
+      vertex -2.94686 0.562143 5
+      vertex -2.92775 0.654429 0
+      vertex -2.92775 0.654429 5
+    endloop
+  endfacet
+  facet normal 0.979223 -0.202788 0
+    outer loop
+      vertex -2.92775 0.654429 0
+      vertex -2.94686 0.562143 5
+      vertex -2.94686 0.562143 0
+    endloop
+  endfacet
+  facet normal 0.81815 -0.575005 0
+    outer loop
+      vertex -2.48124 1.68625 5
+      vertex -2.42705 1.76336 0
+      vertex -2.42705 1.76336 5
+    endloop
+  endfacet
+  facet normal 0.81815 -0.575005 0
+    outer loop
+      vertex -2.42705 1.76336 0
+      vertex -2.48124 1.68625 5
+      vertex -2.48124 1.68625 0
+    endloop
+  endfacet
+  facet normal 0.54902 -0.835809 0
+    outer loop
+      vertex -1.68625 2.48124 0
+      vertex -1.60748 2.53298 5
+      vertex -1.68625 2.48124 5
+    endloop
+  endfacet
+  facet normal 0.54902 -0.835809 0
+    outer loop
+      vertex -1.60748 2.53298 5
+      vertex -1.68625 2.48124 0
+      vertex -1.60748 2.53298 0
+    endloop
+  endfacet
+  facet normal 0.0784537 -0.996918 0
+    outer loop
+      vertex -0.282325 2.98669 0
+      vertex -0.188371 2.99408 5
+      vertex -0.282325 2.98669 5
+    endloop
+  endfacet
+  facet normal 0.0784537 -0.996918 0
+    outer loop
+      vertex -0.188371 2.99408 5
+      vertex -0.282325 2.98669 0
+      vertex -0.188371 2.99408 0
+    endloop
+  endfacet
+  facet normal -0.972371 0.233441 0
+    outer loop
+      vertex 2.90575 -0.746069 0
+      vertex 2.92775 -0.654429 5
+      vertex 2.92775 -0.654429 0
+    endloop
+  endfacet
+  facet normal -0.972371 0.233441 0
+    outer loop
+      vertex 2.92775 -0.654429 5
+      vertex 2.90575 -0.746069 0
+      vertex 2.90575 -0.746069 5
+    endloop
+  endfacet
+  facet normal -0.695914 0.718125 0
+    outer loop
+      vertex 2.12132 -2.12132 0
+      vertex 2.05364 -2.18691 5
+      vertex 2.12132 -2.12132 5
+    endloop
+  endfacet
+  facet normal -0.695914 0.718125 0
+    outer loop
+      vertex 2.05364 -2.18691 5
+      vertex 2.12132 -2.12132 0
+      vertex 2.05364 -2.18691 0
+    endloop
+  endfacet
+  facet normal -0.54902 0.835809 0
+    outer loop
+      vertex 1.68625 -2.48124 0
+      vertex 1.60748 -2.53298 5
+      vertex 1.68625 -2.48124 5
+    endloop
+  endfacet
+  facet normal -0.54902 0.835809 0
+    outer loop
+      vertex 1.60748 -2.53298 5
+      vertex 1.68625 -2.48124 0
+      vertex 1.60748 -2.53298 0
+    endloop
+  endfacet
+  facet normal -0.81815 0.575005 0
+    outer loop
+      vertex 2.42705 -1.76336 0
+      vertex 2.48124 -1.68625 5
+      vertex 2.48124 -1.68625 0
+    endloop
+  endfacet
+  facet normal -0.81815 0.575005 0
+    outer loop
+      vertex 2.48124 -1.68625 5
+      vertex 2.42705 -1.76336 0
+      vertex 2.42705 -1.76336 5
+    endloop
+  endfacet
+  facet normal -0.923882 0.382677 0
+    outer loop
+      vertex 2.75326 -1.19144 0
+      vertex 2.78933 -1.10437 5
+      vertex 2.78933 -1.10437 0
+    endloop
+  endfacet
+  facet normal -0.923882 0.382677 0
+    outer loop
+      vertex 2.78933 -1.10437 5
+      vertex 2.75326 -1.19144 0
+      vertex 2.75326 -1.19144 5
+    endloop
+  endfacet
+  facet normal 0.294035 0.955795 -0
+    outer loop
+      vertex -0.836973 -2.88088 0
+      vertex -0.927051 -2.85317 5
+      vertex -0.836973 -2.88088 5
+    endloop
+  endfacet
+  facet normal 0.294035 0.955795 0
+    outer loop
+      vertex -0.927051 -2.85317 5
+      vertex -0.836973 -2.88088 0
+      vertex -0.927051 -2.85317 0
+    endloop
+  endfacet
+  facet normal 0.625237 0.780435 -0
+    outer loop
+      vertex -1.83872 -2.37046 0
+      vertex -1.91227 -2.31154 5
+      vertex -1.83872 -2.37046 5
+    endloop
+  endfacet
+  facet normal 0.625237 0.780435 0
+    outer loop
+      vertex -1.91227 -2.31154 5
+      vertex -1.83872 -2.37046 0
+      vertex -1.91227 -2.31154 0
+    endloop
+  endfacet
+  facet normal 0.439933 0.89803 -0
+    outer loop
+      vertex -1.27734 -2.71448 0
+      vertex -1.36197 -2.67302 5
+      vertex -1.27734 -2.71448 5
+    endloop
+  endfacet
+  facet normal 0.439933 0.89803 0
+    outer loop
+      vertex -1.36197 -2.67302 5
+      vertex -1.27734 -2.71448 0
+      vertex -1.36197 -2.67302 0
+    endloop
+  endfacet
+  facet normal 0.86863 0.495461 0
+    outer loop
+      vertex -2.58223 -1.52712 5
+      vertex -2.62892 -1.44526 0
+      vertex -2.62892 -1.44526 5
+    endloop
+  endfacet
+  facet normal 0.86863 0.495461 0
+    outer loop
+      vertex -2.62892 -1.44526 0
+      vertex -2.58223 -1.52712 5
+      vertex -2.58223 -1.52712 0
+    endloop
+  endfacet
+  facet normal 0.73963 0.673014 0
+    outer loop
+      vertex -2.18691 -2.05364 5
+      vertex -2.25033 -1.98394 0
+      vertex -2.25033 -1.98394 5
+    endloop
+  endfacet
+  facet normal 0.73963 0.673014 0
+    outer loop
+      vertex -2.25033 -1.98394 0
+      vertex -2.18691 -2.05364 5
+      vertex -2.18691 -2.05364 0
+    endloop
+  endfacet
+  facet normal 0.923882 0.382677 0
+    outer loop
+      vertex -2.75326 -1.19144 5
+      vertex -2.78933 -1.10437 0
+      vertex -2.78933 -1.10437 5
+    endloop
+  endfacet
+  facet normal 0.923882 0.382677 0
+    outer loop
+      vertex -2.78933 -1.10437 0
+      vertex -2.75326 -1.19144 5
+      vertex -2.75326 -1.19144 0
+    endloop
+  endfacet
+  facet normal -0.99396 -0.109743 0
+    outer loop
+      vertex 2.98669 0.282325 0
+      vertex 2.97634 0.375999 5
+      vertex 2.97634 0.375999 0
+    endloop
+  endfacet
+  facet normal -0.99396 -0.109743 0
+    outer loop
+      vertex 2.97634 0.375999 5
+      vertex 2.98669 0.282325 0
+      vertex 2.98669 0.282325 5
+    endloop
+  endfacet
+  facet normal -0.955795 -0.294035 0
+    outer loop
+      vertex 2.88088 0.836973 0
+      vertex 2.85317 0.927051 5
+      vertex 2.85317 0.927051 0
+    endloop
+  endfacet
+  facet normal -0.955795 -0.294035 0
+    outer loop
+      vertex 2.85317 0.927051 5
+      vertex 2.88088 0.836973 0
+      vertex 2.88088 0.836973 5
+    endloop
+  endfacet
+  facet normal -0.935444 -0.353476 0
+    outer loop
+      vertex 2.82264 1.01621 0
+      vertex 2.78933 1.10437 5
+      vertex 2.78933 1.10437 0
+    endloop
+  endfacet
+  facet normal -0.935444 -0.353476 0
+    outer loop
+      vertex 2.78933 1.10437 5
+      vertex 2.82264 1.01621 0
+      vertex 2.82264 1.01621 5
+    endloop
+  endfacet
+  facet normal -0.972371 -0.233441 0
+    outer loop
+      vertex 2.92775 0.654429 0
+      vertex 2.90575 0.746069 5
+      vertex 2.90575 0.746069 0
+    endloop
+  endfacet
+  facet normal -0.972371 -0.233441 0
+    outer loop
+      vertex 2.90575 0.746069 5
+      vertex 2.92775 0.654429 0
+      vertex 2.92775 0.654429 5
+    endloop
+  endfacet
+  facet normal -0.760405 -0.649449 0
+    outer loop
+      vertex 2.31154 1.91227 0
+      vertex 2.25033 1.98394 5
+      vertex 2.25033 1.98394 0
+    endloop
+  endfacet
+  facet normal -0.760405 -0.649449 0
+    outer loop
+      vertex 2.25033 1.98394 5
+      vertex 2.31154 1.91227 0
+      vertex 2.31154 1.91227 5
+    endloop
+  endfacet
+  facet normal -0.780435 -0.625237 0
+    outer loop
+      vertex 2.37046 1.83872 0
+      vertex 2.31154 1.91227 5
+      vertex 2.31154 1.91227 0
+    endloop
+  endfacet
+  facet normal -0.780435 -0.625237 0
+    outer loop
+      vertex 2.31154 1.91227 5
+      vertex 2.37046 1.83872 0
+      vertex 2.37046 1.83872 5
+    endloop
+  endfacet
+  facet normal -0.73963 -0.673014 0
+    outer loop
+      vertex 2.25033 1.98394 0
+      vertex 2.18691 2.05364 5
+      vertex 2.18691 2.05364 0
+    endloop
+  endfacet
+  facet normal -0.73963 -0.673014 0
+    outer loop
+      vertex 2.18691 2.05364 5
+      vertex 2.25033 1.98394 0
+      vertex 2.25033 1.98394 5
+    endloop
+  endfacet
+  facet normal -0.89803 -0.439933 0
+    outer loop
+      vertex 2.71448 1.27734 0
+      vertex 2.67302 1.36197 5
+      vertex 2.67302 1.36197 0
+    endloop
+  endfacet
+  facet normal -0.89803 -0.439933 0
+    outer loop
+      vertex 2.67302 1.36197 5
+      vertex 2.71448 1.27734 0
+      vertex 2.71448 1.27734 5
+    endloop
+  endfacet
+  facet normal -0.1409 -0.990024 0
+    outer loop
+      vertex 0.375999 2.97634 0
+      vertex 0.469303 2.96306 5
+      vertex 0.375999 2.97634 5
+    endloop
+  endfacet
+  facet normal -0.1409 -0.990024 -0
+    outer loop
+      vertex 0.469303 2.96306 5
+      vertex 0.375999 2.97634 0
+      vertex 0.469303 2.96306 0
+    endloop
+  endfacet
+  facet normal -0.294035 -0.955795 0
+    outer loop
+      vertex 0.836973 2.88088 0
+      vertex 0.927051 2.85317 5
+      vertex 0.836973 2.88088 5
+    endloop
+  endfacet
+  facet normal -0.294035 -0.955795 -0
+    outer loop
+      vertex 0.927051 2.85317 5
+      vertex 0.836973 2.88088 0
+      vertex 0.927051 2.85317 0
+    endloop
+  endfacet
+  facet normal -0.263877 -0.964556 0
+    outer loop
+      vertex 0.746069 2.90575 0
+      vertex 0.836973 2.88088 5
+      vertex 0.746069 2.90575 5
+    endloop
+  endfacet
+  facet normal -0.263877 -0.964556 -0
+    outer loop
+      vertex 0.836973 2.88088 5
+      vertex 0.746069 2.90575 0
+      vertex 0.836973 2.88088 0
+    endloop
+  endfacet
+  facet normal -0.171926 -0.98511 0
+    outer loop
+      vertex 0.469303 2.96306 0
+      vertex 0.562143 2.94686 5
+      vertex 0.469303 2.96306 5
+    endloop
+  endfacet
+  facet normal -0.171926 -0.98511 -0
+    outer loop
+      vertex 0.562143 2.94686 5
+      vertex 0.469303 2.96306 0
+      vertex 0.562143 2.94686 0
+    endloop
+  endfacet
+  facet normal -0.0784537 -0.996918 0
+    outer loop
+      vertex 0.188371 2.99408 0
+      vertex 0.282325 2.98669 5
+      vertex 0.188371 2.99408 5
+    endloop
+  endfacet
+  facet normal -0.0784537 -0.996918 -0
+    outer loop
+      vertex 0.282325 2.98669 5
+      vertex 0.188371 2.99408 0
+      vertex 0.282325 2.98669 0
+    endloop
+  endfacet
+  facet normal -0.46793 -0.883766 0
+    outer loop
+      vertex 1.36197 2.67302 0
+      vertex 1.44526 2.62892 5
+      vertex 1.36197 2.67302 5
+    endloop
+  endfacet
+  facet normal -0.46793 -0.883766 -0
+    outer loop
+      vertex 1.44526 2.62892 5
+      vertex 1.36197 2.67302 0
+      vertex 1.44526 2.62892 0
+    endloop
+  endfacet
+  facet normal -0.495461 -0.86863 0
+    outer loop
+      vertex 1.44526 2.62892 0
+      vertex 1.52712 2.58223 5
+      vertex 1.44526 2.62892 5
+    endloop
+  endfacet
+  facet normal -0.495461 -0.86863 -0
+    outer loop
+      vertex 1.52712 2.58223 5
+      vertex 1.44526 2.62892 0
+      vertex 1.52712 2.58223 0
+    endloop
+  endfacet
+  facet normal -0.41152 -0.911401 0
+    outer loop
+      vertex 1.19144 2.75326 0
+      vertex 1.27734 2.71448 5
+      vertex 1.19144 2.75326 5
+    endloop
+  endfacet
+  facet normal -0.41152 -0.911401 -0
+    outer loop
+      vertex 1.27734 2.71448 5
+      vertex 1.19144 2.75326 0
+      vertex 1.27734 2.71448 0
+    endloop
+  endfacet
+  facet normal -0.600424 -0.799682 0
+    outer loop
+      vertex 1.76336 2.42705 0
+      vertex 1.83872 2.37046 5
+      vertex 1.76336 2.42705 5
+    endloop
+  endfacet
+  facet normal -0.600424 -0.799682 -0
+    outer loop
+      vertex 1.83872 2.37046 5
+      vertex 1.76336 2.42705 0
+      vertex 1.83872 2.37046 0
+    endloop
+  endfacet
+  facet normal -0.649449 -0.760405 0
+    outer loop
+      vertex 1.91227 2.31154 0
+      vertex 1.98394 2.25033 5
+      vertex 1.91227 2.31154 5
+    endloop
+  endfacet
+  facet normal -0.649449 -0.760405 -0
+    outer loop
+      vertex 1.98394 2.25033 5
+      vertex 1.91227 2.31154 0
+      vertex 1.98394 2.25033 0
+    endloop
+  endfacet
+  facet normal 0.99396 -0.109743 0
+    outer loop
+      vertex -2.98669 0.282325 5
+      vertex -2.97634 0.375999 0
+      vertex -2.97634 0.375999 5
+    endloop
+  endfacet
+  facet normal 0.99396 -0.109743 0
+    outer loop
+      vertex -2.97634 0.375999 0
+      vertex -2.98669 0.282325 5
+      vertex -2.98669 0.282325 0
+    endloop
+  endfacet
+  facet normal 0.760405 -0.649449 0
+    outer loop
+      vertex -2.31154 1.91227 5
+      vertex -2.25033 1.98394 0
+      vertex -2.25033 1.98394 5
+    endloop
+  endfacet
+  facet normal 0.760405 -0.649449 0
+    outer loop
+      vertex -2.25033 1.98394 0
+      vertex -2.31154 1.91227 5
+      vertex -2.31154 1.91227 0
+    endloop
+  endfacet
+  facet normal 0.86863 -0.495461 0
+    outer loop
+      vertex -2.62892 1.44526 5
+      vertex -2.58223 1.52712 0
+      vertex -2.58223 1.52712 5
+    endloop
+  endfacet
+  facet normal 0.86863 -0.495461 0
+    outer loop
+      vertex -2.58223 1.52712 0
+      vertex -2.62892 1.44526 5
+      vertex -2.62892 1.44526 0
+    endloop
+  endfacet
+  facet normal 0.883766 -0.46793 0
+    outer loop
+      vertex -2.67302 1.36197 5
+      vertex -2.62892 1.44526 0
+      vertex -2.62892 1.44526 5
+    endloop
+  endfacet
+  facet normal 0.883766 -0.46793 0
+    outer loop
+      vertex -2.62892 1.44526 0
+      vertex -2.67302 1.36197 5
+      vertex -2.67302 1.36197 0
+    endloop
+  endfacet
+  facet normal 0.852638 -0.522502 0
+    outer loop
+      vertex -2.58223 1.52712 5
+      vertex -2.53298 1.60748 0
+      vertex -2.53298 1.60748 5
+    endloop
+  endfacet
+  facet normal 0.852638 -0.522502 0
+    outer loop
+      vertex -2.53298 1.60748 0
+      vertex -2.58223 1.52712 5
+      vertex -2.58223 1.52712 0
+    endloop
+  endfacet
+  facet normal 0.946083 -0.323925 0
+    outer loop
+      vertex -2.85317 0.927051 5
+      vertex -2.82264 1.01621 0
+      vertex -2.82264 1.01621 5
+    endloop
+  endfacet
+  facet normal 0.946083 -0.323925 0
+    outer loop
+      vertex -2.82264 1.01621 0
+      vertex -2.85317 0.927051 5
+      vertex -2.85317 0.927051 0
+    endloop
+  endfacet
+  facet normal 0.923882 -0.382677 0
+    outer loop
+      vertex -2.78933 1.10437 5
+      vertex -2.75326 1.19144 0
+      vertex -2.75326 1.19144 5
+    endloop
+  endfacet
+  facet normal 0.923882 -0.382677 0
+    outer loop
+      vertex -2.75326 1.19144 0
+      vertex -2.78933 1.10437 5
+      vertex -2.78933 1.10437 0
+    endloop
+  endfacet
+  facet normal 0.98511 -0.171926 0
+    outer loop
+      vertex -2.96306 0.469303 5
+      vertex -2.94686 0.562143 0
+      vertex -2.94686 0.562143 5
+    endloop
+  endfacet
+  facet normal 0.98511 -0.171926 0
+    outer loop
+      vertex -2.94686 0.562143 0
+      vertex -2.96306 0.469303 5
+      vertex -2.96306 0.469303 0
+    endloop
+  endfacet
+  facet normal 0.996918 -0.0784537 0
+    outer loop
+      vertex -2.99408 0.188371 5
+      vertex -2.98669 0.282325 0
+      vertex -2.98669 0.282325 5
+    endloop
+  endfacet
+  facet normal 0.996918 -0.0784537 0
+    outer loop
+      vertex -2.98669 0.282325 0
+      vertex -2.99408 0.188371 5
+      vertex -2.99408 0.188371 0
+    endloop
+  endfacet
+  facet normal 0.625237 -0.780435 0
+    outer loop
+      vertex -1.91227 2.31154 0
+      vertex -1.83872 2.37046 5
+      vertex -1.91227 2.31154 5
+    endloop
+  endfacet
+  facet normal 0.625237 -0.780435 0
+    outer loop
+      vertex -1.83872 2.37046 5
+      vertex -1.91227 2.31154 0
+      vertex -1.83872 2.37046 0
+    endloop
+  endfacet
+  facet normal 0.46793 -0.883766 0
+    outer loop
+      vertex -1.44526 2.62892 0
+      vertex -1.36197 2.67302 5
+      vertex -1.44526 2.62892 5
+    endloop
+  endfacet
+  facet normal 0.46793 -0.883766 0
+    outer loop
+      vertex -1.36197 2.67302 5
+      vertex -1.44526 2.62892 0
+      vertex -1.36197 2.67302 0
+    endloop
+  endfacet
+  facet normal 0.495461 -0.86863 0
+    outer loop
+      vertex -1.52712 2.58223 0
+      vertex -1.44526 2.62892 5
+      vertex -1.52712 2.58223 5
+    endloop
+  endfacet
+  facet normal 0.495461 -0.86863 0
+    outer loop
+      vertex -1.44526 2.62892 5
+      vertex -1.52712 2.58223 0
+      vertex -1.44526 2.62892 0
+    endloop
+  endfacet
+  facet normal 0.575005 -0.81815 0
+    outer loop
+      vertex -1.76336 2.42705 0
+      vertex -1.68625 2.48124 5
+      vertex -1.76336 2.42705 5
+    endloop
+  endfacet
+  facet normal 0.575005 -0.81815 0
+    outer loop
+      vertex -1.68625 2.48124 5
+      vertex -1.76336 2.42705 0
+      vertex -1.68625 2.48124 0
+    endloop
+  endfacet
+  facet normal 0.649449 -0.760405 0
+    outer loop
+      vertex -1.98394 2.25033 0
+      vertex -1.91227 2.31154 5
+      vertex -1.98394 2.25033 5
+    endloop
+  endfacet
+  facet normal 0.649449 -0.760405 0
+    outer loop
+      vertex -1.91227 2.31154 5
+      vertex -1.98394 2.25033 0
+      vertex -1.91227 2.31154 0
+    endloop
+  endfacet
+  facet normal 0.294035 -0.955795 0
+    outer loop
+      vertex -0.927051 2.85317 0
+      vertex -0.836973 2.88088 5
+      vertex -0.927051 2.85317 5
+    endloop
+  endfacet
+  facet normal 0.294035 -0.955795 0
+    outer loop
+      vertex -0.836973 2.88088 5
+      vertex -0.927051 2.85317 0
+      vertex -0.836973 2.88088 0
+    endloop
+  endfacet
+  facet normal 0.047105 -0.99889 0
+    outer loop
+      vertex -0.188371 2.99408 0
+      vertex -0.0942316 2.99852 5
+      vertex -0.188371 2.99408 5
+    endloop
+  endfacet
+  facet normal 0.047105 -0.99889 0
+    outer loop
+      vertex -0.0942316 2.99852 5
+      vertex -0.188371 2.99408 0
+      vertex -0.0942316 2.99852 0
+    endloop
+  endfacet
+  facet normal -0.649449 0.760405 0
+    outer loop
+      vertex 1.98394 -2.25033 0
+      vertex 1.91227 -2.31154 5
+      vertex 1.98394 -2.25033 5
+    endloop
+  endfacet
+  facet normal -0.649449 0.760405 0
+    outer loop
+      vertex 1.91227 -2.31154 5
+      vertex 1.98394 -2.25033 0
+      vertex 1.91227 -2.31154 0
+    endloop
+  endfacet
+  facet normal -0.673014 0.73963 0
+    outer loop
+      vertex 2.05364 -2.18691 0
+      vertex 1.98394 -2.25033 5
+      vertex 2.05364 -2.18691 5
+    endloop
+  endfacet
+  facet normal -0.673014 0.73963 0
+    outer loop
+      vertex 1.98394 -2.25033 5
+      vertex 2.05364 -2.18691 0
+      vertex 1.98394 -2.25033 0
+    endloop
+  endfacet
+  facet normal -0.911401 0.41152 0
+    outer loop
+      vertex 2.71448 -1.27734 0
+      vertex 2.75326 -1.19144 5
+      vertex 2.75326 -1.19144 0
+    endloop
+  endfacet
+  facet normal -0.911401 0.41152 0
+    outer loop
+      vertex 2.75326 -1.19144 5
+      vertex 2.71448 -1.27734 0
+      vertex 2.71448 -1.27734 5
+    endloop
+  endfacet
+  facet normal -0.946083 0.323925 0
+    outer loop
+      vertex 2.82264 -1.01621 0
+      vertex 2.85317 -0.927051 5
+      vertex 2.85317 -0.927051 0
+    endloop
+  endfacet
+  facet normal -0.946083 0.323925 0
+    outer loop
+      vertex 2.85317 -0.927051 5
+      vertex 2.82264 -1.01621 0
+      vertex 2.82264 -1.01621 5
+    endloop
+  endfacet
+  facet normal 0.649449 0.760405 -0
+    outer loop
+      vertex -1.91227 -2.31154 0
+      vertex -1.98394 -2.25033 5
+      vertex -1.91227 -2.31154 5
+    endloop
+  endfacet
+  facet normal 0.649449 0.760405 0
+    outer loop
+      vertex -1.98394 -2.25033 5
+      vertex -1.91227 -2.31154 0
+      vertex -1.98394 -2.25033 0
+    endloop
+  endfacet
+  facet normal 0.46793 0.883766 -0
+    outer loop
+      vertex -1.36197 -2.67302 0
+      vertex -1.44526 -2.62892 5
+      vertex -1.36197 -2.67302 5
+    endloop
+  endfacet
+  facet normal 0.46793 0.883766 0
+    outer loop
+      vertex -1.44526 -2.62892 5
+      vertex -1.36197 -2.67302 0
+      vertex -1.44526 -2.62892 0
+    endloop
+  endfacet
+  facet normal 0.495461 0.86863 -0
+    outer loop
+      vertex -1.44526 -2.62892 0
+      vertex -1.52712 -2.58223 5
+      vertex -1.44526 -2.62892 5
+    endloop
+  endfacet
+  facet normal 0.495461 0.86863 0
+    outer loop
+      vertex -1.52712 -2.58223 5
+      vertex -1.44526 -2.62892 0
+      vertex -1.52712 -2.58223 0
+    endloop
+  endfacet
+  facet normal 0.382677 0.923882 -0
+    outer loop
+      vertex -1.10437 -2.78933 0
+      vertex -1.19144 -2.75326 5
+      vertex -1.10437 -2.78933 5
+    endloop
+  endfacet
+  facet normal 0.382677 0.923882 0
+    outer loop
+      vertex -1.19144 -2.75326 5
+      vertex -1.10437 -2.78933 0
+      vertex -1.19144 -2.75326 0
+    endloop
+  endfacet
+  facet normal 0.109743 0.99396 -0
+    outer loop
+      vertex -0.282325 -2.98669 0
+      vertex -0.375999 -2.97634 5
+      vertex -0.282325 -2.98669 5
+    endloop
+  endfacet
+  facet normal 0.109743 0.99396 0
+    outer loop
+      vertex -0.375999 -2.97634 5
+      vertex -0.282325 -2.98669 0
+      vertex -0.375999 -2.97634 0
+    endloop
+  endfacet
+  facet normal 0.171926 0.98511 -0
+    outer loop
+      vertex -0.469303 -2.96306 0
+      vertex -0.562143 -2.94686 5
+      vertex -0.469303 -2.96306 5
+    endloop
+  endfacet
+  facet normal 0.171926 0.98511 0
+    outer loop
+      vertex -0.562143 -2.94686 5
+      vertex -0.469303 -2.96306 0
+      vertex -0.562143 -2.94686 0
+    endloop
+  endfacet
+  facet normal 0.0784537 0.996918 -0
+    outer loop
+      vertex -0.188371 -2.99408 0
+      vertex -0.282325 -2.98669 5
+      vertex -0.188371 -2.99408 5
+    endloop
+  endfacet
+  facet normal 0.0784537 0.996918 0
+    outer loop
+      vertex -0.282325 -2.98669 5
+      vertex -0.188371 -2.99408 0
+      vertex -0.282325 -2.98669 0
+    endloop
+  endfacet
+  facet normal 0.780435 0.625237 0
+    outer loop
+      vertex -2.31154 -1.91227 5
+      vertex -2.37046 -1.83872 0
+      vertex -2.37046 -1.83872 5
+    endloop
+  endfacet
+  facet normal 0.780435 0.625237 0
+    outer loop
+      vertex -2.37046 -1.83872 0
+      vertex -2.31154 -1.91227 5
+      vertex -2.31154 -1.91227 0
+    endloop
+  endfacet
+  facet normal 0.883766 0.46793 0
+    outer loop
+      vertex -2.62892 -1.44526 5
+      vertex -2.67302 -1.36197 0
+      vertex -2.67302 -1.36197 5
+    endloop
+  endfacet
+  facet normal 0.883766 0.46793 0
+    outer loop
+      vertex -2.67302 -1.36197 0
+      vertex -2.62892 -1.44526 5
+      vertex -2.62892 -1.44526 0
+    endloop
+  endfacet
+  facet normal 0.81815 0.575005 0
+    outer loop
+      vertex -2.42705 -1.76336 5
+      vertex -2.48124 -1.68625 0
+      vertex -2.48124 -1.68625 5
+    endloop
+  endfacet
+  facet normal 0.81815 0.575005 0
+    outer loop
+      vertex -2.48124 -1.68625 0
+      vertex -2.42705 -1.76336 5
+      vertex -2.42705 -1.76336 0
+    endloop
+  endfacet
+  facet normal 0.760405 0.649449 0
+    outer loop
+      vertex -2.25033 -1.98394 5
+      vertex -2.31154 -1.91227 0
+      vertex -2.31154 -1.91227 5
+    endloop
+  endfacet
+  facet normal 0.760405 0.649449 0
+    outer loop
+      vertex -2.31154 -1.91227 0
+      vertex -2.25033 -1.98394 5
+      vertex -2.25033 -1.98394 0
+    endloop
+  endfacet
+  facet normal 0.98511 0.171926 0
+    outer loop
+      vertex -2.94686 -0.562143 5
+      vertex -2.96306 -0.469303 0
+      vertex -2.96306 -0.469303 5
+    endloop
+  endfacet
+  facet normal 0.98511 0.171926 0
+    outer loop
+      vertex -2.96306 -0.469303 0
+      vertex -2.94686 -0.562143 5
+      vertex -2.94686 -0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.5 0 0
+      vertex 3 0 0
+      vertex 2.99852 0.0942316 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.49926 0.0471153 0
+      vertex 2.99852 0.0942316 0
+      vertex 2.99408 0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 3 0 0
+      vertex 1.5 0 0
+      vertex 2.99852 -0.0942316 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.49704 0.0941849 0
+      vertex 2.99408 0.188371 0
+      vertex 2.98669 0.282325 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49926 -0.0471153 0
+      vertex 2.99852 -0.0942316 0
+      vertex 1.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.49334 0.141162 0
+      vertex 2.98669 0.282325 0
+      vertex 2.97634 0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.99852 -0.0942316 0
+      vertex 1.49926 -0.0471153 0
+      vertex 2.99408 -0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.48817 0.188 0
+      vertex 2.97634 0.375999 0
+      vertex 2.96306 0.469303 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49704 -0.0941849 0
+      vertex 2.99408 -0.188371 0
+      vertex 1.49926 -0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.48153 0.234652 0
+      vertex 2.96306 0.469303 0
+      vertex 2.94686 0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.99408 -0.188371 0
+      vertex 1.49704 -0.0941849 0
+      vertex 2.98669 -0.282325 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.47343 0.281072 0
+      vertex 2.94686 0.562143 0
+      vertex 2.92775 0.654429 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.49334 -0.141162 0
+      vertex 2.98669 -0.282325 0
+      vertex 1.49704 -0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.46387 0.327214 0
+      vertex 2.92775 0.654429 0
+      vertex 2.90575 0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98669 -0.282325 0
+      vertex 1.49334 -0.141162 0
+      vertex 2.97634 -0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.45287 0.373034 0
+      vertex 2.90575 0.746069 0
+      vertex 2.88088 0.836973 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.48817 -0.188 0
+      vertex 2.97634 -0.375999 0
+      vertex 1.49334 -0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.44044 0.418487 0
+      vertex 2.88088 0.836973 0
+      vertex 2.85317 0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.97634 -0.375999 0
+      vertex 1.48817 -0.188 0
+      vertex 2.96306 -0.469303 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.42658 0.463525 0
+      vertex 2.85317 0.927051 0
+      vertex 2.82264 1.01621 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.48153 -0.234652 0
+      vertex 2.96306 -0.469303 0
+      vertex 1.48817 -0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.41132 0.508106 0
+      vertex 2.82264 1.01621 0
+      vertex 2.78933 1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.96306 -0.469303 0
+      vertex 1.48153 -0.234652 0
+      vertex 2.94686 -0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.39466 0.552186 0
+      vertex 2.78933 1.10437 0
+      vertex 2.75326 1.19144 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.47343 -0.281072 0
+      vertex 2.94686 -0.562143 0
+      vertex 1.48153 -0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.37663 0.595721 0
+      vertex 2.75326 1.19144 0
+      vertex 2.71448 1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.94686 -0.562143 0
+      vertex 1.47343 -0.281072 0
+      vertex 2.92775 -0.654429 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.35724 0.638668 0
+      vertex 2.71448 1.27734 0
+      vertex 2.67302 1.36197 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.46387 -0.327214 0
+      vertex 2.92775 -0.654429 0
+      vertex 1.47343 -0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.33651 0.680985 0
+      vertex 2.67302 1.36197 0
+      vertex 2.62892 1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.92775 -0.654429 0
+      vertex 1.46387 -0.327214 0
+      vertex 2.90575 -0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.31446 0.722631 0
+      vertex 2.62892 1.44526 0
+      vertex 2.58223 1.52712 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.45287 -0.373034 0
+      vertex 2.90575 -0.746069 0
+      vertex 1.46387 -0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.29111 0.763561 0
+      vertex 2.58223 1.52712 0
+      vertex 2.53298 1.60748 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.90575 -0.746069 0
+      vertex 1.45287 -0.373034 0
+      vertex 2.88088 -0.836973 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.26649 0.80374 0
+      vertex 2.53298 1.60748 0
+      vertex 2.48124 1.68625 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.44044 -0.418487 0
+      vertex 2.88088 -0.836973 0
+      vertex 1.45287 -0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.24062 0.843124 0
+      vertex 2.48124 1.68625 0
+      vertex 2.42705 1.76336 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.88088 -0.836973 0
+      vertex 1.44044 -0.418487 0
+      vertex 2.85317 -0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.21352 0.881678 0
+      vertex 2.42705 1.76336 0
+      vertex 2.37046 1.83872 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.42658 -0.463525 0
+      vertex 2.85317 -0.927051 0
+      vertex 1.44044 -0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.18523 0.91936 0
+      vertex 2.37046 1.83872 0
+      vertex 2.31154 1.91227 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.85317 -0.927051 0
+      vertex 1.42658 -0.463525 0
+      vertex 2.82264 -1.01621 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.15577 0.956136 0
+      vertex 2.31154 1.91227 0
+      vertex 2.25033 1.98394 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.41132 -0.508106 0
+      vertex 2.82264 -1.01621 0
+      vertex 1.42658 -0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.12517 0.991967 0
+      vertex 2.25033 1.98394 0
+      vertex 2.18691 2.05364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.82264 -1.01621 0
+      vertex 1.41132 -0.508106 0
+      vertex 2.78933 -1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.09345 1.02682 0
+      vertex 2.18691 2.05364 0
+      vertex 2.12132 2.12132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.39466 -0.552186 0
+      vertex 2.78933 -1.10437 0
+      vertex 1.41132 -0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.06066 1.06066 0
+      vertex 2.12132 2.12132 0
+      vertex 2.05364 2.18691 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.78933 -1.10437 0
+      vertex 1.39466 -0.552186 0
+      vertex 2.75326 -1.19144 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.02682 1.09345 0
+      vertex 2.05364 2.18691 0
+      vertex 1.98394 2.25033 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.37663 -0.595721 0
+      vertex 2.75326 -1.19144 0
+      vertex 1.39466 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.991967 1.12517 0
+      vertex 1.98394 2.25033 0
+      vertex 1.91227 2.31154 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.75326 -1.19144 0
+      vertex 1.37663 -0.595721 0
+      vertex 2.71448 -1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.956136 1.15577 0
+      vertex 1.91227 2.31154 0
+      vertex 1.83872 2.37046 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.35724 -0.638668 0
+      vertex 2.71448 -1.27734 0
+      vertex 1.37663 -0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.91936 1.18523 0
+      vertex 1.83872 2.37046 0
+      vertex 1.76336 2.42705 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.71448 -1.27734 0
+      vertex 1.35724 -0.638668 0
+      vertex 2.67302 -1.36197 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.881678 1.21352 0
+      vertex 1.76336 2.42705 0
+      vertex 1.68625 2.48124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.33651 -0.680985 0
+      vertex 2.67302 -1.36197 0
+      vertex 1.35724 -0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.843124 1.24062 0
+      vertex 1.68625 2.48124 0
+      vertex 1.60748 2.53298 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.67302 -1.36197 0
+      vertex 1.33651 -0.680985 0
+      vertex 2.62892 -1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.80374 1.26649 0
+      vertex 1.60748 2.53298 0
+      vertex 1.52712 2.58223 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.31446 -0.722631 0
+      vertex 2.62892 -1.44526 0
+      vertex 1.33651 -0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.62892 -1.44526 0
+      vertex 1.31446 -0.722631 0
+      vertex 2.58223 -1.52712 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.99852 0.0942316 0
+      vertex 1.49926 0.0471153 0
+      vertex 1.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.99408 0.188371 0
+      vertex 1.49704 0.0941849 0
+      vertex 1.49926 0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.98669 0.282325 0
+      vertex 1.49334 0.141162 0
+      vertex 1.49704 0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.97634 0.375999 0
+      vertex 1.48817 0.188 0
+      vertex 1.49334 0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.96306 0.469303 0
+      vertex 1.48153 0.234652 0
+      vertex 1.48817 0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.94686 0.562143 0
+      vertex 1.47343 0.281072 0
+      vertex 1.48153 0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.92775 0.654429 0
+      vertex 1.46387 0.327214 0
+      vertex 1.47343 0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.90575 0.746069 0
+      vertex 1.45287 0.373034 0
+      vertex 1.46387 0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.763561 1.29111 0
+      vertex 1.52712 2.58223 0
+      vertex 1.44526 2.62892 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.88088 0.836973 0
+      vertex 1.44044 0.418487 0
+      vertex 1.45287 0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.85317 0.927051 0
+      vertex 1.42658 0.463525 0
+      vertex 1.44044 0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.82264 1.01621 0
+      vertex 1.41132 0.508106 0
+      vertex 1.42658 0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.78933 1.10437 0
+      vertex 1.39466 0.552186 0
+      vertex 1.41132 0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.75326 1.19144 0
+      vertex 1.37663 0.595721 0
+      vertex 1.39466 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.722631 1.31446 0
+      vertex 1.44526 2.62892 0
+      vertex 1.36197 2.67302 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.71448 1.27734 0
+      vertex 1.35724 0.638668 0
+      vertex 1.37663 0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.67302 1.36197 0
+      vertex 1.33651 0.680985 0
+      vertex 1.35724 0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.62892 1.44526 0
+      vertex 1.31446 0.722631 0
+      vertex 1.33651 0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.58223 1.52712 0
+      vertex 1.29111 0.763561 0
+      vertex 1.31446 0.722631 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.680985 1.33651 0
+      vertex 1.36197 2.67302 0
+      vertex 1.27734 2.71448 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.53298 1.60748 0
+      vertex 1.26649 0.80374 0
+      vertex 1.29111 0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.48124 1.68625 0
+      vertex 1.24062 0.843124 0
+      vertex 1.26649 0.80374 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.42705 1.76336 0
+      vertex 1.21352 0.881678 0
+      vertex 1.24062 0.843124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.638668 1.35724 0
+      vertex 1.27734 2.71448 0
+      vertex 1.19144 2.75326 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37046 1.83872 0
+      vertex 1.18523 0.91936 0
+      vertex 1.21352 0.881678 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.31154 1.91227 0
+      vertex 1.15577 0.956136 0
+      vertex 1.18523 0.91936 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25033 1.98394 0
+      vertex 1.12517 0.991967 0
+      vertex 1.15577 0.956136 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.595721 1.37663 0
+      vertex 1.19144 2.75326 0
+      vertex 1.10437 2.78933 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.18691 2.05364 0
+      vertex 1.09345 1.02682 0
+      vertex 1.12517 0.991967 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.12132 2.12132 0
+      vertex 1.06066 1.06066 0
+      vertex 1.09345 1.02682 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.05364 2.18691 0
+      vertex 1.02682 1.09345 0
+      vertex 1.06066 1.06066 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.552186 1.39466 0
+      vertex 1.10437 2.78933 0
+      vertex 1.01621 2.82264 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.98394 2.25033 0
+      vertex 0.991967 1.12517 0
+      vertex 1.02682 1.09345 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.91227 2.31154 0
+      vertex 0.956136 1.15577 0
+      vertex 0.991967 1.12517 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.508106 1.41132 0
+      vertex 1.01621 2.82264 0
+      vertex 0.927051 2.85317 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.83872 2.37046 0
+      vertex 0.91936 1.18523 0
+      vertex 0.956136 1.15577 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.76336 2.42705 0
+      vertex 0.881678 1.21352 0
+      vertex 0.91936 1.18523 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.68625 2.48124 0
+      vertex 0.843124 1.24062 0
+      vertex 0.881678 1.21352 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.463525 1.42658 0
+      vertex 0.927051 2.85317 0
+      vertex 0.836973 2.88088 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.60748 2.53298 0
+      vertex 0.80374 1.26649 0
+      vertex 0.843124 1.24062 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.52712 2.58223 0
+      vertex 0.763561 1.29111 0
+      vertex 0.80374 1.26649 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.418487 1.44044 0
+      vertex 0.836973 2.88088 0
+      vertex 0.746069 2.90575 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.44526 2.62892 0
+      vertex 0.722631 1.31446 0
+      vertex 0.763561 1.29111 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.36197 2.67302 0
+      vertex 0.680985 1.33651 0
+      vertex 0.722631 1.31446 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.373034 1.45287 0
+      vertex 0.746069 2.90575 0
+      vertex 0.654429 2.92775 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.27734 2.71448 0
+      vertex 0.638668 1.35724 0
+      vertex 0.680985 1.33651 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.19144 2.75326 0
+      vertex 0.595721 1.37663 0
+      vertex 0.638668 1.35724 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.327214 1.46387 0
+      vertex 0.654429 2.92775 0
+      vertex 0.562143 2.94686 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.10437 2.78933 0
+      vertex 0.552186 1.39466 0
+      vertex 0.595721 1.37663 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.01621 2.82264 0
+      vertex 0.508106 1.41132 0
+      vertex 0.552186 1.39466 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.281072 1.47343 0
+      vertex 0.562143 2.94686 0
+      vertex 0.469303 2.96306 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.927051 2.85317 0
+      vertex 0.463525 1.42658 0
+      vertex 0.508106 1.41132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.836973 2.88088 0
+      vertex 0.418487 1.44044 0
+      vertex 0.463525 1.42658 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.234652 1.48153 0
+      vertex 0.469303 2.96306 0
+      vertex 0.375999 2.97634 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.746069 2.90575 0
+      vertex 0.373034 1.45287 0
+      vertex 0.418487 1.44044 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.654429 2.92775 0
+      vertex 0.327214 1.46387 0
+      vertex 0.373034 1.45287 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.188 1.48817 0
+      vertex 0.375999 2.97634 0
+      vertex 0.282325 2.98669 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.562143 2.94686 0
+      vertex 0.281072 1.47343 0
+      vertex 0.327214 1.46387 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.469303 2.96306 0
+      vertex 0.234652 1.48153 0
+      vertex 0.281072 1.47343 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.141162 1.49334 0
+      vertex 0.282325 2.98669 0
+      vertex 0.188371 2.99408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.375999 2.97634 0
+      vertex 0.188 1.48817 0
+      vertex 0.234652 1.48153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.282325 2.98669 0
+      vertex 0.141162 1.49334 0
+      vertex 0.188 1.48817 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.0941849 1.49704 0
+      vertex 0.188371 2.99408 0
+      vertex 0.0942316 2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.188371 2.99408 0
+      vertex 0.0941849 1.49704 0
+      vertex 0.141162 1.49334 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.0942316 2.99852 0
+      vertex 0.0471153 1.49926 0
+      vertex 0.0941849 1.49704 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 3 0
+      vertex 0.0471153 1.49926 0
+      vertex 0.0942316 2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 3 0
+      vertex 0 1.5 0
+      vertex 0.0471153 1.49926 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 3 0
+      vertex -0.0471153 1.49926 0
+      vertex 0 1.5 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.0942316 2.99852 0
+      vertex -0.0471153 1.49926 0
+      vertex 0 3 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0471153 1.49926 0
+      vertex -0.0942316 2.99852 0
+      vertex -0.0941849 1.49704 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.188371 2.99408 0
+      vertex -0.0941849 1.49704 0
+      vertex -0.0942316 2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0941849 1.49704 0
+      vertex -0.188371 2.99408 0
+      vertex -0.141162 1.49334 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.282325 2.98669 0
+      vertex -0.141162 1.49334 0
+      vertex -0.188371 2.99408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.141162 1.49334 0
+      vertex -0.282325 2.98669 0
+      vertex -0.188 1.48817 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.375999 2.97634 0
+      vertex -0.188 1.48817 0
+      vertex -0.282325 2.98669 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.188 1.48817 0
+      vertex -0.375999 2.97634 0
+      vertex -0.234652 1.48153 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.469303 2.96306 0
+      vertex -0.234652 1.48153 0
+      vertex -0.375999 2.97634 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.234652 1.48153 0
+      vertex -0.469303 2.96306 0
+      vertex -0.281072 1.47343 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.562143 2.94686 0
+      vertex -0.281072 1.47343 0
+      vertex -0.469303 2.96306 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.281072 1.47343 0
+      vertex -0.562143 2.94686 0
+      vertex -0.327214 1.46387 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.654429 2.92775 0
+      vertex -0.327214 1.46387 0
+      vertex -0.562143 2.94686 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.327214 1.46387 0
+      vertex -0.654429 2.92775 0
+      vertex -0.373034 1.45287 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.746069 2.90575 0
+      vertex -0.373034 1.45287 0
+      vertex -0.654429 2.92775 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.373034 1.45287 0
+      vertex -0.746069 2.90575 0
+      vertex -0.418487 1.44044 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.836973 2.88088 0
+      vertex -0.418487 1.44044 0
+      vertex -0.746069 2.90575 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.418487 1.44044 0
+      vertex -0.836973 2.88088 0
+      vertex -0.463525 1.42658 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -0.927051 2.85317 0
+      vertex -0.463525 1.42658 0
+      vertex -0.836973 2.88088 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.463525 1.42658 0
+      vertex -0.927051 2.85317 0
+      vertex -0.508106 1.41132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.01621 2.82264 0
+      vertex -0.508106 1.41132 0
+      vertex -0.927051 2.85317 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.508106 1.41132 0
+      vertex -1.01621 2.82264 0
+      vertex -0.552186 1.39466 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.10437 2.78933 0
+      vertex -0.552186 1.39466 0
+      vertex -1.01621 2.82264 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.552186 1.39466 0
+      vertex -1.10437 2.78933 0
+      vertex -0.595721 1.37663 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.19144 2.75326 0
+      vertex -0.595721 1.37663 0
+      vertex -1.10437 2.78933 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.595721 1.37663 0
+      vertex -1.19144 2.75326 0
+      vertex -0.638668 1.35724 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.27734 2.71448 0
+      vertex -0.638668 1.35724 0
+      vertex -1.19144 2.75326 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.638668 1.35724 0
+      vertex -1.27734 2.71448 0
+      vertex -0.680985 1.33651 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.36197 2.67302 0
+      vertex -0.680985 1.33651 0
+      vertex -1.27734 2.71448 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.680985 1.33651 0
+      vertex -1.36197 2.67302 0
+      vertex -0.722631 1.31446 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.44526 2.62892 0
+      vertex -0.722631 1.31446 0
+      vertex -1.36197 2.67302 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.722631 1.31446 0
+      vertex -1.44526 2.62892 0
+      vertex -0.763561 1.29111 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.52712 2.58223 0
+      vertex -0.763561 1.29111 0
+      vertex -1.44526 2.62892 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.763561 1.29111 0
+      vertex -1.52712 2.58223 0
+      vertex -0.80374 1.26649 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.60748 2.53298 0
+      vertex -0.80374 1.26649 0
+      vertex -1.52712 2.58223 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.80374 1.26649 0
+      vertex -1.60748 2.53298 0
+      vertex -0.843124 1.24062 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.68625 2.48124 0
+      vertex -0.843124 1.24062 0
+      vertex -1.60748 2.53298 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.843124 1.24062 0
+      vertex -1.68625 2.48124 0
+      vertex -0.881678 1.21352 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.76336 2.42705 0
+      vertex -0.881678 1.21352 0
+      vertex -1.68625 2.48124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.881678 1.21352 0
+      vertex -1.76336 2.42705 0
+      vertex -0.91936 1.18523 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.83872 2.37046 0
+      vertex -0.91936 1.18523 0
+      vertex -1.76336 2.42705 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.91936 1.18523 0
+      vertex -1.83872 2.37046 0
+      vertex -0.956136 1.15577 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.91227 2.31154 0
+      vertex -0.956136 1.15577 0
+      vertex -1.83872 2.37046 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.956136 1.15577 0
+      vertex -1.91227 2.31154 0
+      vertex -0.991967 1.12517 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -1.98394 2.25033 0
+      vertex -0.991967 1.12517 0
+      vertex -1.91227 2.31154 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.991967 1.12517 0
+      vertex -1.98394 2.25033 0
+      vertex -1.02682 1.09345 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.05364 2.18691 0
+      vertex -1.02682 1.09345 0
+      vertex -1.98394 2.25033 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.02682 1.09345 0
+      vertex -2.05364 2.18691 0
+      vertex -1.06066 1.06066 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.12132 2.12132 0
+      vertex -1.06066 1.06066 0
+      vertex -2.05364 2.18691 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 1.06066 0
+      vertex -2.12132 2.12132 0
+      vertex -1.09345 1.02682 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.18691 2.05364 0
+      vertex -1.09345 1.02682 0
+      vertex -2.12132 2.12132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09345 1.02682 0
+      vertex -2.18691 2.05364 0
+      vertex -1.12517 0.991967 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.25033 1.98394 0
+      vertex -1.12517 0.991967 0
+      vertex -2.18691 2.05364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.12517 0.991967 0
+      vertex -2.25033 1.98394 0
+      vertex -1.15577 0.956136 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.31154 1.91227 0
+      vertex -1.15577 0.956136 0
+      vertex -2.25033 1.98394 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15577 0.956136 0
+      vertex -2.31154 1.91227 0
+      vertex -1.18523 0.91936 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.37046 1.83872 0
+      vertex -1.18523 0.91936 0
+      vertex -2.31154 1.91227 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.18523 0.91936 0
+      vertex -2.37046 1.83872 0
+      vertex -1.21352 0.881678 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.42705 1.76336 0
+      vertex -1.21352 0.881678 0
+      vertex -2.37046 1.83872 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.21352 0.881678 0
+      vertex -2.42705 1.76336 0
+      vertex -1.24062 0.843124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.48124 1.68625 0
+      vertex -1.24062 0.843124 0
+      vertex -2.42705 1.76336 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.24062 0.843124 0
+      vertex -2.48124 1.68625 0
+      vertex -1.26649 0.80374 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.53298 1.60748 0
+      vertex -1.26649 0.80374 0
+      vertex -2.48124 1.68625 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.26649 0.80374 0
+      vertex -2.53298 1.60748 0
+      vertex -1.29111 0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.29111 0.763561 0
+      vertex -2.58223 1.52712 0
+      vertex -1.31446 0.722631 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.58223 1.52712 0
+      vertex -1.29111 0.763561 0
+      vertex -2.53298 1.60748 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.29111 -0.763561 0
+      vertex 2.58223 -1.52712 0
+      vertex 1.31446 -0.722631 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.58223 -1.52712 0
+      vertex 1.29111 -0.763561 0
+      vertex 2.53298 -1.60748 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.26649 -0.80374 0
+      vertex 2.53298 -1.60748 0
+      vertex 1.29111 -0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.53298 -1.60748 0
+      vertex 1.26649 -0.80374 0
+      vertex 2.48124 -1.68625 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.24062 -0.843124 0
+      vertex 2.48124 -1.68625 0
+      vertex 1.26649 -0.80374 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.48124 -1.68625 0
+      vertex 1.24062 -0.843124 0
+      vertex 2.42705 -1.76336 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.21352 -0.881678 0
+      vertex 2.42705 -1.76336 0
+      vertex 1.24062 -0.843124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.42705 -1.76336 0
+      vertex 1.21352 -0.881678 0
+      vertex 2.37046 -1.83872 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.18523 -0.91936 0
+      vertex 2.37046 -1.83872 0
+      vertex 1.21352 -0.881678 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.37046 -1.83872 0
+      vertex 1.18523 -0.91936 0
+      vertex 2.31154 -1.91227 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.15577 -0.956136 0
+      vertex 2.31154 -1.91227 0
+      vertex 1.18523 -0.91936 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.31154 -1.91227 0
+      vertex 1.15577 -0.956136 0
+      vertex 2.25033 -1.98394 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.12517 -0.991967 0
+      vertex 2.25033 -1.98394 0
+      vertex 1.15577 -0.956136 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.25033 -1.98394 0
+      vertex 1.12517 -0.991967 0
+      vertex 2.18691 -2.05364 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.09345 -1.02682 0
+      vertex 2.18691 -2.05364 0
+      vertex 1.12517 -0.991967 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.18691 -2.05364 0
+      vertex 1.09345 -1.02682 0
+      vertex 2.12132 -2.12132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.06066 -1.06066 0
+      vertex 2.12132 -2.12132 0
+      vertex 1.09345 -1.02682 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.12132 -2.12132 0
+      vertex 1.06066 -1.06066 0
+      vertex 2.05364 -2.18691 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 1.02682 -1.09345 0
+      vertex 2.05364 -2.18691 0
+      vertex 1.06066 -1.06066 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 2.05364 -2.18691 0
+      vertex 1.02682 -1.09345 0
+      vertex 1.98394 -2.25033 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.991967 -1.12517 0
+      vertex 1.98394 -2.25033 0
+      vertex 1.02682 -1.09345 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.98394 -2.25033 0
+      vertex 0.991967 -1.12517 0
+      vertex 1.91227 -2.31154 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.956136 -1.15577 0
+      vertex 1.91227 -2.31154 0
+      vertex 0.991967 -1.12517 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.91227 -2.31154 0
+      vertex 0.956136 -1.15577 0
+      vertex 1.83872 -2.37046 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.91936 -1.18523 0
+      vertex 1.83872 -2.37046 0
+      vertex 0.956136 -1.15577 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.83872 -2.37046 0
+      vertex 0.91936 -1.18523 0
+      vertex 1.76336 -2.42705 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.881678 -1.21352 0
+      vertex 1.76336 -2.42705 0
+      vertex 0.91936 -1.18523 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.76336 -2.42705 0
+      vertex 0.881678 -1.21352 0
+      vertex 1.68625 -2.48124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.843124 -1.24062 0
+      vertex 1.68625 -2.48124 0
+      vertex 0.881678 -1.21352 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.68625 -2.48124 0
+      vertex 0.843124 -1.24062 0
+      vertex 1.60748 -2.53298 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.80374 -1.26649 0
+      vertex 1.60748 -2.53298 0
+      vertex 0.843124 -1.24062 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.60748 -2.53298 0
+      vertex 0.80374 -1.26649 0
+      vertex 1.52712 -2.58223 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.763561 -1.29111 0
+      vertex 1.52712 -2.58223 0
+      vertex 0.80374 -1.26649 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.52712 -2.58223 0
+      vertex 0.763561 -1.29111 0
+      vertex 1.44526 -2.62892 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.722631 -1.31446 0
+      vertex 1.44526 -2.62892 0
+      vertex 0.763561 -1.29111 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.44526 -2.62892 0
+      vertex 0.722631 -1.31446 0
+      vertex 1.36197 -2.67302 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.680985 -1.33651 0
+      vertex 1.36197 -2.67302 0
+      vertex 0.722631 -1.31446 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.36197 -2.67302 0
+      vertex 0.680985 -1.33651 0
+      vertex 1.27734 -2.71448 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.638668 -1.35724 0
+      vertex 1.27734 -2.71448 0
+      vertex 0.680985 -1.33651 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.27734 -2.71448 0
+      vertex 0.638668 -1.35724 0
+      vertex 1.19144 -2.75326 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.595721 -1.37663 0
+      vertex 1.19144 -2.75326 0
+      vertex 0.638668 -1.35724 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.19144 -2.75326 0
+      vertex 0.595721 -1.37663 0
+      vertex 1.10437 -2.78933 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.552186 -1.39466 0
+      vertex 1.10437 -2.78933 0
+      vertex 0.595721 -1.37663 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.10437 -2.78933 0
+      vertex 0.552186 -1.39466 0
+      vertex 1.01621 -2.82264 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.508106 -1.41132 0
+      vertex 1.01621 -2.82264 0
+      vertex 0.552186 -1.39466 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 1.01621 -2.82264 0
+      vertex 0.508106 -1.41132 0
+      vertex 0.927051 -2.85317 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.463525 -1.42658 0
+      vertex 0.927051 -2.85317 0
+      vertex 0.508106 -1.41132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.927051 -2.85317 0
+      vertex 0.463525 -1.42658 0
+      vertex 0.836973 -2.88088 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.418487 -1.44044 0
+      vertex 0.836973 -2.88088 0
+      vertex 0.463525 -1.42658 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.836973 -2.88088 0
+      vertex 0.418487 -1.44044 0
+      vertex 0.746069 -2.90575 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.373034 -1.45287 0
+      vertex 0.746069 -2.90575 0
+      vertex 0.418487 -1.44044 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.746069 -2.90575 0
+      vertex 0.373034 -1.45287 0
+      vertex 0.654429 -2.92775 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.327214 -1.46387 0
+      vertex 0.654429 -2.92775 0
+      vertex 0.373034 -1.45287 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.654429 -2.92775 0
+      vertex 0.327214 -1.46387 0
+      vertex 0.562143 -2.94686 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.281072 -1.47343 0
+      vertex 0.562143 -2.94686 0
+      vertex 0.327214 -1.46387 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.562143 -2.94686 0
+      vertex 0.281072 -1.47343 0
+      vertex 0.469303 -2.96306 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.234652 -1.48153 0
+      vertex 0.469303 -2.96306 0
+      vertex 0.281072 -1.47343 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.469303 -2.96306 0
+      vertex 0.234652 -1.48153 0
+      vertex 0.375999 -2.97634 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.188 -1.48817 0
+      vertex 0.375999 -2.97634 0
+      vertex 0.234652 -1.48153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.375999 -2.97634 0
+      vertex 0.188 -1.48817 0
+      vertex 0.282325 -2.98669 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.141162 -1.49334 0
+      vertex 0.282325 -2.98669 0
+      vertex 0.188 -1.48817 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.282325 -2.98669 0
+      vertex 0.141162 -1.49334 0
+      vertex 0.188371 -2.99408 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.0941849 -1.49704 0
+      vertex 0.188371 -2.99408 0
+      vertex 0.141162 -1.49334 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0.188371 -2.99408 0
+      vertex 0.0941849 -1.49704 0
+      vertex 0.0942316 -2.99852 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0.0471153 -1.49926 0
+      vertex 0.0942316 -2.99852 0
+      vertex 0.0941849 -1.49704 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 0 -1.5 0
+      vertex 0.0942316 -2.99852 0
+      vertex 0.0471153 -1.49926 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 0 -1.5 0
+      vertex 0 -3 0
+      vertex 0.0942316 -2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0471153 -1.49926 0
+      vertex 0 -3 0
+      vertex 0 -1.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0942316 -2.99852 0
+      vertex -0.0471153 -1.49926 0
+      vertex -0.0941849 -1.49704 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0471153 -1.49926 0
+      vertex -0.0942316 -2.99852 0
+      vertex 0 -3 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.188371 -2.99408 0
+      vertex -0.0941849 -1.49704 0
+      vertex -0.141162 -1.49334 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.282325 -2.98669 0
+      vertex -0.141162 -1.49334 0
+      vertex -0.188 -1.48817 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.0941849 -1.49704 0
+      vertex -0.188371 -2.99408 0
+      vertex -0.0942316 -2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.375999 -2.97634 0
+      vertex -0.188 -1.48817 0
+      vertex -0.234652 -1.48153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.469303 -2.96306 0
+      vertex -0.234652 -1.48153 0
+      vertex -0.281072 -1.47343 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.141162 -1.49334 0
+      vertex -0.282325 -2.98669 0
+      vertex -0.188371 -2.99408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.562143 -2.94686 0
+      vertex -0.281072 -1.47343 0
+      vertex -0.327214 -1.46387 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.654429 -2.92775 0
+      vertex -0.327214 -1.46387 0
+      vertex -0.373034 -1.45287 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.188 -1.48817 0
+      vertex -0.375999 -2.97634 0
+      vertex -0.282325 -2.98669 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.746069 -2.90575 0
+      vertex -0.373034 -1.45287 0
+      vertex -0.418487 -1.44044 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.836973 -2.88088 0
+      vertex -0.418487 -1.44044 0
+      vertex -0.463525 -1.42658 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.234652 -1.48153 0
+      vertex -0.469303 -2.96306 0
+      vertex -0.375999 -2.97634 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.927051 -2.85317 0
+      vertex -0.463525 -1.42658 0
+      vertex -0.508106 -1.41132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.01621 -2.82264 0
+      vertex -0.508106 -1.41132 0
+      vertex -0.552186 -1.39466 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.281072 -1.47343 0
+      vertex -0.562143 -2.94686 0
+      vertex -0.469303 -2.96306 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.10437 -2.78933 0
+      vertex -0.552186 -1.39466 0
+      vertex -0.595721 -1.37663 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.19144 -2.75326 0
+      vertex -0.595721 -1.37663 0
+      vertex -0.638668 -1.35724 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.327214 -1.46387 0
+      vertex -0.654429 -2.92775 0
+      vertex -0.562143 -2.94686 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.27734 -2.71448 0
+      vertex -0.638668 -1.35724 0
+      vertex -0.680985 -1.33651 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.36197 -2.67302 0
+      vertex -0.680985 -1.33651 0
+      vertex -0.722631 -1.31446 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.373034 -1.45287 0
+      vertex -0.746069 -2.90575 0
+      vertex -0.654429 -2.92775 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44526 -2.62892 0
+      vertex -0.722631 -1.31446 0
+      vertex -0.763561 -1.29111 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.52712 -2.58223 0
+      vertex -0.763561 -1.29111 0
+      vertex -0.80374 -1.26649 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.418487 -1.44044 0
+      vertex -0.836973 -2.88088 0
+      vertex -0.746069 -2.90575 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.60748 -2.53298 0
+      vertex -0.80374 -1.26649 0
+      vertex -0.843124 -1.24062 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.68625 -2.48124 0
+      vertex -0.843124 -1.24062 0
+      vertex -0.881678 -1.21352 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.76336 -2.42705 0
+      vertex -0.881678 -1.21352 0
+      vertex -0.91936 -1.18523 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.463525 -1.42658 0
+      vertex -0.927051 -2.85317 0
+      vertex -0.836973 -2.88088 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.83872 -2.37046 0
+      vertex -0.91936 -1.18523 0
+      vertex -0.956136 -1.15577 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.91227 -2.31154 0
+      vertex -0.956136 -1.15577 0
+      vertex -0.991967 -1.12517 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.508106 -1.41132 0
+      vertex -1.01621 -2.82264 0
+      vertex -0.927051 -2.85317 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.98394 -2.25033 0
+      vertex -0.991967 -1.12517 0
+      vertex -1.02682 -1.09345 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.05364 -2.18691 0
+      vertex -1.02682 -1.09345 0
+      vertex -1.06066 -1.06066 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.12132 -2.12132 0
+      vertex -1.06066 -1.06066 0
+      vertex -1.09345 -1.02682 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.552186 -1.39466 0
+      vertex -1.10437 -2.78933 0
+      vertex -1.01621 -2.82264 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.18691 -2.05364 0
+      vertex -1.09345 -1.02682 0
+      vertex -1.12517 -0.991967 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.25033 -1.98394 0
+      vertex -1.12517 -0.991967 0
+      vertex -1.15577 -0.956136 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.31154 -1.91227 0
+      vertex -1.15577 -0.956136 0
+      vertex -1.18523 -0.91936 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.595721 -1.37663 0
+      vertex -1.19144 -2.75326 0
+      vertex -1.10437 -2.78933 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.37046 -1.83872 0
+      vertex -1.18523 -0.91936 0
+      vertex -1.21352 -0.881678 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.42705 -1.76336 0
+      vertex -1.21352 -0.881678 0
+      vertex -1.24062 -0.843124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.48124 -1.68625 0
+      vertex -1.24062 -0.843124 0
+      vertex -1.26649 -0.80374 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.638668 -1.35724 0
+      vertex -1.27734 -2.71448 0
+      vertex -1.19144 -2.75326 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.53298 -1.60748 0
+      vertex -1.26649 -0.80374 0
+      vertex -1.29111 -0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.58223 -1.52712 0
+      vertex -1.29111 -0.763561 0
+      vertex -1.31446 -0.722631 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.62892 -1.44526 0
+      vertex -1.31446 -0.722631 0
+      vertex -1.33651 -0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.67302 -1.36197 0
+      vertex -1.33651 -0.680985 0
+      vertex -1.35724 -0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.680985 -1.33651 0
+      vertex -1.36197 -2.67302 0
+      vertex -1.27734 -2.71448 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.71448 -1.27734 0
+      vertex -1.35724 -0.638668 0
+      vertex -1.37663 -0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.75326 -1.19144 0
+      vertex -1.37663 -0.595721 0
+      vertex -1.39466 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.78933 -1.10437 0
+      vertex -1.39466 -0.552186 0
+      vertex -1.41132 -0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.82264 -1.01621 0
+      vertex -1.41132 -0.508106 0
+      vertex -1.42658 -0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.85317 -0.927051 0
+      vertex -1.42658 -0.463525 0
+      vertex -1.44044 -0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.722631 -1.31446 0
+      vertex -1.44526 -2.62892 0
+      vertex -1.36197 -2.67302 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.88088 -0.836973 0
+      vertex -1.44044 -0.418487 0
+      vertex -1.45287 -0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.90575 -0.746069 0
+      vertex -1.45287 -0.373034 0
+      vertex -1.46387 -0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.92775 -0.654429 0
+      vertex -1.46387 -0.327214 0
+      vertex -1.47343 -0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.94686 -0.562143 0
+      vertex -1.47343 -0.281072 0
+      vertex -1.48153 -0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.96306 -0.469303 0
+      vertex -1.48153 -0.234652 0
+      vertex -1.48817 -0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.97634 -0.375999 0
+      vertex -1.48817 -0.188 0
+      vertex -1.49334 -0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.98669 -0.282325 0
+      vertex -1.49334 -0.141162 0
+      vertex -1.49704 -0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.99408 -0.188371 0
+      vertex -1.49704 -0.0941849 0
+      vertex -1.49926 -0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.763561 -1.29111 0
+      vertex -1.52712 -2.58223 0
+      vertex -1.44526 -2.62892 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -2.99852 -0.0942316 0
+      vertex -1.49926 -0.0471153 0
+      vertex -1.5 0 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.62892 1.44526 0
+      vertex -1.31446 0.722631 0
+      vertex -2.58223 1.52712 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.31446 0.722631 0
+      vertex -2.62892 1.44526 0
+      vertex -1.33651 0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.80374 -1.26649 0
+      vertex -1.60748 -2.53298 0
+      vertex -1.52712 -2.58223 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.67302 1.36197 0
+      vertex -1.33651 0.680985 0
+      vertex -2.62892 1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.843124 -1.24062 0
+      vertex -1.68625 -2.48124 0
+      vertex -1.60748 -2.53298 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.33651 0.680985 0
+      vertex -2.67302 1.36197 0
+      vertex -1.35724 0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.881678 -1.21352 0
+      vertex -1.76336 -2.42705 0
+      vertex -1.68625 -2.48124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.71448 1.27734 0
+      vertex -1.35724 0.638668 0
+      vertex -2.67302 1.36197 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.91936 -1.18523 0
+      vertex -1.83872 -2.37046 0
+      vertex -1.76336 -2.42705 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.35724 0.638668 0
+      vertex -2.71448 1.27734 0
+      vertex -1.37663 0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.956136 -1.15577 0
+      vertex -1.91227 -2.31154 0
+      vertex -1.83872 -2.37046 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.75326 1.19144 0
+      vertex -1.37663 0.595721 0
+      vertex -2.71448 1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -0.991967 -1.12517 0
+      vertex -1.98394 -2.25033 0
+      vertex -1.91227 -2.31154 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.37663 0.595721 0
+      vertex -2.75326 1.19144 0
+      vertex -1.39466 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.02682 -1.09345 0
+      vertex -2.05364 -2.18691 0
+      vertex -1.98394 -2.25033 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.78933 1.10437 0
+      vertex -1.39466 0.552186 0
+      vertex -2.75326 1.19144 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.06066 -1.06066 0
+      vertex -2.12132 -2.12132 0
+      vertex -2.05364 -2.18691 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.39466 0.552186 0
+      vertex -2.78933 1.10437 0
+      vertex -1.41132 0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.09345 -1.02682 0
+      vertex -2.18691 -2.05364 0
+      vertex -2.12132 -2.12132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.82264 1.01621 0
+      vertex -1.41132 0.508106 0
+      vertex -2.78933 1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.12517 -0.991967 0
+      vertex -2.25033 -1.98394 0
+      vertex -2.18691 -2.05364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.41132 0.508106 0
+      vertex -2.82264 1.01621 0
+      vertex -1.42658 0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.15577 -0.956136 0
+      vertex -2.31154 -1.91227 0
+      vertex -2.25033 -1.98394 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.85317 0.927051 0
+      vertex -1.42658 0.463525 0
+      vertex -2.82264 1.01621 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.18523 -0.91936 0
+      vertex -2.37046 -1.83872 0
+      vertex -2.31154 -1.91227 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.42658 0.463525 0
+      vertex -2.85317 0.927051 0
+      vertex -1.44044 0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.21352 -0.881678 0
+      vertex -2.42705 -1.76336 0
+      vertex -2.37046 -1.83872 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.88088 0.836973 0
+      vertex -1.44044 0.418487 0
+      vertex -2.85317 0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.24062 -0.843124 0
+      vertex -2.48124 -1.68625 0
+      vertex -2.42705 -1.76336 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44044 0.418487 0
+      vertex -2.88088 0.836973 0
+      vertex -1.45287 0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.26649 -0.80374 0
+      vertex -2.53298 -1.60748 0
+      vertex -2.48124 -1.68625 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.90575 0.746069 0
+      vertex -1.45287 0.373034 0
+      vertex -2.88088 0.836973 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.29111 -0.763561 0
+      vertex -2.58223 -1.52712 0
+      vertex -2.53298 -1.60748 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.45287 0.373034 0
+      vertex -2.90575 0.746069 0
+      vertex -1.46387 0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.31446 -0.722631 0
+      vertex -2.62892 -1.44526 0
+      vertex -2.58223 -1.52712 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.92775 0.654429 0
+      vertex -1.46387 0.327214 0
+      vertex -2.90575 0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.33651 -0.680985 0
+      vertex -2.67302 -1.36197 0
+      vertex -2.62892 -1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.46387 0.327214 0
+      vertex -2.92775 0.654429 0
+      vertex -1.47343 0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.35724 -0.638668 0
+      vertex -2.71448 -1.27734 0
+      vertex -2.67302 -1.36197 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.94686 0.562143 0
+      vertex -1.47343 0.281072 0
+      vertex -2.92775 0.654429 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.37663 -0.595721 0
+      vertex -2.75326 -1.19144 0
+      vertex -2.71448 -1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47343 0.281072 0
+      vertex -2.94686 0.562143 0
+      vertex -1.48153 0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.39466 -0.552186 0
+      vertex -2.78933 -1.10437 0
+      vertex -2.75326 -1.19144 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.96306 0.469303 0
+      vertex -1.48153 0.234652 0
+      vertex -2.94686 0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.41132 -0.508106 0
+      vertex -2.82264 -1.01621 0
+      vertex -2.78933 -1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.48153 0.234652 0
+      vertex -2.96306 0.469303 0
+      vertex -1.48817 0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.42658 -0.463525 0
+      vertex -2.85317 -0.927051 0
+      vertex -2.82264 -1.01621 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.97634 0.375999 0
+      vertex -1.48817 0.188 0
+      vertex -2.96306 0.469303 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.44044 -0.418487 0
+      vertex -2.88088 -0.836973 0
+      vertex -2.85317 -0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.48817 0.188 0
+      vertex -2.97634 0.375999 0
+      vertex -1.49334 0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.45287 -0.373034 0
+      vertex -2.90575 -0.746069 0
+      vertex -2.88088 -0.836973 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.98669 0.282325 0
+      vertex -1.49334 0.141162 0
+      vertex -2.97634 0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.46387 -0.327214 0
+      vertex -2.92775 -0.654429 0
+      vertex -2.90575 -0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49334 0.141162 0
+      vertex -2.98669 0.282325 0
+      vertex -1.49704 0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.47343 -0.281072 0
+      vertex -2.94686 -0.562143 0
+      vertex -2.92775 -0.654429 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.99408 0.188371 0
+      vertex -1.49704 0.0941849 0
+      vertex -2.98669 0.282325 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.48153 -0.234652 0
+      vertex -2.96306 -0.469303 0
+      vertex -2.94686 -0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49704 0.0941849 0
+      vertex -2.99408 0.188371 0
+      vertex -1.49926 0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.48817 -0.188 0
+      vertex -2.97634 -0.375999 0
+      vertex -2.96306 -0.469303 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex -2.99852 0.0942316 0
+      vertex -1.49926 0.0471153 0
+      vertex -2.99408 0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49334 -0.141162 0
+      vertex -2.98669 -0.282325 0
+      vertex -2.97634 -0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49926 0.0471153 0
+      vertex -2.99852 0.0942316 0
+      vertex -1.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49704 -0.0941849 0
+      vertex -2.99408 -0.188371 0
+      vertex -2.98669 -0.282325 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -3 0 0
+      vertex -1.5 0 0
+      vertex -2.99852 0.0942316 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.49926 -0.0471153 0
+      vertex -2.99852 -0.0942316 0
+      vertex -2.99408 -0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex -1.5 0 0
+      vertex -3 0 0
+      vertex -2.99852 -0.0942316 0
+    endloop
+  endfacet
+  facet normal -0.996918 -0.0784537 0
+    outer loop
+      vertex 2.99408 0.188371 0
+      vertex 2.98669 0.282325 5
+      vertex 2.98669 0.282325 0
+    endloop
+  endfacet
+  facet normal -0.996918 -0.0784537 0
+    outer loop
+      vertex 2.98669 0.282325 5
+      vertex 2.99408 0.188371 0
+      vertex 2.99408 0.188371 5
+    endloop
+  endfacet
+  facet normal -0.99889 -0.047105 0
+    outer loop
+      vertex 2.99852 0.0942316 0
+      vertex 2.99408 0.188371 5
+      vertex 2.99408 0.188371 0
+    endloop
+  endfacet
+  facet normal -0.99889 -0.047105 0
+    outer loop
+      vertex 2.99408 0.188371 5
+      vertex 2.99852 0.0942316 0
+      vertex 2.99852 0.0942316 5
+    endloop
+  endfacet
+  facet normal -0.990024 -0.1409 0
+    outer loop
+      vertex 2.97634 0.375999 0
+      vertex 2.96306 0.469303 5
+      vertex 2.96306 0.469303 0
+    endloop
+  endfacet
+  facet normal -0.990024 -0.1409 0
+    outer loop
+      vertex 2.96306 0.469303 5
+      vertex 2.97634 0.375999 0
+      vertex 2.97634 0.375999 5
+    endloop
+  endfacet
+  facet normal -0.98511 -0.171926 0
+    outer loop
+      vertex 2.96306 0.469303 0
+      vertex 2.94686 0.562143 5
+      vertex 2.94686 0.562143 0
+    endloop
+  endfacet
+  facet normal -0.98511 -0.171926 0
+    outer loop
+      vertex 2.94686 0.562143 5
+      vertex 2.96306 0.469303 0
+      vertex 2.96306 0.469303 5
+    endloop
+  endfacet
+  facet normal -0.946083 -0.323925 0
+    outer loop
+      vertex 2.85317 0.927051 0
+      vertex 2.82264 1.01621 5
+      vertex 2.82264 1.01621 0
+    endloop
+  endfacet
+  facet normal -0.946083 -0.323925 0
+    outer loop
+      vertex 2.82264 1.01621 5
+      vertex 2.85317 0.927051 0
+      vertex 2.85317 0.927051 5
+    endloop
+  endfacet
+  facet normal -0.852638 -0.522502 0
+    outer loop
+      vertex 2.58223 1.52712 0
+      vertex 2.53298 1.60748 5
+      vertex 2.53298 1.60748 0
+    endloop
+  endfacet
+  facet normal -0.852638 -0.522502 0
+    outer loop
+      vertex 2.53298 1.60748 5
+      vertex 2.58223 1.52712 0
+      vertex 2.58223 1.52712 5
+    endloop
+  endfacet
+  facet normal -0.911401 -0.41152 0
+    outer loop
+      vertex 2.75326 1.19144 0
+      vertex 2.71448 1.27734 5
+      vertex 2.71448 1.27734 0
+    endloop
+  endfacet
+  facet normal -0.911401 -0.41152 0
+    outer loop
+      vertex 2.71448 1.27734 5
+      vertex 2.75326 1.19144 0
+      vertex 2.75326 1.19144 5
+    endloop
+  endfacet
+  facet normal -0.353476 -0.935444 0
+    outer loop
+      vertex 1.01621 2.82264 0
+      vertex 1.10437 2.78933 5
+      vertex 1.01621 2.82264 5
+    endloop
+  endfacet
+  facet normal -0.353476 -0.935444 -0
+    outer loop
+      vertex 1.10437 2.78933 5
+      vertex 1.01621 2.82264 0
+      vertex 1.10437 2.78933 0
+    endloop
+  endfacet
+  facet normal -0.233441 -0.972371 0
+    outer loop
+      vertex 0.654429 2.92775 0
+      vertex 0.746069 2.90575 5
+      vertex 0.654429 2.92775 5
+    endloop
+  endfacet
+  facet normal -0.233441 -0.972371 -0
+    outer loop
+      vertex 0.746069 2.90575 5
+      vertex 0.654429 2.92775 0
+      vertex 0.746069 2.90575 0
+    endloop
+  endfacet
+  facet normal -0.109743 -0.99396 0
+    outer loop
+      vertex 0.282325 2.98669 0
+      vertex 0.375999 2.97634 5
+      vertex 0.282325 2.98669 5
+    endloop
+  endfacet
+  facet normal -0.109743 -0.99396 -0
+    outer loop
+      vertex 0.375999 2.97634 5
+      vertex 0.282325 2.98669 0
+      vertex 0.375999 2.97634 0
+    endloop
+  endfacet
+  facet normal -0.047105 -0.99889 0
+    outer loop
+      vertex 0.0942316 2.99852 0
+      vertex 0.188371 2.99408 5
+      vertex 0.0942316 2.99852 5
+    endloop
+  endfacet
+  facet normal -0.047105 -0.99889 -0
+    outer loop
+      vertex 0.188371 2.99408 5
+      vertex 0.0942316 2.99852 0
+      vertex 0.188371 2.99408 0
+    endloop
+  endfacet
+  facet normal -0.439933 -0.89803 0
+    outer loop
+      vertex 1.27734 2.71448 0
+      vertex 1.36197 2.67302 5
+      vertex 1.27734 2.71448 5
+    endloop
+  endfacet
+  facet normal -0.439933 -0.89803 -0
+    outer loop
+      vertex 1.36197 2.67302 5
+      vertex 1.27734 2.71448 0
+      vertex 1.36197 2.67302 0
+    endloop
+  endfacet
+  facet normal -0.673014 -0.73963 0
+    outer loop
+      vertex 1.98394 2.25033 0
+      vertex 2.05364 2.18691 5
+      vertex 1.98394 2.25033 5
+    endloop
+  endfacet
+  facet normal -0.673014 -0.73963 -0
+    outer loop
+      vertex 2.05364 2.18691 5
+      vertex 1.98394 2.25033 0
+      vertex 2.05364 2.18691 0
+    endloop
+  endfacet
+  facet normal 0.718125 -0.695914 0
+    outer loop
+      vertex -2.18691 2.05364 5
+      vertex -2.12132 2.12132 0
+      vertex -2.12132 2.12132 5
+    endloop
+  endfacet
+  facet normal 0.718125 -0.695914 0
+    outer loop
+      vertex -2.12132 2.12132 0
+      vertex -2.18691 2.05364 5
+      vertex -2.18691 2.05364 0
+    endloop
+  endfacet
+  facet normal 0.780435 -0.625237 0
+    outer loop
+      vertex -2.37046 1.83872 5
+      vertex -2.31154 1.91227 0
+      vertex -2.31154 1.91227 5
+    endloop
+  endfacet
+  facet normal 0.780435 -0.625237 0
+    outer loop
+      vertex -2.31154 1.91227 0
+      vertex -2.37046 1.83872 5
+      vertex -2.37046 1.83872 0
+    endloop
+  endfacet
+  facet normal 0.799682 -0.600424 0
+    outer loop
+      vertex -2.42705 1.76336 5
+      vertex -2.37046 1.83872 0
+      vertex -2.37046 1.83872 5
+    endloop
+  endfacet
+  facet normal 0.799682 -0.600424 0
+    outer loop
+      vertex -2.37046 1.83872 0
+      vertex -2.42705 1.76336 5
+      vertex -2.42705 1.76336 0
+    endloop
+  endfacet
+  facet normal 0.89803 -0.439933 0
+    outer loop
+      vertex -2.71448 1.27734 5
+      vertex -2.67302 1.36197 0
+      vertex -2.67302 1.36197 5
+    endloop
+  endfacet
+  facet normal 0.89803 -0.439933 0
+    outer loop
+      vertex -2.67302 1.36197 0
+      vertex -2.71448 1.27734 5
+      vertex -2.71448 1.27734 0
+    endloop
+  endfacet
+  facet normal 0.835809 -0.54902 0
+    outer loop
+      vertex -2.53298 1.60748 5
+      vertex -2.48124 1.68625 0
+      vertex -2.48124 1.68625 5
+    endloop
+  endfacet
+  facet normal 0.835809 -0.54902 0
+    outer loop
+      vertex -2.48124 1.68625 0
+      vertex -2.53298 1.60748 5
+      vertex -2.53298 1.60748 0
+    endloop
+  endfacet
+  facet normal 0.935444 -0.353476 0
+    outer loop
+      vertex -2.82264 1.01621 5
+      vertex -2.78933 1.10437 0
+      vertex -2.78933 1.10437 5
+    endloop
+  endfacet
+  facet normal 0.935444 -0.353476 0
+    outer loop
+      vertex -2.78933 1.10437 0
+      vertex -2.82264 1.01621 5
+      vertex -2.82264 1.01621 0
+    endloop
+  endfacet
+  facet normal 0.964556 -0.263877 0
+    outer loop
+      vertex -2.90575 0.746069 5
+      vertex -2.88088 0.836973 0
+      vertex -2.88088 0.836973 5
+    endloop
+  endfacet
+  facet normal 0.964556 -0.263877 0
+    outer loop
+      vertex -2.88088 0.836973 0
+      vertex -2.90575 0.746069 5
+      vertex -2.90575 0.746069 0
+    endloop
+  endfacet
+  facet normal 0.972371 -0.233441 0
+    outer loop
+      vertex -2.92775 0.654429 5
+      vertex -2.90575 0.746069 0
+      vertex -2.90575 0.746069 5
+    endloop
+  endfacet
+  facet normal 0.972371 -0.233441 0
+    outer loop
+      vertex -2.90575 0.746069 0
+      vertex -2.92775 0.654429 5
+      vertex -2.92775 0.654429 0
+    endloop
+  endfacet
+  facet normal 0.955795 -0.294035 0
+    outer loop
+      vertex -2.88088 0.836973 5
+      vertex -2.85317 0.927051 0
+      vertex -2.85317 0.927051 5
+    endloop
+  endfacet
+  facet normal 0.955795 -0.294035 0
+    outer loop
+      vertex -2.85317 0.927051 0
+      vertex -2.88088 0.836973 5
+      vertex -2.88088 0.836973 0
+    endloop
+  endfacet
+  facet normal 0.990024 -0.1409 0
+    outer loop
+      vertex -2.97634 0.375999 5
+      vertex -2.96306 0.469303 0
+      vertex -2.96306 0.469303 5
+    endloop
+  endfacet
+  facet normal 0.990024 -0.1409 0
+    outer loop
+      vertex -2.96306 0.469303 0
+      vertex -2.97634 0.375999 5
+      vertex -2.97634 0.375999 0
+    endloop
+  endfacet
+  facet normal 0.99889 -0.047105 0
+    outer loop
+      vertex -2.99852 0.0942316 5
+      vertex -2.99408 0.188371 0
+      vertex -2.99408 0.188371 5
+    endloop
+  endfacet
+  facet normal 0.99889 -0.047105 0
+    outer loop
+      vertex -2.99408 0.188371 0
+      vertex -2.99852 0.0942316 5
+      vertex -2.99852 0.0942316 0
+    endloop
+  endfacet
+  facet normal 0.439933 -0.89803 0
+    outer loop
+      vertex -1.36197 2.67302 0
+      vertex -1.27734 2.71448 5
+      vertex -1.36197 2.67302 5
+    endloop
+  endfacet
+  facet normal 0.439933 -0.89803 0
+    outer loop
+      vertex -1.27734 2.71448 5
+      vertex -1.36197 2.67302 0
+      vertex -1.27734 2.71448 0
+    endloop
+  endfacet
+  facet normal 0.41152 -0.911401 0
+    outer loop
+      vertex -1.27734 2.71448 0
+      vertex -1.19144 2.75326 5
+      vertex -1.27734 2.71448 5
+    endloop
+  endfacet
+  facet normal 0.41152 -0.911401 0
+    outer loop
+      vertex -1.19144 2.75326 5
+      vertex -1.27734 2.71448 0
+      vertex -1.19144 2.75326 0
+    endloop
+  endfacet
+  facet normal 0.522502 -0.852638 0
+    outer loop
+      vertex -1.60748 2.53298 0
+      vertex -1.52712 2.58223 5
+      vertex -1.60748 2.53298 5
+    endloop
+  endfacet
+  facet normal 0.522502 -0.852638 0
+    outer loop
+      vertex -1.52712 2.58223 5
+      vertex -1.60748 2.53298 0
+      vertex -1.52712 2.58223 0
+    endloop
+  endfacet
+  facet normal 0.600424 -0.799682 0
+    outer loop
+      vertex -1.83872 2.37046 0
+      vertex -1.76336 2.42705 5
+      vertex -1.83872 2.37046 5
+    endloop
+  endfacet
+  facet normal 0.600424 -0.799682 0
+    outer loop
+      vertex -1.76336 2.42705 5
+      vertex -1.83872 2.37046 0
+      vertex -1.76336 2.42705 0
+    endloop
+  endfacet
+  facet normal 0.673014 -0.73963 0
+    outer loop
+      vertex -2.05364 2.18691 0
+      vertex -1.98394 2.25033 5
+      vertex -2.05364 2.18691 5
+    endloop
+  endfacet
+  facet normal 0.673014 -0.73963 0
+    outer loop
+      vertex -1.98394 2.25033 5
+      vertex -2.05364 2.18691 0
+      vertex -1.98394 2.25033 0
+    endloop
+  endfacet
+  facet normal 0.233441 -0.972371 0
+    outer loop
+      vertex -0.746069 2.90575 0
+      vertex -0.654429 2.92775 5
+      vertex -0.746069 2.90575 5
+    endloop
+  endfacet
+  facet normal 0.233441 -0.972371 0
+    outer loop
+      vertex -0.654429 2.92775 5
+      vertex -0.746069 2.90575 0
+      vertex -0.654429 2.92775 0
+    endloop
+  endfacet
+  facet normal 0.202788 -0.979223 0
+    outer loop
+      vertex -0.654429 2.92775 0
+      vertex -0.562143 2.94686 5
+      vertex -0.654429 2.92775 5
+    endloop
+  endfacet
+  facet normal 0.202788 -0.979223 0
+    outer loop
+      vertex -0.562143 2.94686 5
+      vertex -0.654429 2.92775 0
+      vertex -0.562143 2.94686 0
+    endloop
+  endfacet
+  facet normal 0.263877 -0.964556 0
+    outer loop
+      vertex -0.836973 2.88088 0
+      vertex -0.746069 2.90575 5
+      vertex -0.836973 2.88088 5
+    endloop
+  endfacet
+  facet normal 0.263877 -0.964556 0
+    outer loop
+      vertex -0.746069 2.90575 5
+      vertex -0.836973 2.88088 0
+      vertex -0.746069 2.90575 0
+    endloop
+  endfacet
+  facet normal 0.323925 -0.946083 0
+    outer loop
+      vertex -1.01621 2.82264 0
+      vertex -0.927051 2.85317 5
+      vertex -1.01621 2.82264 5
+    endloop
+  endfacet
+  facet normal 0.323925 -0.946083 0
+    outer loop
+      vertex -0.927051 2.85317 5
+      vertex -1.01621 2.82264 0
+      vertex -0.927051 2.85317 0
+    endloop
+  endfacet
+  facet normal 0.353476 -0.935444 0
+    outer loop
+      vertex -1.10437 2.78933 0
+      vertex -1.01621 2.82264 5
+      vertex -1.10437 2.78933 5
+    endloop
+  endfacet
+  facet normal 0.353476 -0.935444 0
+    outer loop
+      vertex -1.01621 2.82264 5
+      vertex -1.10437 2.78933 0
+      vertex -1.01621 2.82264 0
+    endloop
+  endfacet
+  facet normal 0.109743 -0.99396 0
+    outer loop
+      vertex -0.375999 2.97634 0
+      vertex -0.282325 2.98669 5
+      vertex -0.375999 2.97634 5
+    endloop
+  endfacet
+  facet normal 0.109743 -0.99396 0
+    outer loop
+      vertex -0.282325 2.98669 5
+      vertex -0.375999 2.97634 0
+      vertex -0.282325 2.98669 0
+    endloop
+  endfacet
+  facet normal 0.1409 -0.990024 0
+    outer loop
+      vertex -0.469303 2.96306 0
+      vertex -0.375999 2.97634 5
+      vertex -0.469303 2.96306 5
+    endloop
+  endfacet
+  facet normal 0.1409 -0.990024 0
+    outer loop
+      vertex -0.375999 2.97634 5
+      vertex -0.469303 2.96306 0
+      vertex -0.375999 2.97634 0
+    endloop
+  endfacet
+  facet normal 0.0157153 -0.999877 0
+    outer loop
+      vertex -0.0942316 2.99852 0
+      vertex 0 3 5
+      vertex -0.0942316 2.99852 5
+    endloop
+  endfacet
+  facet normal 0.0157153 -0.999877 0
+    outer loop
+      vertex 0 3 5
+      vertex -0.0942316 2.99852 0
+      vertex 0 3 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0157153 0
+    outer loop
+      vertex 2.99852 -0.0942316 0
+      vertex 3 0 5
+      vertex 3 0 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0157153 0
+    outer loop
+      vertex 3 0 5
+      vertex 2.99852 -0.0942316 0
+      vertex 2.99852 -0.0942316 5
+    endloop
+  endfacet
+  facet normal -0.0157153 0.999877 0
+    outer loop
+      vertex 0.0942316 -2.99852 0
+      vertex 0 -3 5
+      vertex 0.0942316 -2.99852 5
+    endloop
+  endfacet
+  facet normal -0.0157153 0.999877 0
+    outer loop
+      vertex 0 -3 5
+      vertex 0.0942316 -2.99852 0
+      vertex 0 -3 0
+    endloop
+  endfacet
+  facet normal -0.0784537 0.996918 0
+    outer loop
+      vertex 0.282325 -2.98669 0
+      vertex 0.188371 -2.99408 5
+      vertex 0.282325 -2.98669 5
+    endloop
+  endfacet
+  facet normal -0.0784537 0.996918 0
+    outer loop
+      vertex 0.188371 -2.99408 5
+      vertex 0.282325 -2.98669 0
+      vertex 0.188371 -2.99408 0
+    endloop
+  endfacet
+  facet normal -0.171926 0.98511 0
+    outer loop
+      vertex 0.562143 -2.94686 0
+      vertex 0.469303 -2.96306 5
+      vertex 0.562143 -2.94686 5
+    endloop
+  endfacet
+  facet normal -0.171926 0.98511 0
+    outer loop
+      vertex 0.469303 -2.96306 5
+      vertex 0.562143 -2.94686 0
+      vertex 0.469303 -2.96306 0
+    endloop
+  endfacet
+  facet normal -0.109743 0.99396 0
+    outer loop
+      vertex 0.375999 -2.97634 0
+      vertex 0.282325 -2.98669 5
+      vertex 0.375999 -2.97634 5
+    endloop
+  endfacet
+  facet normal -0.109743 0.99396 0
+    outer loop
+      vertex 0.282325 -2.98669 5
+      vertex 0.375999 -2.97634 0
+      vertex 0.282325 -2.98669 0
+    endloop
+  endfacet
+  facet normal -0.323925 0.946083 0
+    outer loop
+      vertex 1.01621 -2.82264 0
+      vertex 0.927051 -2.85317 5
+      vertex 1.01621 -2.82264 5
+    endloop
+  endfacet
+  facet normal -0.323925 0.946083 0
+    outer loop
+      vertex 0.927051 -2.85317 5
+      vertex 1.01621 -2.82264 0
+      vertex 0.927051 -2.85317 0
+    endloop
+  endfacet
+  facet normal -0.382677 0.923882 0
+    outer loop
+      vertex 1.19144 -2.75326 0
+      vertex 1.10437 -2.78933 5
+      vertex 1.19144 -2.75326 5
+    endloop
+  endfacet
+  facet normal -0.382677 0.923882 0
+    outer loop
+      vertex 1.10437 -2.78933 5
+      vertex 1.19144 -2.75326 0
+      vertex 1.10437 -2.78933 0
+    endloop
+  endfacet
+  facet normal -0.263877 0.964556 0
+    outer loop
+      vertex 0.836973 -2.88088 0
+      vertex 0.746069 -2.90575 5
+      vertex 0.836973 -2.88088 5
+    endloop
+  endfacet
+  facet normal -0.263877 0.964556 0
+    outer loop
+      vertex 0.746069 -2.90575 5
+      vertex 0.836973 -2.88088 0
+      vertex 0.746069 -2.90575 0
+    endloop
+  endfacet
+  facet normal -0.202788 0.979223 0
+    outer loop
+      vertex 0.654429 -2.92775 0
+      vertex 0.562143 -2.94686 5
+      vertex 0.654429 -2.92775 5
+    endloop
+  endfacet
+  facet normal -0.202788 0.979223 0
+    outer loop
+      vertex 0.562143 -2.94686 5
+      vertex 0.654429 -2.92775 0
+      vertex 0.562143 -2.94686 0
+    endloop
+  endfacet
+  facet normal -0.600424 0.799682 0
+    outer loop
+      vertex 1.83872 -2.37046 0
+      vertex 1.76336 -2.42705 5
+      vertex 1.83872 -2.37046 5
+    endloop
+  endfacet
+  facet normal -0.600424 0.799682 0
+    outer loop
+      vertex 1.76336 -2.42705 5
+      vertex 1.83872 -2.37046 0
+      vertex 1.76336 -2.42705 0
+    endloop
+  endfacet
+  facet normal -0.575005 0.81815 0
+    outer loop
+      vertex 1.76336 -2.42705 0
+      vertex 1.68625 -2.48124 5
+      vertex 1.76336 -2.42705 5
+    endloop
+  endfacet
+  facet normal -0.575005 0.81815 0
+    outer loop
+      vertex 1.68625 -2.48124 5
+      vertex 1.76336 -2.42705 0
+      vertex 1.68625 -2.48124 0
+    endloop
+  endfacet
+  facet normal -0.495461 0.86863 0
+    outer loop
+      vertex 1.52712 -2.58223 0
+      vertex 1.44526 -2.62892 5
+      vertex 1.52712 -2.58223 5
+    endloop
+  endfacet
+  facet normal -0.495461 0.86863 0
+    outer loop
+      vertex 1.44526 -2.62892 5
+      vertex 1.52712 -2.58223 0
+      vertex 1.44526 -2.62892 0
+    endloop
+  endfacet
+  facet normal -0.46793 0.883766 0
+    outer loop
+      vertex 1.44526 -2.62892 0
+      vertex 1.36197 -2.67302 5
+      vertex 1.44526 -2.62892 5
+    endloop
+  endfacet
+  facet normal -0.46793 0.883766 0
+    outer loop
+      vertex 1.36197 -2.67302 5
+      vertex 1.44526 -2.62892 0
+      vertex 1.36197 -2.67302 0
+    endloop
+  endfacet
+  facet normal -0.41152 0.911401 0
+    outer loop
+      vertex 1.27734 -2.71448 0
+      vertex 1.19144 -2.75326 5
+      vertex 1.27734 -2.71448 5
+    endloop
+  endfacet
+  facet normal -0.41152 0.911401 0
+    outer loop
+      vertex 1.19144 -2.75326 5
+      vertex 1.27734 -2.71448 0
+      vertex 1.19144 -2.75326 0
+    endloop
+  endfacet
+  facet normal -0.73963 0.673014 0
+    outer loop
+      vertex 2.18691 -2.05364 0
+      vertex 2.25033 -1.98394 5
+      vertex 2.25033 -1.98394 0
+    endloop
+  endfacet
+  facet normal -0.73963 0.673014 0
+    outer loop
+      vertex 2.25033 -1.98394 5
+      vertex 2.18691 -2.05364 0
+      vertex 2.18691 -2.05364 5
+    endloop
+  endfacet
+  facet normal -0.780435 0.625237 0
+    outer loop
+      vertex 2.31154 -1.91227 0
+      vertex 2.37046 -1.83872 5
+      vertex 2.37046 -1.83872 0
+    endloop
+  endfacet
+  facet normal -0.780435 0.625237 0
+    outer loop
+      vertex 2.37046 -1.83872 5
+      vertex 2.31154 -1.91227 0
+      vertex 2.31154 -1.91227 5
+    endloop
+  endfacet
+  facet normal -0.835809 0.54902 0
+    outer loop
+      vertex 2.48124 -1.68625 0
+      vertex 2.53298 -1.60748 5
+      vertex 2.53298 -1.60748 0
+    endloop
+  endfacet
+  facet normal -0.835809 0.54902 0
+    outer loop
+      vertex 2.53298 -1.60748 5
+      vertex 2.48124 -1.68625 0
+      vertex 2.48124 -1.68625 5
+    endloop
+  endfacet
+  facet normal -0.89803 0.439933 0
+    outer loop
+      vertex 2.67302 -1.36197 0
+      vertex 2.71448 -1.27734 5
+      vertex 2.71448 -1.27734 0
+    endloop
+  endfacet
+  facet normal -0.89803 0.439933 0
+    outer loop
+      vertex 2.71448 -1.27734 5
+      vertex 2.67302 -1.36197 0
+      vertex 2.67302 -1.36197 5
+    endloop
+  endfacet
+  facet normal -0.86863 0.495461 0
+    outer loop
+      vertex 2.58223 -1.52712 0
+      vertex 2.62892 -1.44526 5
+      vertex 2.62892 -1.44526 0
+    endloop
+  endfacet
+  facet normal -0.86863 0.495461 0
+    outer loop
+      vertex 2.62892 -1.44526 5
+      vertex 2.58223 -1.52712 0
+      vertex 2.58223 -1.52712 5
+    endloop
+  endfacet
+  facet normal -0.955795 0.294035 0
+    outer loop
+      vertex 2.85317 -0.927051 0
+      vertex 2.88088 -0.836973 5
+      vertex 2.88088 -0.836973 0
+    endloop
+  endfacet
+  facet normal -0.955795 0.294035 0
+    outer loop
+      vertex 2.88088 -0.836973 5
+      vertex 2.85317 -0.927051 0
+      vertex 2.85317 -0.927051 5
+    endloop
+  endfacet
+  facet normal -0.98511 0.171926 0
+    outer loop
+      vertex 2.94686 -0.562143 0
+      vertex 2.96306 -0.469303 5
+      vertex 2.96306 -0.469303 0
+    endloop
+  endfacet
+  facet normal -0.98511 0.171926 0
+    outer loop
+      vertex 2.96306 -0.469303 5
+      vertex 2.94686 -0.562143 0
+      vertex 2.94686 -0.562143 5
+    endloop
+  endfacet
+  facet normal -0.996918 0.0784537 0
+    outer loop
+      vertex 2.98669 -0.282325 0
+      vertex 2.99408 -0.188371 5
+      vertex 2.99408 -0.188371 0
+    endloop
+  endfacet
+  facet normal -0.996918 0.0784537 0
+    outer loop
+      vertex 2.99408 -0.188371 5
+      vertex 2.98669 -0.282325 0
+      vertex 2.98669 -0.282325 5
+    endloop
+  endfacet
+  facet normal -0.990024 0.1409 0
+    outer loop
+      vertex 2.96306 -0.469303 0
+      vertex 2.97634 -0.375999 5
+      vertex 2.97634 -0.375999 0
+    endloop
+  endfacet
+  facet normal -0.990024 0.1409 0
+    outer loop
+      vertex 2.97634 -0.375999 5
+      vertex 2.96306 -0.469303 0
+      vertex 2.96306 -0.469303 5
+    endloop
+  endfacet
+  facet normal 0.695914 0.718125 -0
+    outer loop
+      vertex -2.05364 -2.18691 0
+      vertex -2.12132 -2.12132 5
+      vertex -2.05364 -2.18691 5
+    endloop
+  endfacet
+  facet normal 0.695914 0.718125 0
+    outer loop
+      vertex -2.12132 -2.12132 5
+      vertex -2.05364 -2.18691 0
+      vertex -2.12132 -2.12132 0
+    endloop
+  endfacet
+  facet normal 0.575005 0.81815 -0
+    outer loop
+      vertex -1.68625 -2.48124 0
+      vertex -1.76336 -2.42705 5
+      vertex -1.68625 -2.48124 5
+    endloop
+  endfacet
+  facet normal 0.575005 0.81815 0
+    outer loop
+      vertex -1.76336 -2.42705 5
+      vertex -1.68625 -2.48124 0
+      vertex -1.76336 -2.42705 0
+    endloop
+  endfacet
+  facet normal 0.54902 0.835809 -0
+    outer loop
+      vertex -1.60748 -2.53298 0
+      vertex -1.68625 -2.48124 5
+      vertex -1.60748 -2.53298 5
+    endloop
+  endfacet
+  facet normal 0.54902 0.835809 0
+    outer loop
+      vertex -1.68625 -2.48124 5
+      vertex -1.60748 -2.53298 0
+      vertex -1.68625 -2.48124 0
+    endloop
+  endfacet
+  facet normal 0.353476 0.935444 -0
+    outer loop
+      vertex -1.01621 -2.82264 0
+      vertex -1.10437 -2.78933 5
+      vertex -1.01621 -2.82264 5
+    endloop
+  endfacet
+  facet normal 0.353476 0.935444 0
+    outer loop
+      vertex -1.10437 -2.78933 5
+      vertex -1.01621 -2.82264 0
+      vertex -1.10437 -2.78933 0
+    endloop
+  endfacet
+  facet normal 0.202788 0.979223 -0
+    outer loop
+      vertex -0.562143 -2.94686 0
+      vertex -0.654429 -2.92775 5
+      vertex -0.562143 -2.94686 5
+    endloop
+  endfacet
+  facet normal 0.202788 0.979223 0
+    outer loop
+      vertex -0.654429 -2.92775 5
+      vertex -0.562143 -2.94686 0
+      vertex -0.654429 -2.92775 0
+    endloop
+  endfacet
+  facet normal 0.233441 0.972371 -0
+    outer loop
+      vertex -0.654429 -2.92775 0
+      vertex -0.746069 -2.90575 5
+      vertex -0.654429 -2.92775 5
+    endloop
+  endfacet
+  facet normal 0.233441 0.972371 0
+    outer loop
+      vertex -0.746069 -2.90575 5
+      vertex -0.654429 -2.92775 0
+      vertex -0.746069 -2.90575 0
+    endloop
+  endfacet
+  facet normal 0.1409 0.990024 -0
+    outer loop
+      vertex -0.375999 -2.97634 0
+      vertex -0.469303 -2.96306 5
+      vertex -0.375999 -2.97634 5
+    endloop
+  endfacet
+  facet normal 0.1409 0.990024 0
+    outer loop
+      vertex -0.469303 -2.96306 5
+      vertex -0.375999 -2.97634 0
+      vertex -0.469303 -2.96306 0
+    endloop
+  endfacet
+  facet normal 0.047105 0.99889 -0
+    outer loop
+      vertex -0.0942316 -2.99852 0
+      vertex -0.188371 -2.99408 5
+      vertex -0.0942316 -2.99852 5
+    endloop
+  endfacet
+  facet normal 0.047105 0.99889 0
+    outer loop
+      vertex -0.188371 -2.99408 5
+      vertex -0.0942316 -2.99852 0
+      vertex -0.188371 -2.99408 0
+    endloop
+  endfacet
+  facet normal 0.911401 0.41152 0
+    outer loop
+      vertex -2.71448 -1.27734 5
+      vertex -2.75326 -1.19144 0
+      vertex -2.75326 -1.19144 5
+    endloop
+  endfacet
+  facet normal 0.911401 0.41152 0
+    outer loop
+      vertex -2.75326 -1.19144 0
+      vertex -2.71448 -1.27734 5
+      vertex -2.71448 -1.27734 0
+    endloop
+  endfacet
+  facet normal 0.835809 0.54902 0
+    outer loop
+      vertex -2.48124 -1.68625 5
+      vertex -2.53298 -1.60748 0
+      vertex -2.53298 -1.60748 5
+    endloop
+  endfacet
+  facet normal 0.835809 0.54902 0
+    outer loop
+      vertex -2.53298 -1.60748 0
+      vertex -2.48124 -1.68625 5
+      vertex -2.48124 -1.68625 0
+    endloop
+  endfacet
+  facet normal 0.852638 0.522502 0
+    outer loop
+      vertex -2.53298 -1.60748 5
+      vertex -2.58223 -1.52712 0
+      vertex -2.58223 -1.52712 5
+    endloop
+  endfacet
+  facet normal 0.852638 0.522502 0
+    outer loop
+      vertex -2.58223 -1.52712 0
+      vertex -2.53298 -1.60748 5
+      vertex -2.53298 -1.60748 0
+    endloop
+  endfacet
+  facet normal 0.799682 0.600424 0
+    outer loop
+      vertex -2.37046 -1.83872 5
+      vertex -2.42705 -1.76336 0
+      vertex -2.42705 -1.76336 5
+    endloop
+  endfacet
+  facet normal 0.799682 0.600424 0
+    outer loop
+      vertex -2.42705 -1.76336 0
+      vertex -2.37046 -1.83872 5
+      vertex -2.37046 -1.83872 0
+    endloop
+  endfacet
+  facet normal 0.979223 0.202788 0
+    outer loop
+      vertex -2.92775 -0.654429 5
+      vertex -2.94686 -0.562143 0
+      vertex -2.94686 -0.562143 5
+    endloop
+  endfacet
+  facet normal 0.979223 0.202788 0
+    outer loop
+      vertex -2.94686 -0.562143 0
+      vertex -2.92775 -0.654429 5
+      vertex -2.92775 -0.654429 0
+    endloop
+  endfacet
+  facet normal 0.964556 0.263877 0
+    outer loop
+      vertex -2.88088 -0.836973 5
+      vertex -2.90575 -0.746069 0
+      vertex -2.90575 -0.746069 5
+    endloop
+  endfacet
+  facet normal 0.964556 0.263877 0
+    outer loop
+      vertex -2.90575 -0.746069 0
+      vertex -2.88088 -0.836973 5
+      vertex -2.88088 -0.836973 0
+    endloop
+  endfacet
+  facet normal 0.946083 0.323925 0
+    outer loop
+      vertex -2.82264 -1.01621 5
+      vertex -2.85317 -0.927051 0
+      vertex -2.85317 -0.927051 5
+    endloop
+  endfacet
+  facet normal 0.946083 0.323925 0
+    outer loop
+      vertex -2.85317 -0.927051 0
+      vertex -2.82264 -1.01621 5
+      vertex -2.82264 -1.01621 0
+    endloop
+  endfacet
+  facet normal 0.99396 0.109743 0
+    outer loop
+      vertex -2.97634 -0.375999 5
+      vertex -2.98669 -0.282325 0
+      vertex -2.98669 -0.282325 5
+    endloop
+  endfacet
+  facet normal 0.99396 0.109743 0
+    outer loop
+      vertex -2.98669 -0.282325 0
+      vertex -2.97634 -0.375999 5
+      vertex -2.97634 -0.375999 0
+    endloop
+  endfacet
+  facet normal 0.996918 0.0784537 0
+    outer loop
+      vertex -2.98669 -0.282325 5
+      vertex -2.99408 -0.188371 0
+      vertex -2.99408 -0.188371 5
+    endloop
+  endfacet
+  facet normal 0.996918 0.0784537 0
+    outer loop
+      vertex -2.99408 -0.188371 0
+      vertex -2.98669 -0.282325 5
+      vertex -2.98669 -0.282325 0
+    endloop
+  endfacet
+  facet normal 0.999877 0.0157153 0
+    outer loop
+      vertex -2.99852 -0.0942316 5
+      vertex -3 0 0
+      vertex -3 0 5
+    endloop
+  endfacet
+  facet normal 0.999877 0.0157153 0
+    outer loop
+      vertex -3 0 0
+      vertex -2.99852 -0.0942316 5
+      vertex -2.99852 -0.0942316 0
+    endloop
+  endfacet
+  facet normal -0.964556 -0.263877 0
+    outer loop
+      vertex 2.90575 0.746069 0
+      vertex 2.88088 0.836973 5
+      vertex 2.88088 0.836973 0
+    endloop
+  endfacet
+  facet normal -0.964556 -0.263877 0
+    outer loop
+      vertex 2.88088 0.836973 5
+      vertex 2.90575 0.746069 0
+      vertex 2.90575 0.746069 5
+    endloop
+  endfacet
+  facet normal -0.799682 -0.600424 0
+    outer loop
+      vertex 2.42705 1.76336 0
+      vertex 2.37046 1.83872 5
+      vertex 2.37046 1.83872 0
+    endloop
+  endfacet
+  facet normal -0.799682 -0.600424 0
+    outer loop
+      vertex 2.37046 1.83872 5
+      vertex 2.42705 1.76336 0
+      vertex 2.42705 1.76336 5
+    endloop
+  endfacet
+  facet normal -0.718125 -0.695914 0
+    outer loop
+      vertex 2.18691 2.05364 0
+      vertex 2.12132 2.12132 5
+      vertex 2.12132 2.12132 0
+    endloop
+  endfacet
+  facet normal -0.718125 -0.695914 0
+    outer loop
+      vertex 2.12132 2.12132 5
+      vertex 2.18691 2.05364 0
+      vertex 2.18691 2.05364 5
+    endloop
+  endfacet
+  facet normal -0.835809 -0.54902 0
+    outer loop
+      vertex 2.53298 1.60748 0
+      vertex 2.48124 1.68625 5
+      vertex 2.48124 1.68625 0
+    endloop
+  endfacet
+  facet normal -0.835809 -0.54902 0
+    outer loop
+      vertex 2.48124 1.68625 5
+      vertex 2.53298 1.60748 0
+      vertex 2.53298 1.60748 5
+    endloop
+  endfacet
+  facet normal -0.86863 -0.495461 0
+    outer loop
+      vertex 2.62892 1.44526 0
+      vertex 2.58223 1.52712 5
+      vertex 2.58223 1.52712 0
+    endloop
+  endfacet
+  facet normal -0.86863 -0.495461 0
+    outer loop
+      vertex 2.58223 1.52712 5
+      vertex 2.62892 1.44526 0
+      vertex 2.62892 1.44526 5
+    endloop
+  endfacet
+  facet normal -0.522502 -0.852638 0
+    outer loop
+      vertex 1.52712 2.58223 0
+      vertex 1.60748 2.53298 5
+      vertex 1.52712 2.58223 5
+    endloop
+  endfacet
+  facet normal -0.522502 -0.852638 -0
+    outer loop
+      vertex 1.60748 2.53298 5
+      vertex 1.52712 2.58223 0
+      vertex 1.60748 2.53298 0
+    endloop
+  endfacet
+  facet normal -0.575005 -0.81815 0
+    outer loop
+      vertex 1.68625 2.48124 0
+      vertex 1.76336 2.42705 5
+      vertex 1.68625 2.48124 5
+    endloop
+  endfacet
+  facet normal -0.575005 -0.81815 -0
+    outer loop
+      vertex 1.76336 2.42705 5
+      vertex 1.68625 2.48124 0
+      vertex 1.76336 2.42705 0
+    endloop
+  endfacet
+  facet normal -0.047105 0.99889 0
+    outer loop
+      vertex 0.188371 -2.99408 0
+      vertex 0.0942316 -2.99852 5
+      vertex 0.188371 -2.99408 5
+    endloop
+  endfacet
+  facet normal -0.047105 0.99889 0
+    outer loop
+      vertex 0.0942316 -2.99852 5
+      vertex 0.188371 -2.99408 0
+      vertex 0.0942316 -2.99852 0
+    endloop
+  endfacet
+  facet normal -0.1409 0.990024 0
+    outer loop
+      vertex 0.469303 -2.96306 0
+      vertex 0.375999 -2.97634 5
+      vertex 0.469303 -2.96306 5
+    endloop
+  endfacet
+  facet normal -0.1409 0.990024 0
+    outer loop
+      vertex 0.375999 -2.97634 5
+      vertex 0.469303 -2.96306 0
+      vertex 0.375999 -2.97634 0
+    endloop
+  endfacet
+  facet normal -0.353476 0.935444 0
+    outer loop
+      vertex 1.10437 -2.78933 0
+      vertex 1.01621 -2.82264 5
+      vertex 1.10437 -2.78933 5
+    endloop
+  endfacet
+  facet normal -0.353476 0.935444 0
+    outer loop
+      vertex 1.01621 -2.82264 5
+      vertex 1.10437 -2.78933 0
+      vertex 1.01621 -2.82264 0
+    endloop
+  endfacet
+  facet normal -0.294035 0.955795 0
+    outer loop
+      vertex 0.927051 -2.85317 0
+      vertex 0.836973 -2.88088 5
+      vertex 0.927051 -2.85317 5
+    endloop
+  endfacet
+  facet normal -0.294035 0.955795 0
+    outer loop
+      vertex 0.836973 -2.88088 5
+      vertex 0.927051 -2.85317 0
+      vertex 0.836973 -2.88088 0
+    endloop
+  endfacet
+  facet normal -0.233441 0.972371 0
+    outer loop
+      vertex 0.746069 -2.90575 0
+      vertex 0.654429 -2.92775 5
+      vertex 0.746069 -2.90575 5
+    endloop
+  endfacet
+  facet normal -0.233441 0.972371 0
+    outer loop
+      vertex 0.654429 -2.92775 5
+      vertex 0.746069 -2.90575 0
+      vertex 0.654429 -2.92775 0
+    endloop
+  endfacet
+  facet normal -0.718125 0.695914 0
+    outer loop
+      vertex 2.12132 -2.12132 0
+      vertex 2.18691 -2.05364 5
+      vertex 2.18691 -2.05364 0
+    endloop
+  endfacet
+  facet normal -0.718125 0.695914 0
+    outer loop
+      vertex 2.18691 -2.05364 5
+      vertex 2.12132 -2.12132 0
+      vertex 2.12132 -2.12132 5
+    endloop
+  endfacet
+  facet normal -0.625237 0.780435 0
+    outer loop
+      vertex 1.91227 -2.31154 0
+      vertex 1.83872 -2.37046 5
+      vertex 1.91227 -2.31154 5
+    endloop
+  endfacet
+  facet normal -0.625237 0.780435 0
+    outer loop
+      vertex 1.83872 -2.37046 5
+      vertex 1.91227 -2.31154 0
+      vertex 1.83872 -2.37046 0
+    endloop
+  endfacet
+  facet normal -0.522502 0.852638 0
+    outer loop
+      vertex 1.60748 -2.53298 0
+      vertex 1.52712 -2.58223 5
+      vertex 1.60748 -2.53298 5
+    endloop
+  endfacet
+  facet normal -0.522502 0.852638 0
+    outer loop
+      vertex 1.52712 -2.58223 5
+      vertex 1.60748 -2.53298 0
+      vertex 1.52712 -2.58223 0
+    endloop
+  endfacet
+  facet normal -0.439933 0.89803 0
+    outer loop
+      vertex 1.36197 -2.67302 0
+      vertex 1.27734 -2.71448 5
+      vertex 1.36197 -2.67302 5
+    endloop
+  endfacet
+  facet normal -0.439933 0.89803 0
+    outer loop
+      vertex 1.27734 -2.71448 5
+      vertex 1.36197 -2.67302 0
+      vertex 1.27734 -2.71448 0
+    endloop
+  endfacet
+  facet normal -0.799682 0.600424 0
+    outer loop
+      vertex 2.37046 -1.83872 0
+      vertex 2.42705 -1.76336 5
+      vertex 2.42705 -1.76336 0
+    endloop
+  endfacet
+  facet normal -0.799682 0.600424 0
+    outer loop
+      vertex 2.42705 -1.76336 5
+      vertex 2.37046 -1.83872 0
+      vertex 2.37046 -1.83872 5
+    endloop
+  endfacet
+  facet normal -0.852638 0.522502 0
+    outer loop
+      vertex 2.53298 -1.60748 0
+      vertex 2.58223 -1.52712 5
+      vertex 2.58223 -1.52712 0
+    endloop
+  endfacet
+  facet normal -0.852638 0.522502 0
+    outer loop
+      vertex 2.58223 -1.52712 5
+      vertex 2.53298 -1.60748 0
+      vertex 2.53298 -1.60748 5
+    endloop
+  endfacet
+  facet normal -0.935444 0.353476 0
+    outer loop
+      vertex 2.78933 -1.10437 0
+      vertex 2.82264 -1.01621 5
+      vertex 2.82264 -1.01621 0
+    endloop
+  endfacet
+  facet normal -0.935444 0.353476 0
+    outer loop
+      vertex 2.82264 -1.01621 5
+      vertex 2.78933 -1.10437 0
+      vertex 2.78933 -1.10437 5
+    endloop
+  endfacet
+  facet normal -0.883766 0.46793 0
+    outer loop
+      vertex 2.62892 -1.44526 0
+      vertex 2.67302 -1.36197 5
+      vertex 2.67302 -1.36197 0
+    endloop
+  endfacet
+  facet normal -0.883766 0.46793 0
+    outer loop
+      vertex 2.67302 -1.36197 5
+      vertex 2.62892 -1.44526 0
+      vertex 2.62892 -1.44526 5
+    endloop
+  endfacet
+  facet normal -0.964556 0.263877 0
+    outer loop
+      vertex 2.88088 -0.836973 0
+      vertex 2.90575 -0.746069 5
+      vertex 2.90575 -0.746069 0
+    endloop
+  endfacet
+  facet normal -0.964556 0.263877 0
+    outer loop
+      vertex 2.90575 -0.746069 5
+      vertex 2.88088 -0.836973 0
+      vertex 2.88088 -0.836973 5
+    endloop
+  endfacet
+  facet normal -0.979223 0.202788 0
+    outer loop
+      vertex 2.92775 -0.654429 0
+      vertex 2.94686 -0.562143 5
+      vertex 2.94686 -0.562143 0
+    endloop
+  endfacet
+  facet normal -0.979223 0.202788 0
+    outer loop
+      vertex 2.94686 -0.562143 5
+      vertex 2.92775 -0.654429 0
+      vertex 2.92775 -0.654429 5
+    endloop
+  endfacet
+  facet normal -0.99889 0.047105 0
+    outer loop
+      vertex 2.99408 -0.188371 0
+      vertex 2.99852 -0.0942316 5
+      vertex 2.99852 -0.0942316 0
+    endloop
+  endfacet
+  facet normal -0.99889 0.047105 0
+    outer loop
+      vertex 2.99852 -0.0942316 5
+      vertex 2.99408 -0.188371 0
+      vertex 2.99408 -0.188371 5
+    endloop
+  endfacet
+  facet normal -0.99396 0.109743 0
+    outer loop
+      vertex 2.97634 -0.375999 0
+      vertex 2.98669 -0.282325 5
+      vertex 2.98669 -0.282325 0
+    endloop
+  endfacet
+  facet normal -0.99396 0.109743 0
+    outer loop
+      vertex 2.98669 -0.282325 5
+      vertex 2.97634 -0.375999 0
+      vertex 2.97634 -0.375999 5
+    endloop
+  endfacet
+  facet normal 0.673014 0.73963 -0
+    outer loop
+      vertex -1.98394 -2.25033 0
+      vertex -2.05364 -2.18691 5
+      vertex -1.98394 -2.25033 5
+    endloop
+  endfacet
+  facet normal 0.673014 0.73963 0
+    outer loop
+      vertex -2.05364 -2.18691 5
+      vertex -1.98394 -2.25033 0
+      vertex -2.05364 -2.18691 0
+    endloop
+  endfacet
+  facet normal 0.600424 0.799682 -0
+    outer loop
+      vertex -1.76336 -2.42705 0
+      vertex -1.83872 -2.37046 5
+      vertex -1.76336 -2.42705 5
+    endloop
+  endfacet
+  facet normal 0.600424 0.799682 0
+    outer loop
+      vertex -1.83872 -2.37046 5
+      vertex -1.76336 -2.42705 0
+      vertex -1.83872 -2.37046 0
+    endloop
+  endfacet
+  facet normal 0.41152 0.911401 -0
+    outer loop
+      vertex -1.19144 -2.75326 0
+      vertex -1.27734 -2.71448 5
+      vertex -1.19144 -2.75326 5
+    endloop
+  endfacet
+  facet normal 0.41152 0.911401 0
+    outer loop
+      vertex -1.27734 -2.71448 5
+      vertex -1.19144 -2.75326 0
+      vertex -1.27734 -2.71448 0
+    endloop
+  endfacet
+  facet normal 0.522502 0.852638 -0
+    outer loop
+      vertex -1.52712 -2.58223 0
+      vertex -1.60748 -2.53298 5
+      vertex -1.52712 -2.58223 5
+    endloop
+  endfacet
+  facet normal 0.522502 0.852638 0
+    outer loop
+      vertex -1.60748 -2.53298 5
+      vertex -1.52712 -2.58223 0
+      vertex -1.60748 -2.53298 0
+    endloop
+  endfacet
+  facet normal 0.323925 0.946083 -0
+    outer loop
+      vertex -0.927051 -2.85317 0
+      vertex -1.01621 -2.82264 5
+      vertex -0.927051 -2.85317 5
+    endloop
+  endfacet
+  facet normal 0.323925 0.946083 0
+    outer loop
+      vertex -1.01621 -2.82264 5
+      vertex -0.927051 -2.85317 0
+      vertex -1.01621 -2.82264 0
+    endloop
+  endfacet
+  facet normal 0.263877 0.964556 -0
+    outer loop
+      vertex -0.746069 -2.90575 0
+      vertex -0.836973 -2.88088 5
+      vertex -0.746069 -2.90575 5
+    endloop
+  endfacet
+  facet normal 0.263877 0.964556 0
+    outer loop
+      vertex -0.836973 -2.88088 5
+      vertex -0.746069 -2.90575 0
+      vertex -0.836973 -2.88088 0
+    endloop
+  endfacet
+  facet normal 0.0157153 0.999877 -0
+    outer loop
+      vertex 0 -3 0
+      vertex -0.0942316 -2.99852 5
+      vertex 0 -3 5
+    endloop
+  endfacet
+  facet normal 0.0157153 0.999877 0
+    outer loop
+      vertex -0.0942316 -2.99852 5
+      vertex 0 -3 0
+      vertex -0.0942316 -2.99852 0
+    endloop
+  endfacet
+  facet normal 0.89803 0.439933 0
+    outer loop
+      vertex -2.67302 -1.36197 5
+      vertex -2.71448 -1.27734 0
+      vertex -2.71448 -1.27734 5
+    endloop
+  endfacet
+  facet normal 0.89803 0.439933 0
+    outer loop
+      vertex -2.71448 -1.27734 0
+      vertex -2.67302 -1.36197 5
+      vertex -2.67302 -1.36197 0
+    endloop
+  endfacet
+  facet normal 0.972371 0.233441 0
+    outer loop
+      vertex -2.90575 -0.746069 5
+      vertex -2.92775 -0.654429 0
+      vertex -2.92775 -0.654429 5
+    endloop
+  endfacet
+  facet normal 0.972371 0.233441 0
+    outer loop
+      vertex -2.92775 -0.654429 0
+      vertex -2.90575 -0.746069 5
+      vertex -2.90575 -0.746069 0
+    endloop
+  endfacet
+  facet normal 0.955795 0.294035 0
+    outer loop
+      vertex -2.85317 -0.927051 5
+      vertex -2.88088 -0.836973 0
+      vertex -2.88088 -0.836973 5
+    endloop
+  endfacet
+  facet normal 0.955795 0.294035 0
+    outer loop
+      vertex -2.88088 -0.836973 0
+      vertex -2.85317 -0.927051 5
+      vertex -2.85317 -0.927051 0
+    endloop
+  endfacet
+  facet normal 0.935444 0.353476 0
+    outer loop
+      vertex -2.78933 -1.10437 5
+      vertex -2.82264 -1.01621 0
+      vertex -2.82264 -1.01621 5
+    endloop
+  endfacet
+  facet normal 0.935444 0.353476 0
+    outer loop
+      vertex -2.82264 -1.01621 0
+      vertex -2.78933 -1.10437 5
+      vertex -2.78933 -1.10437 0
+    endloop
+  endfacet
+  facet normal 0.990024 0.1409 0
+    outer loop
+      vertex -2.96306 -0.469303 5
+      vertex -2.97634 -0.375999 0
+      vertex -2.97634 -0.375999 5
+    endloop
+  endfacet
+  facet normal 0.990024 0.1409 0
+    outer loop
+      vertex -2.97634 -0.375999 0
+      vertex -2.96306 -0.469303 5
+      vertex -2.96306 -0.469303 0
+    endloop
+  endfacet
+  facet normal 0.99889 0.047105 0
+    outer loop
+      vertex -2.99408 -0.188371 5
+      vertex -2.99852 -0.0942316 0
+      vertex -2.99852 -0.0942316 5
+    endloop
+  endfacet
+  facet normal 0.99889 0.047105 0
+    outer loop
+      vertex -2.99852 -0.0942316 0
+      vertex -2.99408 -0.188371 5
+      vertex -2.99408 -0.188371 0
+    endloop
+  endfacet
+  facet normal -0.760405 0.649449 0
+    outer loop
+      vertex 2.25033 -1.98394 0
+      vertex 2.31154 -1.91227 5
+      vertex 2.31154 -1.91227 0
+    endloop
+  endfacet
+  facet normal -0.760405 0.649449 0
+    outer loop
+      vertex 2.31154 -1.91227 5
+      vertex 2.25033 -1.98394 0
+      vertex 2.25033 -1.98394 5
+    endloop
+  endfacet
+  facet normal -0.911382 -0.411562 0
+    outer loop
+      vertex 231.377 0.595721 -5
+      vertex 231.357 0.638668 0
+      vertex 231.357 0.638668 -5
+    endloop
+  endfacet
+  facet normal -0.911382 -0.411562 0
+    outer loop
+      vertex 231.357 0.638668 0
+      vertex 231.377 0.595721 -5
+      vertex 231.377 0.595721 0
+    endloop
+  endfacet
+  facet normal -0.353464 -0.935448 0
+    outer loop
+      vertex 230.508 1.41132 -5
+      vertex 230.552 1.39466 0
+      vertex 230.508 1.41132 0
+    endloop
+  endfacet
+  facet normal -0.353464 -0.935448 -0
+    outer loop
+      vertex 230.552 1.39466 0
+      vertex 230.508 1.41132 -5
+      vertex 230.552 1.39466 -5
+    endloop
+  endfacet
+  facet normal 0.382683 -0.92388 0
+    outer loop
+      vertex 229.404 1.37663 -5
+      vertex 229.448 1.39466 0
+      vertex 229.404 1.37663 0
+    endloop
+  endfacet
+  facet normal 0.382683 -0.92388 0
+    outer loop
+      vertex 229.448 1.39466 0
+      vertex 229.404 1.37663 -5
+      vertex 229.448 1.39466 -5
+    endloop
+  endfacet
+  facet normal 0.935507 -0.353307 0
+    outer loop
+      vertex 228.589 0.508106 0
+      vertex 228.605 0.552186 -5
+      vertex 228.605 0.552186 0
+    endloop
+  endfacet
+  facet normal 0.935507 -0.353307 0
+    outer loop
+      vertex 228.605 0.552186 -5
+      vertex 228.589 0.508106 0
+      vertex 228.589 0.508106 -5
+    endloop
+  endfacet
+  facet normal -0.998897 0.0469536 0
+    outer loop
+      vertex 231.497 -0.0941849 -5
+      vertex 231.499 -0.0471153 0
+      vertex 231.499 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal -0.998897 0.0469536 0
+    outer loop
+      vertex 231.499 -0.0471153 0
+      vertex 231.497 -0.0941849 -5
+      vertex 231.497 -0.0941849 0
+    endloop
+  endfacet
+  facet normal -0.522527 -0.852623 0
+    outer loop
+      vertex 230.764 1.29111 -5
+      vertex 230.804 1.26649 0
+      vertex 230.764 1.29111 0
+    endloop
+  endfacet
+  facet normal -0.522527 -0.852623 -0
+    outer loop
+      vertex 230.804 1.26649 0
+      vertex 230.764 1.29111 -5
+      vertex 230.804 1.26649 -5
+    endloop
+  endfacet
+  facet normal 0.739695 -0.672943 0
+    outer loop
+      vertex 228.875 0.991967 0
+      vertex 228.907 1.02682 -5
+      vertex 228.907 1.02682 0
+    endloop
+  endfacet
+  facet normal 0.739695 -0.672943 0
+    outer loop
+      vertex 228.907 1.02682 -5
+      vertex 228.875 0.991967 0
+      vertex 228.875 0.991967 -5
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex 229.673 1.46387 -5
+      vertex 229.719 1.47343 0
+      vertex 229.673 1.46387 0
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex 229.719 1.47343 0
+      vertex 229.673 1.46387 -5
+      vertex 229.719 1.47343 -5
+    endloop
+  endfacet
+  facet normal -0.411475 0.911421 0
+    outer loop
+      vertex 230.639 -1.35724 -5
+      vertex 230.596 -1.37663 0
+      vertex 230.639 -1.35724 0
+    endloop
+  endfacet
+  facet normal -0.411475 0.911421 0
+    outer loop
+      vertex 230.596 -1.37663 0
+      vertex 230.639 -1.35724 -5
+      vertex 230.596 -1.37663 -5
+    endloop
+  endfacet
+  facet normal 0.673029 0.739616 -0
+    outer loop
+      vertex 229.008 -1.12517 -5
+      vertex 228.973 -1.09345 0
+      vertex 229.008 -1.12517 0
+    endloop
+  endfacet
+  facet normal 0.673029 0.739616 0
+    outer loop
+      vertex 228.973 -1.09345 0
+      vertex 229.008 -1.12517 -5
+      vertex 228.973 -1.09345 -5
+    endloop
+  endfacet
+  facet normal 0.911382 0.411562 0
+    outer loop
+      vertex 228.643 -0.638668 0
+      vertex 228.623 -0.595721 -5
+      vertex 228.623 -0.595721 0
+    endloop
+  endfacet
+  facet normal 0.911382 0.411562 0
+    outer loop
+      vertex 228.623 -0.595721 -5
+      vertex 228.643 -0.638668 0
+      vertex 228.643 -0.638668 -5
+    endloop
+  endfacet
+  facet normal -0.990029 -0.14086 0
+    outer loop
+      vertex 231.488 0.188 -5
+      vertex 231.482 0.234652 0
+      vertex 231.482 0.234652 -5
+    endloop
+  endfacet
+  facet normal -0.990029 -0.14086 0
+    outer loop
+      vertex 231.482 0.234652 0
+      vertex 231.488 0.188 -5
+      vertex 231.488 0.188 0
+    endloop
+  endfacet
+  facet normal -0.955797 -0.294029 0
+    outer loop
+      vertex 231.44 0.418487 -5
+      vertex 231.427 0.463525 0
+      vertex 231.427 0.463525 -5
+    endloop
+  endfacet
+  facet normal -0.955797 -0.294029 0
+    outer loop
+      vertex 231.427 0.463525 0
+      vertex 231.44 0.418487 -5
+      vertex 231.44 0.418487 0
+    endloop
+  endfacet
+  facet normal -0.83573 -0.54914 0
+    outer loop
+      vertex 231.266 0.80374 -5
+      vertex 231.241 0.843124 0
+      vertex 231.241 0.843124 -5
+    endloop
+  endfacet
+  facet normal -0.83573 -0.54914 0
+    outer loop
+      vertex 231.241 0.843124 0
+      vertex 231.266 0.80374 -5
+      vertex 231.266 0.80374 0
+    endloop
+  endfacet
+  facet normal -0.171936 -0.985108 0
+    outer loop
+      vertex 230.235 1.48153 -5
+      vertex 230.281 1.47343 0
+      vertex 230.235 1.48153 0
+    endloop
+  endfacet
+  facet normal -0.171936 -0.985108 -0
+    outer loop
+      vertex 230.281 1.47343 0
+      vertex 230.235 1.48153 -5
+      vertex 230.281 1.47343 -5
+    endloop
+  endfacet
+  facet normal -0.625263 -0.780414 0
+    outer loop
+      vertex 230.919 1.18523 -5
+      vertex 230.956 1.15577 0
+      vertex 230.919 1.18523 0
+    endloop
+  endfacet
+  facet normal -0.625263 -0.780414 -0
+    outer loop
+      vertex 230.956 1.15577 0
+      vertex 230.919 1.18523 -5
+      vertex 230.956 1.15577 -5
+    endloop
+  endfacet
+  facet normal 0.985106 -0.171946 0
+    outer loop
+      vertex 228.518 0.234652 0
+      vertex 228.527 0.281072 -5
+      vertex 228.527 0.281072 0
+    endloop
+  endfacet
+  facet normal 0.985106 -0.171946 0
+    outer loop
+      vertex 228.527 0.281072 -5
+      vertex 228.518 0.234652 0
+      vertex 228.518 0.234652 -5
+    endloop
+  endfacet
+  facet normal 0.852724 -0.522362 0
+    outer loop
+      vertex 228.709 0.763561 0
+      vertex 228.734 0.80374 -5
+      vertex 228.734 0.80374 0
+    endloop
+  endfacet
+  facet normal 0.852724 -0.522362 0
+    outer loop
+      vertex 228.734 0.80374 -5
+      vertex 228.709 0.763561 0
+      vertex 228.709 0.763561 -5
+    endloop
+  endfacet
+  facet normal 0.109716 -0.993963 0
+    outer loop
+      vertex 229.812 1.48817 -5
+      vertex 229.859 1.49334 0
+      vertex 229.812 1.48817 0
+    endloop
+  endfacet
+  facet normal 0.109716 -0.993963 0
+    outer loop
+      vertex 229.859 1.49334 0
+      vertex 229.812 1.48817 -5
+      vertex 229.859 1.49334 -5
+    endloop
+  endfacet
+  facet normal 0.549031 -0.835802 0
+    outer loop
+      vertex 229.157 1.24062 -5
+      vertex 229.196 1.26649 0
+      vertex 229.157 1.24062 0
+    endloop
+  endfacet
+  facet normal 0.549031 -0.835802 0
+    outer loop
+      vertex 229.196 1.26649 0
+      vertex 229.157 1.24062 -5
+      vertex 229.196 1.26649 -5
+    endloop
+  endfacet
+  facet normal 0.467963 -0.883748 0
+    outer loop
+      vertex 229.277 1.31446 -5
+      vertex 229.319 1.33651 0
+      vertex 229.277 1.31446 0
+    endloop
+  endfacet
+  facet normal 0.467963 -0.883748 0
+    outer loop
+      vertex 229.319 1.33651 0
+      vertex 229.277 1.31446 -5
+      vertex 229.319 1.33651 -5
+    endloop
+  endfacet
+  facet normal 0.818263 0.574844 0
+    outer loop
+      vertex 228.786 -0.881678 0
+      vertex 228.759 -0.843124 -5
+      vertex 228.759 -0.843124 0
+    endloop
+  endfacet
+  facet normal 0.818263 0.574844 0
+    outer loop
+      vertex 228.759 -0.843124 -5
+      vertex 228.786 -0.881678 0
+      vertex 228.786 -0.881678 -5
+    endloop
+  endfacet
+  facet normal -0.88364 -0.468167 0
+    outer loop
+      vertex 231.337 0.680985 -5
+      vertex 231.314 0.722631 0
+      vertex 231.314 0.722631 -5
+    endloop
+  endfacet
+  facet normal -0.88364 -0.468167 0
+    outer loop
+      vertex 231.314 0.722631 0
+      vertex 231.337 0.680985 -5
+      vertex 231.337 0.680985 0
+    endloop
+  endfacet
+  facet normal -0.868636 -0.49545 0
+    outer loop
+      vertex 231.314 0.722631 -5
+      vertex 231.291 0.763561 0
+      vertex 231.291 0.763561 -5
+    endloop
+  endfacet
+  facet normal -0.868636 -0.49545 0
+    outer loop
+      vertex 231.291 0.763561 0
+      vertex 231.314 0.722631 -5
+      vertex 231.314 0.722631 0
+    endloop
+  endfacet
+  facet normal -0.718141 -0.695898 0
+    outer loop
+      vertex 231.093 1.02682 -5
+      vertex 231.061 1.06066 0
+      vertex 231.061 1.06066 -5
+    endloop
+  endfacet
+  facet normal -0.718141 -0.695898 0
+    outer loop
+      vertex 231.061 1.06066 0
+      vertex 231.093 1.02682 -5
+      vertex 231.093 1.02682 0
+    endloop
+  endfacet
+  facet normal -0.780411 -0.625267 0
+    outer loop
+      vertex 231.185 0.91936 -5
+      vertex 231.156 0.956136 0
+      vertex 231.156 0.956136 -5
+    endloop
+  endfacet
+  facet normal -0.780411 -0.625267 0
+    outer loop
+      vertex 231.156 0.956136 0
+      vertex 231.185 0.91936 -5
+      vertex 231.185 0.91936 0
+    endloop
+  endfacet
+  facet normal 0.0157243 -0.999876 0
+    outer loop
+      vertex 229.953 1.49926 -5
+      vertex 230 1.5 0
+      vertex 229.953 1.49926 0
+    endloop
+  endfacet
+  facet normal 0.0157243 -0.999876 0
+    outer loop
+      vertex 230 1.5 0
+      vertex 229.953 1.49926 -5
+      vertex 230 1.5 -5
+    endloop
+  endfacet
+  facet normal -0.263847 -0.964565 0
+    outer loop
+      vertex 230.373 1.45287 -5
+      vertex 230.418 1.44044 0
+      vertex 230.373 1.45287 0
+    endloop
+  endfacet
+  facet normal -0.263847 -0.964565 -0
+    outer loop
+      vertex 230.418 1.44044 0
+      vertex 230.373 1.45287 -5
+      vertex 230.418 1.44044 -5
+    endloop
+  endfacet
+  facet normal -0.140917 -0.990021 0
+    outer loop
+      vertex 230.188 1.48817 -5
+      vertex 230.235 1.48153 0
+      vertex 230.188 1.48817 0
+    endloop
+  endfacet
+  facet normal -0.140917 -0.990021 -0
+    outer loop
+      vertex 230.235 1.48153 0
+      vertex 230.188 1.48817 -5
+      vertex 230.235 1.48153 -5
+    endloop
+  endfacet
+  facet normal -0.0784559 -0.996918 0
+    outer loop
+      vertex 230.094 1.49704 -5
+      vertex 230.141 1.49334 0
+      vertex 230.094 1.49704 0
+    endloop
+  endfacet
+  facet normal -0.0784559 -0.996918 -0
+    outer loop
+      vertex 230.141 1.49334 0
+      vertex 230.094 1.49704 -5
+      vertex 230.141 1.49334 -5
+    endloop
+  endfacet
+  facet normal -0.439961 -0.898017 0
+    outer loop
+      vertex 230.639 1.35724 -5
+      vertex 230.681 1.33651 0
+      vertex 230.639 1.35724 0
+    endloop
+  endfacet
+  facet normal -0.439961 -0.898017 -0
+    outer loop
+      vertex 230.681 1.33651 0
+      vertex 230.639 1.35724 -5
+      vertex 230.681 1.33651 -5
+    endloop
+  endfacet
+  facet normal -0.411475 -0.911421 0
+    outer loop
+      vertex 230.596 1.37663 -5
+      vertex 230.639 1.35724 0
+      vertex 230.596 1.37663 0
+    endloop
+  endfacet
+  facet normal -0.411475 -0.911421 -0
+    outer loop
+      vertex 230.639 1.35724 0
+      vertex 230.596 1.37663 -5
+      vertex 230.639 1.35724 -5
+    endloop
+  endfacet
+  facet normal -0.673029 -0.739616 0
+    outer loop
+      vertex 230.992 1.12517 -5
+      vertex 231.027 1.09345 0
+      vertex 230.992 1.12517 0
+    endloop
+  endfacet
+  facet normal -0.673029 -0.739616 -0
+    outer loop
+      vertex 231.027 1.09345 0
+      vertex 230.992 1.12517 -5
+      vertex 231.027 1.09345 -5
+    endloop
+  endfacet
+  facet normal 0.964549 -0.263905 0
+    outer loop
+      vertex 228.547 0.373034 0
+      vertex 228.56 0.418487 -5
+      vertex 228.56 0.418487 0
+    endloop
+  endfacet
+  facet normal 0.964549 -0.263905 0
+    outer loop
+      vertex 228.56 0.418487 -5
+      vertex 228.547 0.373034 0
+      vertex 228.547 0.373034 -5
+    endloop
+  endfacet
+  facet normal 0.999879 -0.0155434 0
+    outer loop
+      vertex 228.5 0 0
+      vertex 228.501 0.0471153 -5
+      vertex 228.501 0.0471153 0
+    endloop
+  endfacet
+  facet normal 0.999879 -0.0155434 0
+    outer loop
+      vertex 228.501 0.0471153 -5
+      vertex 228.5 0 0
+      vertex 228.5 0 -5
+    endloop
+  endfacet
+  facet normal 0.990029 -0.14086 0
+    outer loop
+      vertex 228.512 0.188 0
+      vertex 228.518 0.234652 -5
+      vertex 228.518 0.234652 0
+    endloop
+  endfacet
+  facet normal 0.990029 -0.14086 0
+    outer loop
+      vertex 228.518 0.234652 -5
+      vertex 228.512 0.188 0
+      vertex 228.512 0.188 -5
+    endloop
+  endfacet
+  facet normal 0.996925 -0.0783632 0
+    outer loop
+      vertex 228.503 0.0941849 0
+      vertex 228.507 0.141162 -5
+      vertex 228.507 0.141162 0
+    endloop
+  endfacet
+  facet normal 0.996925 -0.0783632 0
+    outer loop
+      vertex 228.507 0.141162 -5
+      vertex 228.503 0.0941849 0
+      vertex 228.503 0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0.898108 -0.439774 0
+    outer loop
+      vertex 228.643 0.638668 0
+      vertex 228.663 0.680985 -5
+      vertex 228.663 0.680985 0
+    endloop
+  endfacet
+  facet normal 0.898108 -0.439774 0
+    outer loop
+      vertex 228.663 0.680985 -5
+      vertex 228.643 0.638668 0
+      vertex 228.643 0.638668 -5
+    endloop
+  endfacet
+  facet normal 0.911382 -0.411562 0
+    outer loop
+      vertex 228.623 0.595721 0
+      vertex 228.643 0.638668 -5
+      vertex 228.643 0.638668 0
+    endloop
+  endfacet
+  facet normal 0.911382 -0.411562 0
+    outer loop
+      vertex 228.643 0.638668 -5
+      vertex 228.623 0.595721 0
+      vertex 228.623 0.595721 -5
+    endloop
+  endfacet
+  facet normal 0.780569 -0.62507 0
+    outer loop
+      vertex 228.815 0.91936 0
+      vertex 228.844 0.956136 -5
+      vertex 228.844 0.956136 0
+    endloop
+  endfacet
+  facet normal 0.780569 -0.62507 0
+    outer loop
+      vertex 228.844 0.956136 -5
+      vertex 228.815 0.91936 0
+      vertex 228.815 0.91936 -5
+    endloop
+  endfacet
+  facet normal 0.294013 -0.955801 0
+    outer loop
+      vertex 229.536 1.42658 -5
+      vertex 229.582 1.44044 0
+      vertex 229.536 1.42658 0
+    endloop
+  endfacet
+  facet normal 0.294013 -0.955801 0
+    outer loop
+      vertex 229.582 1.44044 0
+      vertex 229.536 1.42658 -5
+      vertex 229.582 1.44044 -5
+    endloop
+  endfacet
+  facet normal 0.323984 -0.946062 0
+    outer loop
+      vertex 229.492 1.41132 -5
+      vertex 229.536 1.42658 0
+      vertex 229.492 1.41132 0
+    endloop
+  endfacet
+  facet normal 0.323984 -0.946062 0
+    outer loop
+      vertex 229.536 1.42658 0
+      vertex 229.492 1.41132 -5
+      vertex 229.536 1.42658 -5
+    endloop
+  endfacet
+  facet normal 0.0470911 -0.998891 0
+    outer loop
+      vertex 229.906 1.49704 -5
+      vertex 229.953 1.49926 0
+      vertex 229.906 1.49704 0
+    endloop
+  endfacet
+  facet normal 0.0470911 -0.998891 0
+    outer loop
+      vertex 229.953 1.49926 0
+      vertex 229.906 1.49704 -5
+      vertex 229.953 1.49926 -5
+    endloop
+  endfacet
+  facet normal 0.495387 -0.868672 0
+    outer loop
+      vertex 229.236 1.29111 -5
+      vertex 229.277 1.31446 0
+      vertex 229.236 1.29111 0
+    endloop
+  endfacet
+  facet normal 0.495387 -0.868672 0
+    outer loop
+      vertex 229.277 1.31446 0
+      vertex 229.236 1.29111 -5
+      vertex 229.277 1.31446 -5
+    endloop
+  endfacet
+  facet normal 0.439961 -0.898017 0
+    outer loop
+      vertex 229.319 1.33651 -5
+      vertex 229.361 1.35724 0
+      vertex 229.319 1.33651 0
+    endloop
+  endfacet
+  facet normal 0.439961 -0.898017 0
+    outer loop
+      vertex 229.361 1.35724 0
+      vertex 229.319 1.33651 -5
+      vertex 229.361 1.35724 -5
+    endloop
+  endfacet
+  facet normal 0.625263 -0.780414 0
+    outer loop
+      vertex 229.044 1.15577 -5
+      vertex 229.081 1.18523 0
+      vertex 229.044 1.15577 0
+    endloop
+  endfacet
+  facet normal 0.625263 -0.780414 0
+    outer loop
+      vertex 229.081 1.18523 0
+      vertex 229.044 1.15577 -5
+      vertex 229.081 1.18523 -5
+    endloop
+  endfacet
+  facet normal 0.600505 -0.799621 0
+    outer loop
+      vertex 229.081 1.18523 -5
+      vertex 229.118 1.21352 0
+      vertex 229.081 1.18523 0
+    endloop
+  endfacet
+  facet normal 0.600505 -0.799621 0
+    outer loop
+      vertex 229.118 1.21352 0
+      vertex 229.081 1.18523 -5
+      vertex 229.118 1.21352 -5
+    endloop
+  endfacet
+  facet normal -0.999874 -0.0158672 0
+    outer loop
+      vertex 231.5 0 -5
+      vertex 231.499 0.0471153 0
+      vertex 231.499 0.0471153 -5
+    endloop
+  endfacet
+  facet normal -0.999874 -0.0158672 0
+    outer loop
+      vertex 231.499 0.0471153 0
+      vertex 231.5 0 -5
+      vertex 231.5 0 0
+    endloop
+  endfacet
+  facet normal -0.990029 0.14086 0
+    outer loop
+      vertex 231.482 -0.234652 -5
+      vertex 231.488 -0.188 0
+      vertex 231.488 -0.188 -5
+    endloop
+  endfacet
+  facet normal -0.990029 0.14086 0
+    outer loop
+      vertex 231.488 -0.188 0
+      vertex 231.482 -0.234652 -5
+      vertex 231.482 -0.234652 0
+    endloop
+  endfacet
+  facet normal -0.935507 0.353307 0
+    outer loop
+      vertex 231.395 -0.552186 -5
+      vertex 231.411 -0.508106 0
+      vertex 231.411 -0.508106 -5
+    endloop
+  endfacet
+  facet normal -0.935507 0.353307 0
+    outer loop
+      vertex 231.411 -0.508106 0
+      vertex 231.395 -0.552186 -5
+      vertex 231.395 -0.552186 0
+    endloop
+  endfacet
+  facet normal -0.780411 0.625267 0
+    outer loop
+      vertex 231.156 -0.956136 -5
+      vertex 231.185 -0.91936 0
+      vertex 231.185 -0.91936 -5
+    endloop
+  endfacet
+  facet normal -0.780411 0.625267 0
+    outer loop
+      vertex 231.185 -0.91936 0
+      vertex 231.156 -0.956136 -5
+      vertex 231.156 -0.956136 0
+    endloop
+  endfacet
+  facet normal 0.990029 0.14086 0
+    outer loop
+      vertex 228.518 -0.234652 0
+      vertex 228.512 -0.188 -5
+      vertex 228.512 -0.188 0
+    endloop
+  endfacet
+  facet normal 0.990029 0.14086 0
+    outer loop
+      vertex 228.512 -0.188 -5
+      vertex 228.518 -0.234652 0
+      vertex 228.518 -0.234652 -5
+    endloop
+  endfacet
+  facet normal 0.923857 0.382738 0
+    outer loop
+      vertex 228.623 -0.595721 0
+      vertex 228.605 -0.552186 -5
+      vertex 228.605 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0.923857 0.382738 0
+    outer loop
+      vertex 228.605 -0.552186 -5
+      vertex 228.623 -0.595721 0
+      vertex 228.623 -0.595721 -5
+    endloop
+  endfacet
+  facet normal -0.20279 0.979222 0
+    outer loop
+      vertex 230.327 -1.46387 -5
+      vertex 230.281 -1.47343 0
+      vertex 230.327 -1.46387 0
+    endloop
+  endfacet
+  facet normal -0.20279 0.979222 0
+    outer loop
+      vertex 230.281 -1.47343 0
+      vertex 230.327 -1.46387 -5
+      vertex 230.281 -1.47343 -5
+    endloop
+  endfacet
+  facet normal -0.946018 -0.324115 0
+    outer loop
+      vertex 231.427 0.463525 -5
+      vertex 231.411 0.508106 0
+      vertex 231.411 0.508106 -5
+    endloop
+  endfacet
+  facet normal -0.946018 -0.324115 0
+    outer loop
+      vertex 231.411 0.508106 0
+      vertex 231.427 0.463525 -5
+      vertex 231.427 0.463525 0
+    endloop
+  endfacet
+  facet normal -0.923857 -0.382738 0
+    outer loop
+      vertex 231.395 0.552186 -5
+      vertex 231.377 0.595721 0
+      vertex 231.377 0.595721 -5
+    endloop
+  endfacet
+  facet normal -0.923857 -0.382738 0
+    outer loop
+      vertex 231.377 0.595721 0
+      vertex 231.395 0.552186 -5
+      vertex 231.395 0.552186 0
+    endloop
+  endfacet
+  facet normal -0.898108 -0.439774 0
+    outer loop
+      vertex 231.357 0.638668 -5
+      vertex 231.337 0.680985 0
+      vertex 231.337 0.680985 -5
+    endloop
+  endfacet
+  facet normal -0.898108 -0.439774 0
+    outer loop
+      vertex 231.337 0.680985 0
+      vertex 231.357 0.638668 -5
+      vertex 231.357 0.638668 0
+    endloop
+  endfacet
+  facet normal -0.69603 -0.718013 0
+    outer loop
+      vertex 231.027 1.09345 -5
+      vertex 231.061 1.06066 0
+      vertex 231.027 1.09345 0
+    endloop
+  endfacet
+  facet normal -0.69603 -0.718013 -0
+    outer loop
+      vertex 231.061 1.06066 0
+      vertex 231.027 1.09345 -5
+      vertex 231.061 1.06066 -5
+    endloop
+  endfacet
+  facet normal -0.852724 -0.522362 0
+    outer loop
+      vertex 231.291 0.763561 -5
+      vertex 231.266 0.80374 0
+      vertex 231.266 0.80374 -5
+    endloop
+  endfacet
+  facet normal -0.852724 -0.522362 0
+    outer loop
+      vertex 231.266 0.80374 0
+      vertex 231.291 0.763561 -5
+      vertex 231.291 0.763561 0
+    endloop
+  endfacet
+  facet normal -0.79956 -0.600586 0
+    outer loop
+      vertex 231.214 0.881678 -5
+      vertex 231.185 0.91936 0
+      vertex 231.185 0.91936 -5
+    endloop
+  endfacet
+  facet normal -0.79956 -0.600586 0
+    outer loop
+      vertex 231.185 0.91936 0
+      vertex 231.214 0.881678 -5
+      vertex 231.214 0.881678 0
+    endloop
+  endfacet
+  facet normal -0.818263 -0.574844 0
+    outer loop
+      vertex 231.241 0.843124 -5
+      vertex 231.214 0.881678 0
+      vertex 231.214 0.881678 -5
+    endloop
+  endfacet
+  facet normal -0.818263 -0.574844 0
+    outer loop
+      vertex 231.214 0.881678 0
+      vertex 231.241 0.843124 -5
+      vertex 231.241 0.843124 0
+    endloop
+  endfacet
+  facet normal -0.760501 -0.649337 0
+    outer loop
+      vertex 231.156 0.956136 -5
+      vertex 231.125 0.991967 0
+      vertex 231.125 0.991967 -5
+    endloop
+  endfacet
+  facet normal -0.760501 -0.649337 0
+    outer loop
+      vertex 231.125 0.991967 0
+      vertex 231.156 0.956136 -5
+      vertex 231.156 0.956136 0
+    endloop
+  endfacet
+  facet normal -0.739533 -0.67312 0
+    outer loop
+      vertex 231.125 0.991967 -5
+      vertex 231.093 1.02682 0
+      vertex 231.093 1.02682 -5
+    endloop
+  endfacet
+  facet normal -0.739533 -0.67312 0
+    outer loop
+      vertex 231.093 1.02682 0
+      vertex 231.125 0.991967 -5
+      vertex 231.125 0.991967 0
+    endloop
+  endfacet
+  facet normal -0.294013 -0.955801 0
+    outer loop
+      vertex 230.418 1.44044 -5
+      vertex 230.464 1.42658 0
+      vertex 230.418 1.44044 0
+    endloop
+  endfacet
+  facet normal -0.294013 -0.955801 -0
+    outer loop
+      vertex 230.464 1.42658 0
+      vertex 230.418 1.44044 -5
+      vertex 230.464 1.42658 -5
+    endloop
+  endfacet
+  facet normal -0.323984 -0.946062 0
+    outer loop
+      vertex 230.464 1.42658 -5
+      vertex 230.508 1.41132 0
+      vertex 230.464 1.42658 0
+    endloop
+  endfacet
+  facet normal -0.323984 -0.946062 -0
+    outer loop
+      vertex 230.508 1.41132 0
+      vertex 230.464 1.42658 -5
+      vertex 230.508 1.41132 -5
+    endloop
+  endfacet
+  facet normal -0.0471064 -0.99889 0
+    outer loop
+      vertex 230.047 1.49926 -5
+      vertex 230.094 1.49704 0
+      vertex 230.047 1.49926 0
+    endloop
+  endfacet
+  facet normal -0.0471064 -0.99889 -0
+    outer loop
+      vertex 230.094 1.49704 0
+      vertex 230.047 1.49926 -5
+      vertex 230.094 1.49704 -5
+    endloop
+  endfacet
+  facet normal -0.0157243 -0.999876 0
+    outer loop
+      vertex 230 1.5 -5
+      vertex 230.047 1.49926 0
+      vertex 230 1.5 0
+    endloop
+  endfacet
+  facet normal -0.0157243 -0.999876 -0
+    outer loop
+      vertex 230.047 1.49926 0
+      vertex 230 1.5 -5
+      vertex 230.047 1.49926 -5
+    endloop
+  endfacet
+  facet normal -0.109716 -0.993963 0
+    outer loop
+      vertex 230.141 1.49334 -5
+      vertex 230.188 1.48817 0
+      vertex 230.141 1.49334 0
+    endloop
+  endfacet
+  facet normal -0.109716 -0.993963 -0
+    outer loop
+      vertex 230.188 1.48817 0
+      vertex 230.141 1.49334 -5
+      vertex 230.188 1.48817 -5
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 0
+    outer loop
+      vertex 230.281 1.47343 -5
+      vertex 230.327 1.46387 0
+      vertex 230.281 1.47343 0
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 -0
+    outer loop
+      vertex 230.327 1.46387 0
+      vertex 230.281 1.47343 -5
+      vertex 230.327 1.46387 -5
+    endloop
+  endfacet
+  facet normal -0.23344 -0.972371 0
+    outer loop
+      vertex 230.327 1.46387 -5
+      vertex 230.373 1.45287 0
+      vertex 230.327 1.46387 0
+    endloop
+  endfacet
+  facet normal -0.23344 -0.972371 -0
+    outer loop
+      vertex 230.373 1.45287 0
+      vertex 230.327 1.46387 -5
+      vertex 230.373 1.45287 -5
+    endloop
+  endfacet
+  facet normal -0.467963 -0.883748 0
+    outer loop
+      vertex 230.681 1.33651 -5
+      vertex 230.723 1.31446 0
+      vertex 230.681 1.33651 0
+    endloop
+  endfacet
+  facet normal -0.467963 -0.883748 -0
+    outer loop
+      vertex 230.723 1.31446 0
+      vertex 230.681 1.33651 -5
+      vertex 230.723 1.31446 -5
+    endloop
+  endfacet
+  facet normal -0.495387 -0.868672 0
+    outer loop
+      vertex 230.723 1.31446 -5
+      vertex 230.764 1.29111 0
+      vertex 230.723 1.31446 0
+    endloop
+  endfacet
+  facet normal -0.495387 -0.868672 -0
+    outer loop
+      vertex 230.764 1.29111 0
+      vertex 230.723 1.31446 -5
+      vertex 230.764 1.29111 -5
+    endloop
+  endfacet
+  facet normal -0.382683 -0.92388 0
+    outer loop
+      vertex 230.552 1.39466 -5
+      vertex 230.596 1.37663 0
+      vertex 230.552 1.39466 0
+    endloop
+  endfacet
+  facet normal -0.382683 -0.92388 -0
+    outer loop
+      vertex 230.596 1.37663 0
+      vertex 230.552 1.39466 -5
+      vertex 230.596 1.37663 -5
+    endloop
+  endfacet
+  facet normal -0.57495 -0.818189 0
+    outer loop
+      vertex 230.843 1.24062 -5
+      vertex 230.882 1.21352 0
+      vertex 230.843 1.24062 0
+    endloop
+  endfacet
+  facet normal -0.57495 -0.818189 -0
+    outer loop
+      vertex 230.882 1.21352 0
+      vertex 230.843 1.24062 -5
+      vertex 230.882 1.21352 -5
+    endloop
+  endfacet
+  facet normal -0.549031 -0.835802 0
+    outer loop
+      vertex 230.804 1.26649 -5
+      vertex 230.843 1.24062 0
+      vertex 230.804 1.26649 0
+    endloop
+  endfacet
+  facet normal -0.549031 -0.835802 -0
+    outer loop
+      vertex 230.843 1.24062 0
+      vertex 230.804 1.26649 -5
+      vertex 230.843 1.24062 -5
+    endloop
+  endfacet
+  facet normal -0.649334 -0.760504 0
+    outer loop
+      vertex 230.956 1.15577 -5
+      vertex 230.992 1.12517 0
+      vertex 230.956 1.15577 0
+    endloop
+  endfacet
+  facet normal -0.649334 -0.760504 -0
+    outer loop
+      vertex 230.992 1.12517 0
+      vertex 230.956 1.15577 -5
+      vertex 230.992 1.12517 -5
+    endloop
+  endfacet
+  facet normal 0.955797 -0.294029 0
+    outer loop
+      vertex 228.56 0.418487 0
+      vertex 228.573 0.463525 -5
+      vertex 228.573 0.463525 0
+    endloop
+  endfacet
+  facet normal 0.955797 -0.294029 0
+    outer loop
+      vertex 228.573 0.463525 -5
+      vertex 228.56 0.418487 0
+      vertex 228.56 0.418487 -5
+    endloop
+  endfacet
+  facet normal 0.946018 -0.324115 0
+    outer loop
+      vertex 228.573 0.463525 0
+      vertex 228.589 0.508106 -5
+      vertex 228.589 0.508106 0
+    endloop
+  endfacet
+  facet normal 0.946018 -0.324115 0
+    outer loop
+      vertex 228.589 0.508106 -5
+      vertex 228.573 0.463525 0
+      vertex 228.573 0.463525 -5
+    endloop
+  endfacet
+  facet normal 0.999879 0.0155434 0
+    outer loop
+      vertex 228.501 -0.0471153 0
+      vertex 228.5 0 -5
+      vertex 228.5 0 0
+    endloop
+  endfacet
+  facet normal 0.999879 0.0155434 0
+    outer loop
+      vertex 228.5 0 -5
+      vertex 228.501 -0.0471153 0
+      vertex 228.501 -0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0.998882 -0.0472767 0
+    outer loop
+      vertex 228.501 0.0471153 0
+      vertex 228.503 0.0941849 -5
+      vertex 228.503 0.0941849 0
+    endloop
+  endfacet
+  facet normal 0.998882 -0.0472767 0
+    outer loop
+      vertex 228.503 0.0941849 -5
+      vertex 228.501 0.0471153 0
+      vertex 228.501 0.0471153 -5
+    endloop
+  endfacet
+  facet normal 0.993957 -0.109772 0
+    outer loop
+      vertex 228.507 0.141162 0
+      vertex 228.512 0.188 -5
+      vertex 228.512 0.188 0
+    endloop
+  endfacet
+  facet normal 0.993957 -0.109772 0
+    outer loop
+      vertex 228.512 0.188 -5
+      vertex 228.507 0.141162 0
+      vertex 228.507 0.141162 -5
+    endloop
+  endfacet
+  facet normal 0.979238 -0.202713 0
+    outer loop
+      vertex 228.527 0.281072 0
+      vertex 228.536 0.327214 -5
+      vertex 228.536 0.327214 0
+    endloop
+  endfacet
+  facet normal 0.979238 -0.202713 0
+    outer loop
+      vertex 228.536 0.327214 -5
+      vertex 228.527 0.281072 0
+      vertex 228.527 0.281072 -5
+    endloop
+  endfacet
+  facet normal 0.972365 -0.233468 0
+    outer loop
+      vertex 228.536 0.327214 0
+      vertex 228.547 0.373034 -5
+      vertex 228.547 0.373034 0
+    endloop
+  endfacet
+  facet normal 0.972365 -0.233468 0
+    outer loop
+      vertex 228.547 0.373034 -5
+      vertex 228.536 0.327214 0
+      vertex 228.536 0.327214 -5
+    endloop
+  endfacet
+  facet normal 0.88364 -0.468167 0
+    outer loop
+      vertex 228.663 0.680985 0
+      vertex 228.686 0.722631 -5
+      vertex 228.686 0.722631 0
+    endloop
+  endfacet
+  facet normal 0.88364 -0.468167 0
+    outer loop
+      vertex 228.686 0.722631 -5
+      vertex 228.663 0.680985 0
+      vertex 228.663 0.680985 -5
+    endloop
+  endfacet
+  facet normal 0.868636 -0.49545 0
+    outer loop
+      vertex 228.686 0.722631 0
+      vertex 228.709 0.763561 -5
+      vertex 228.709 0.763561 0
+    endloop
+  endfacet
+  facet normal 0.868636 -0.49545 0
+    outer loop
+      vertex 228.709 0.763561 -5
+      vertex 228.686 0.722631 0
+      vertex 228.686 0.722631 -5
+    endloop
+  endfacet
+  facet normal 0.923857 -0.382738 0
+    outer loop
+      vertex 228.605 0.552186 0
+      vertex 228.623 0.595721 -5
+      vertex 228.623 0.595721 0
+    endloop
+  endfacet
+  facet normal 0.923857 -0.382738 0
+    outer loop
+      vertex 228.623 0.595721 -5
+      vertex 228.605 0.552186 0
+      vertex 228.605 0.552186 -5
+    endloop
+  endfacet
+  facet normal 0.760341 -0.649524 0
+    outer loop
+      vertex 228.844 0.956136 0
+      vertex 228.875 0.991967 -5
+      vertex 228.875 0.991967 0
+    endloop
+  endfacet
+  facet normal 0.760341 -0.649524 0
+    outer loop
+      vertex 228.875 0.991967 -5
+      vertex 228.844 0.956136 0
+      vertex 228.844 0.956136 -5
+    endloop
+  endfacet
+  facet normal 0.818263 -0.574844 0
+    outer loop
+      vertex 228.759 0.843124 0
+      vertex 228.786 0.881678 -5
+      vertex 228.786 0.881678 0
+    endloop
+  endfacet
+  facet normal 0.818263 -0.574844 0
+    outer loop
+      vertex 228.786 0.881678 -5
+      vertex 228.759 0.843124 0
+      vertex 228.759 0.843124 -5
+    endloop
+  endfacet
+  facet normal 0.83573 -0.54914 0
+    outer loop
+      vertex 228.734 0.80374 0
+      vertex 228.759 0.843124 -5
+      vertex 228.759 0.843124 0
+    endloop
+  endfacet
+  facet normal 0.83573 -0.54914 0
+    outer loop
+      vertex 228.759 0.843124 -5
+      vertex 228.734 0.80374 0
+      vertex 228.734 0.80374 -5
+    endloop
+  endfacet
+  facet normal 0.263847 -0.964565 0
+    outer loop
+      vertex 229.582 1.44044 -5
+      vertex 229.627 1.45287 0
+      vertex 229.582 1.44044 0
+    endloop
+  endfacet
+  facet normal 0.263847 -0.964565 0
+    outer loop
+      vertex 229.627 1.45287 0
+      vertex 229.582 1.44044 -5
+      vertex 229.627 1.45287 -5
+    endloop
+  endfacet
+  facet normal 0.23344 -0.972371 0
+    outer loop
+      vertex 229.627 1.45287 -5
+      vertex 229.673 1.46387 0
+      vertex 229.627 1.45287 0
+    endloop
+  endfacet
+  facet normal 0.23344 -0.972371 0
+    outer loop
+      vertex 229.673 1.46387 0
+      vertex 229.627 1.45287 -5
+      vertex 229.673 1.46387 -5
+    endloop
+  endfacet
+  facet normal 0.353464 -0.935448 0
+    outer loop
+      vertex 229.448 1.39466 -5
+      vertex 229.492 1.41132 0
+      vertex 229.448 1.39466 0
+    endloop
+  endfacet
+  facet normal 0.353464 -0.935448 0
+    outer loop
+      vertex 229.492 1.41132 0
+      vertex 229.448 1.39466 -5
+      vertex 229.492 1.41132 -5
+    endloop
+  endfacet
+  facet normal 0.140917 -0.990021 0
+    outer loop
+      vertex 229.765 1.48153 -5
+      vertex 229.812 1.48817 0
+      vertex 229.765 1.48153 0
+    endloop
+  endfacet
+  facet normal 0.140917 -0.990021 0
+    outer loop
+      vertex 229.812 1.48817 0
+      vertex 229.765 1.48153 -5
+      vertex 229.812 1.48817 -5
+    endloop
+  endfacet
+  facet normal 0.171936 -0.985108 0
+    outer loop
+      vertex 229.719 1.47343 -5
+      vertex 229.765 1.48153 0
+      vertex 229.719 1.47343 0
+    endloop
+  endfacet
+  facet normal 0.171936 -0.985108 0
+    outer loop
+      vertex 229.765 1.48153 0
+      vertex 229.719 1.47343 -5
+      vertex 229.765 1.48153 -5
+    endloop
+  endfacet
+  facet normal 0.0784812 -0.996916 0
+    outer loop
+      vertex 229.859 1.49334 -5
+      vertex 229.906 1.49704 0
+      vertex 229.859 1.49334 0
+    endloop
+  endfacet
+  facet normal 0.0784812 -0.996916 0
+    outer loop
+      vertex 229.906 1.49704 0
+      vertex 229.859 1.49334 -5
+      vertex 229.906 1.49704 -5
+    endloop
+  endfacet
+  facet normal 0.522527 -0.852623 0
+    outer loop
+      vertex 229.196 1.26649 -5
+      vertex 229.236 1.29111 0
+      vertex 229.196 1.26649 0
+    endloop
+  endfacet
+  facet normal 0.522527 -0.852623 0
+    outer loop
+      vertex 229.236 1.29111 0
+      vertex 229.196 1.26649 -5
+      vertex 229.236 1.29111 -5
+    endloop
+  endfacet
+  facet normal 0.411475 -0.911421 0
+    outer loop
+      vertex 229.361 1.35724 -5
+      vertex 229.404 1.37663 0
+      vertex 229.361 1.35724 0
+    endloop
+  endfacet
+  facet normal 0.411475 -0.911421 0
+    outer loop
+      vertex 229.404 1.37663 0
+      vertex 229.361 1.35724 -5
+      vertex 229.404 1.37663 -5
+    endloop
+  endfacet
+  facet normal 0.57495 -0.818189 0
+    outer loop
+      vertex 229.118 1.21352 -5
+      vertex 229.157 1.24062 0
+      vertex 229.118 1.21352 0
+    endloop
+  endfacet
+  facet normal 0.57495 -0.818189 0
+    outer loop
+      vertex 229.157 1.24062 0
+      vertex 229.118 1.21352 -5
+      vertex 229.157 1.24062 -5
+    endloop
+  endfacet
+  facet normal 0.673029 -0.739616 0
+    outer loop
+      vertex 228.973 1.09345 -5
+      vertex 229.008 1.12517 0
+      vertex 228.973 1.09345 0
+    endloop
+  endfacet
+  facet normal 0.673029 -0.739616 0
+    outer loop
+      vertex 229.008 1.12517 0
+      vertex 228.973 1.09345 -5
+      vertex 229.008 1.12517 -5
+    endloop
+  endfacet
+  facet normal 0.69603 -0.718013 0
+    outer loop
+      vertex 228.939 1.06066 -5
+      vertex 228.973 1.09345 0
+      vertex 228.939 1.06066 0
+    endloop
+  endfacet
+  facet normal 0.69603 -0.718013 0
+    outer loop
+      vertex 228.973 1.09345 0
+      vertex 228.939 1.06066 -5
+      vertex 228.973 1.09345 -5
+    endloop
+  endfacet
+  facet normal 0.649334 -0.760504 0
+    outer loop
+      vertex 229.008 1.12517 -5
+      vertex 229.044 1.15577 0
+      vertex 229.008 1.12517 0
+    endloop
+  endfacet
+  facet normal 0.649334 -0.760504 0
+    outer loop
+      vertex 229.044 1.15577 0
+      vertex 229.008 1.12517 -5
+      vertex 229.044 1.15577 -5
+    endloop
+  endfacet
+  facet normal 0.717979 -0.696065 0
+    outer loop
+      vertex 228.907 1.02682 0
+      vertex 228.939 1.06066 -5
+      vertex 228.939 1.06066 0
+    endloop
+  endfacet
+  facet normal 0.717979 -0.696065 0
+    outer loop
+      vertex 228.939 1.06066 -5
+      vertex 228.907 1.02682 0
+      vertex 228.907 1.02682 -5
+    endloop
+  endfacet
+  facet normal -0.999874 0.0158672 0
+    outer loop
+      vertex 231.499 -0.0471153 -5
+      vertex 231.5 0 0
+      vertex 231.5 0 -5
+    endloop
+  endfacet
+  facet normal -0.999874 0.0158672 0
+    outer loop
+      vertex 231.5 0 0
+      vertex 231.499 -0.0471153 -5
+      vertex 231.499 -0.0471153 0
+    endloop
+  endfacet
+  facet normal -0.996925 0.0783632 0
+    outer loop
+      vertex 231.493 -0.141162 -5
+      vertex 231.497 -0.0941849 0
+      vertex 231.497 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal -0.996925 0.0783632 0
+    outer loop
+      vertex 231.497 -0.0941849 0
+      vertex 231.493 -0.141162 -5
+      vertex 231.493 -0.141162 0
+    endloop
+  endfacet
+  facet normal -0.993957 0.109772 0
+    outer loop
+      vertex 231.488 -0.188 -5
+      vertex 231.493 -0.141162 0
+      vertex 231.493 -0.141162 -5
+    endloop
+  endfacet
+  facet normal -0.993957 0.109772 0
+    outer loop
+      vertex 231.493 -0.141162 0
+      vertex 231.488 -0.188 -5
+      vertex 231.488 -0.188 0
+    endloop
+  endfacet
+  facet normal -0.972438 0.233162 0
+    outer loop
+      vertex 231.453 -0.373034 -5
+      vertex 231.464 -0.327214 0
+      vertex 231.464 -0.327214 -5
+    endloop
+  endfacet
+  facet normal -0.972438 0.233162 0
+    outer loop
+      vertex 231.464 -0.327214 0
+      vertex 231.453 -0.373034 -5
+      vertex 231.453 -0.373034 0
+    endloop
+  endfacet
+  facet normal -0.985106 0.171946 0
+    outer loop
+      vertex 231.473 -0.281072 -5
+      vertex 231.482 -0.234652 0
+      vertex 231.482 -0.234652 -5
+    endloop
+  endfacet
+  facet normal -0.985106 0.171946 0
+    outer loop
+      vertex 231.482 -0.234652 0
+      vertex 231.473 -0.281072 -5
+      vertex 231.473 -0.281072 0
+    endloop
+  endfacet
+  facet normal -0.868636 0.49545 0
+    outer loop
+      vertex 231.291 -0.763561 -5
+      vertex 231.314 -0.722631 0
+      vertex 231.314 -0.722631 -5
+    endloop
+  endfacet
+  facet normal -0.868636 0.49545 0
+    outer loop
+      vertex 231.314 -0.722631 0
+      vertex 231.291 -0.763561 -5
+      vertex 231.291 -0.763561 0
+    endloop
+  endfacet
+  facet normal -0.549031 0.835802 0
+    outer loop
+      vertex 230.843 -1.24062 -5
+      vertex 230.804 -1.26649 0
+      vertex 230.843 -1.24062 0
+    endloop
+  endfacet
+  facet normal -0.549031 0.835802 0
+    outer loop
+      vertex 230.804 -1.26649 0
+      vertex 230.843 -1.24062 -5
+      vertex 230.804 -1.26649 -5
+    endloop
+  endfacet
+  facet normal -0.739533 0.67312 0
+    outer loop
+      vertex 231.093 -1.02682 -5
+      vertex 231.125 -0.991967 0
+      vertex 231.125 -0.991967 -5
+    endloop
+  endfacet
+  facet normal -0.739533 0.67312 0
+    outer loop
+      vertex 231.125 -0.991967 0
+      vertex 231.093 -1.02682 -5
+      vertex 231.093 -1.02682 0
+    endloop
+  endfacet
+  facet normal 0.495387 0.868672 -0
+    outer loop
+      vertex 229.277 -1.31446 -5
+      vertex 229.236 -1.29111 0
+      vertex 229.277 -1.31446 0
+    endloop
+  endfacet
+  facet normal 0.495387 0.868672 0
+    outer loop
+      vertex 229.236 -1.29111 0
+      vertex 229.277 -1.31446 -5
+      vertex 229.236 -1.29111 -5
+    endloop
+  endfacet
+  facet normal 0.998882 0.0472767 0
+    outer loop
+      vertex 228.503 -0.0941849 0
+      vertex 228.501 -0.0471153 -5
+      vertex 228.501 -0.0471153 0
+    endloop
+  endfacet
+  facet normal 0.998882 0.0472767 0
+    outer loop
+      vertex 228.501 -0.0471153 -5
+      vertex 228.503 -0.0941849 0
+      vertex 228.503 -0.0941849 -5
+    endloop
+  endfacet
+  facet normal 0.946018 0.324115 0
+    outer loop
+      vertex 228.589 -0.508106 0
+      vertex 228.573 -0.463525 -5
+      vertex 228.573 -0.463525 0
+    endloop
+  endfacet
+  facet normal 0.946018 0.324115 0
+    outer loop
+      vertex 228.573 -0.463525 -5
+      vertex 228.589 -0.508106 0
+      vertex 228.589 -0.508106 -5
+    endloop
+  endfacet
+  facet normal 0.996925 0.0783632 0
+    outer loop
+      vertex 228.507 -0.141162 0
+      vertex 228.503 -0.0941849 -5
+      vertex 228.503 -0.0941849 0
+    endloop
+  endfacet
+  facet normal 0.996925 0.0783632 0
+    outer loop
+      vertex 228.503 -0.0941849 -5
+      vertex 228.507 -0.141162 0
+      vertex 228.507 -0.141162 -5
+    endloop
+  endfacet
+  facet normal 0.955797 0.294029 0
+    outer loop
+      vertex 228.573 -0.463525 0
+      vertex 228.56 -0.418487 -5
+      vertex 228.56 -0.418487 0
+    endloop
+  endfacet
+  facet normal 0.955797 0.294029 0
+    outer loop
+      vertex 228.56 -0.418487 -5
+      vertex 228.573 -0.463525 0
+      vertex 228.573 -0.463525 -5
+    endloop
+  endfacet
+  facet normal 0.868636 0.49545 0
+    outer loop
+      vertex 228.709 -0.763561 0
+      vertex 228.686 -0.722631 -5
+      vertex 228.686 -0.722631 0
+    endloop
+  endfacet
+  facet normal 0.868636 0.49545 0
+    outer loop
+      vertex 228.686 -0.722631 -5
+      vertex 228.709 -0.763561 0
+      vertex 228.709 -0.763561 -5
+    endloop
+  endfacet
+  facet normal 0.717979 0.696065 0
+    outer loop
+      vertex 228.939 -1.06066 0
+      vertex 228.907 -1.02682 -5
+      vertex 228.907 -1.02682 0
+    endloop
+  endfacet
+  facet normal 0.717979 0.696065 0
+    outer loop
+      vertex 228.907 -1.02682 -5
+      vertex 228.939 -1.06066 0
+      vertex 228.939 -1.06066 -5
+    endloop
+  endfacet
+  facet normal -0.109716 0.993963 0
+    outer loop
+      vertex 230.188 -1.48817 -5
+      vertex 230.141 -1.49334 0
+      vertex 230.188 -1.48817 0
+    endloop
+  endfacet
+  facet normal -0.109716 0.993963 0
+    outer loop
+      vertex 230.141 -1.49334 0
+      vertex 230.188 -1.48817 -5
+      vertex 230.141 -1.49334 -5
+    endloop
+  endfacet
+  facet normal -0.353464 0.935448 0
+    outer loop
+      vertex 230.552 -1.39466 -5
+      vertex 230.508 -1.41132 0
+      vertex 230.552 -1.39466 0
+    endloop
+  endfacet
+  facet normal -0.353464 0.935448 0
+    outer loop
+      vertex 230.508 -1.41132 0
+      vertex 230.552 -1.39466 -5
+      vertex 230.508 -1.41132 -5
+    endloop
+  endfacet
+  facet normal -0.294013 0.955801 0
+    outer loop
+      vertex 230.464 -1.42658 -5
+      vertex 230.418 -1.44044 0
+      vertex 230.464 -1.42658 0
+    endloop
+  endfacet
+  facet normal -0.294013 0.955801 0
+    outer loop
+      vertex 230.418 -1.44044 0
+      vertex 230.464 -1.42658 -5
+      vertex 230.418 -1.44044 -5
+    endloop
+  endfacet
+  facet normal -0.996925 -0.0783632 0
+    outer loop
+      vertex 231.497 0.0941849 -5
+      vertex 231.493 0.141162 0
+      vertex 231.493 0.141162 -5
+    endloop
+  endfacet
+  facet normal -0.996925 -0.0783632 0
+    outer loop
+      vertex 231.493 0.141162 0
+      vertex 231.497 0.0941849 -5
+      vertex 231.497 0.0941849 0
+    endloop
+  endfacet
+  facet normal -0.935507 -0.353307 0
+    outer loop
+      vertex 231.411 0.508106 -5
+      vertex 231.395 0.552186 0
+      vertex 231.395 0.552186 -5
+    endloop
+  endfacet
+  facet normal -0.935507 -0.353307 0
+    outer loop
+      vertex 231.395 0.552186 0
+      vertex 231.411 0.508106 -5
+      vertex 231.411 0.508106 0
+    endloop
+  endfacet
+  facet normal -0.985106 -0.171946 0
+    outer loop
+      vertex 231.482 0.234652 -5
+      vertex 231.473 0.281072 0
+      vertex 231.473 0.281072 -5
+    endloop
+  endfacet
+  facet normal -0.985106 -0.171946 0
+    outer loop
+      vertex 231.473 0.281072 0
+      vertex 231.482 0.234652 -5
+      vertex 231.482 0.234652 0
+    endloop
+  endfacet
+  facet normal -0.600505 -0.799621 0
+    outer loop
+      vertex 230.882 1.21352 -5
+      vertex 230.919 1.18523 0
+      vertex 230.882 1.21352 0
+    endloop
+  endfacet
+  facet normal -0.600505 -0.799621 -0
+    outer loop
+      vertex 230.919 1.18523 0
+      vertex 230.882 1.21352 -5
+      vertex 230.919 1.18523 -5
+    endloop
+  endfacet
+  facet normal 0.79956 -0.600586 0
+    outer loop
+      vertex 228.786 0.881678 0
+      vertex 228.815 0.91936 -5
+      vertex 228.815 0.91936 0
+    endloop
+  endfacet
+  facet normal 0.79956 -0.600586 0
+    outer loop
+      vertex 228.815 0.91936 -5
+      vertex 228.786 0.881678 0
+      vertex 228.786 0.881678 -5
+    endloop
+  endfacet
+  facet normal -0.946018 0.324115 0
+    outer loop
+      vertex 231.411 -0.508106 -5
+      vertex 231.427 -0.463525 0
+      vertex 231.427 -0.463525 -5
+    endloop
+  endfacet
+  facet normal -0.946018 0.324115 0
+    outer loop
+      vertex 231.427 -0.463525 0
+      vertex 231.411 -0.508106 -5
+      vertex 231.411 -0.508106 0
+    endloop
+  endfacet
+  facet normal -0.923857 0.382738 0
+    outer loop
+      vertex 231.377 -0.595721 -5
+      vertex 231.395 -0.552186 0
+      vertex 231.395 -0.552186 -5
+    endloop
+  endfacet
+  facet normal -0.923857 0.382738 0
+    outer loop
+      vertex 231.395 -0.552186 0
+      vertex 231.377 -0.595721 -5
+      vertex 231.377 -0.595721 0
+    endloop
+  endfacet
+  facet normal -0.898108 0.439774 0
+    outer loop
+      vertex 231.337 -0.680985 -5
+      vertex 231.357 -0.638668 0
+      vertex 231.357 -0.638668 -5
+    endloop
+  endfacet
+  facet normal -0.898108 0.439774 0
+    outer loop
+      vertex 231.357 -0.638668 0
+      vertex 231.337 -0.680985 -5
+      vertex 231.337 -0.680985 0
+    endloop
+  endfacet
+  facet normal -0.495387 0.868672 0
+    outer loop
+      vertex 230.764 -1.29111 -5
+      vertex 230.723 -1.31446 0
+      vertex 230.764 -1.29111 0
+    endloop
+  endfacet
+  facet normal -0.495387 0.868672 0
+    outer loop
+      vertex 230.723 -1.31446 0
+      vertex 230.764 -1.29111 -5
+      vertex 230.723 -1.31446 -5
+    endloop
+  endfacet
+  facet normal -0.83573 0.54914 0
+    outer loop
+      vertex 231.241 -0.843124 -5
+      vertex 231.266 -0.80374 0
+      vertex 231.266 -0.80374 -5
+    endloop
+  endfacet
+  facet normal -0.83573 0.54914 0
+    outer loop
+      vertex 231.266 -0.80374 0
+      vertex 231.241 -0.843124 -5
+      vertex 231.241 -0.843124 0
+    endloop
+  endfacet
+  facet normal -0.0157243 0.999876 0
+    outer loop
+      vertex 230.047 -1.49926 -5
+      vertex 230 -1.5 0
+      vertex 230.047 -1.49926 0
+    endloop
+  endfacet
+  facet normal -0.0157243 0.999876 0
+    outer loop
+      vertex 230 -1.5 0
+      vertex 230.047 -1.49926 -5
+      vertex 230 -1.5 -5
+    endloop
+  endfacet
+  facet normal 0.57495 0.818189 -0
+    outer loop
+      vertex 229.157 -1.24062 -5
+      vertex 229.118 -1.21352 0
+      vertex 229.157 -1.24062 0
+    endloop
+  endfacet
+  facet normal 0.57495 0.818189 0
+    outer loop
+      vertex 229.118 -1.21352 0
+      vertex 229.157 -1.24062 -5
+      vertex 229.118 -1.21352 -5
+    endloop
+  endfacet
+  facet normal 0.411475 0.911421 -0
+    outer loop
+      vertex 229.404 -1.37663 -5
+      vertex 229.361 -1.35724 0
+      vertex 229.404 -1.37663 0
+    endloop
+  endfacet
+  facet normal 0.411475 0.911421 0
+    outer loop
+      vertex 229.361 -1.35724 0
+      vertex 229.404 -1.37663 -5
+      vertex 229.361 -1.35724 -5
+    endloop
+  endfacet
+  facet normal 0.353464 0.935448 -0
+    outer loop
+      vertex 229.492 -1.41132 -5
+      vertex 229.448 -1.39466 0
+      vertex 229.492 -1.41132 0
+    endloop
+  endfacet
+  facet normal 0.353464 0.935448 0
+    outer loop
+      vertex 229.448 -1.39466 0
+      vertex 229.492 -1.41132 -5
+      vertex 229.448 -1.39466 -5
+    endloop
+  endfacet
+  facet normal 0.140917 0.990021 -0
+    outer loop
+      vertex 229.812 -1.48817 -5
+      vertex 229.765 -1.48153 0
+      vertex 229.812 -1.48817 0
+    endloop
+  endfacet
+  facet normal 0.140917 0.990021 0
+    outer loop
+      vertex 229.765 -1.48153 0
+      vertex 229.812 -1.48817 -5
+      vertex 229.765 -1.48153 -5
+    endloop
+  endfacet
+  facet normal 0.935507 0.353307 0
+    outer loop
+      vertex 228.605 -0.552186 0
+      vertex 228.589 -0.508106 -5
+      vertex 228.589 -0.508106 0
+    endloop
+  endfacet
+  facet normal 0.935507 0.353307 0
+    outer loop
+      vertex 228.589 -0.508106 -5
+      vertex 228.605 -0.552186 0
+      vertex 228.605 -0.552186 -5
+    endloop
+  endfacet
+  facet normal 0.993957 0.109772 0
+    outer loop
+      vertex 228.512 -0.188 0
+      vertex 228.507 -0.141162 -5
+      vertex 228.507 -0.141162 0
+    endloop
+  endfacet
+  facet normal 0.993957 0.109772 0
+    outer loop
+      vertex 228.507 -0.141162 -5
+      vertex 228.512 -0.188 0
+      vertex 228.512 -0.188 -5
+    endloop
+  endfacet
+  facet normal 0.979238 0.202713 0
+    outer loop
+      vertex 228.536 -0.327214 0
+      vertex 228.527 -0.281072 -5
+      vertex 228.527 -0.281072 0
+    endloop
+  endfacet
+  facet normal 0.979238 0.202713 0
+    outer loop
+      vertex 228.527 -0.281072 -5
+      vertex 228.536 -0.327214 0
+      vertex 228.536 -0.327214 -5
+    endloop
+  endfacet
+  facet normal 0.88364 0.468167 0
+    outer loop
+      vertex 228.686 -0.722631 0
+      vertex 228.663 -0.680985 -5
+      vertex 228.663 -0.680985 0
+    endloop
+  endfacet
+  facet normal 0.88364 0.468167 0
+    outer loop
+      vertex 228.663 -0.680985 -5
+      vertex 228.686 -0.722631 0
+      vertex 228.686 -0.722631 -5
+    endloop
+  endfacet
+  facet normal 0.83573 0.54914 0
+    outer loop
+      vertex 228.759 -0.843124 0
+      vertex 228.734 -0.80374 -5
+      vertex 228.734 -0.80374 0
+    endloop
+  endfacet
+  facet normal 0.83573 0.54914 0
+    outer loop
+      vertex 228.734 -0.80374 -5
+      vertex 228.759 -0.843124 0
+      vertex 228.759 -0.843124 -5
+    endloop
+  endfacet
+  facet normal 0.852724 0.522362 0
+    outer loop
+      vertex 228.734 -0.80374 0
+      vertex 228.709 -0.763561 -5
+      vertex 228.709 -0.763561 0
+    endloop
+  endfacet
+  facet normal 0.852724 0.522362 0
+    outer loop
+      vertex 228.709 -0.763561 -5
+      vertex 228.734 -0.80374 0
+      vertex 228.734 -0.80374 -5
+    endloop
+  endfacet
+  facet normal 0.780569 0.62507 0
+    outer loop
+      vertex 228.844 -0.956136 0
+      vertex 228.815 -0.91936 -5
+      vertex 228.815 -0.91936 0
+    endloop
+  endfacet
+  facet normal 0.780569 0.62507 0
+    outer loop
+      vertex 228.815 -0.91936 -5
+      vertex 228.844 -0.956136 0
+      vertex 228.844 -0.956136 -5
+    endloop
+  endfacet
+  facet normal 0.760341 0.649524 0
+    outer loop
+      vertex 228.875 -0.991967 0
+      vertex 228.844 -0.956136 -5
+      vertex 228.844 -0.956136 0
+    endloop
+  endfacet
+  facet normal 0.760341 0.649524 0
+    outer loop
+      vertex 228.844 -0.956136 -5
+      vertex 228.875 -0.991967 0
+      vertex 228.875 -0.991967 -5
+    endloop
+  endfacet
+  facet normal 0.69603 0.718013 -0
+    outer loop
+      vertex 228.973 -1.09345 -5
+      vertex 228.939 -1.06066 0
+      vertex 228.973 -1.09345 0
+    endloop
+  endfacet
+  facet normal 0.69603 0.718013 0
+    outer loop
+      vertex 228.939 -1.06066 0
+      vertex 228.973 -1.09345 -5
+      vertex 228.939 -1.06066 -5
+    endloop
+  endfacet
+  facet normal -0.0784559 0.996918 0
+    outer loop
+      vertex 230.141 -1.49334 -5
+      vertex 230.094 -1.49704 0
+      vertex 230.141 -1.49334 0
+    endloop
+  endfacet
+  facet normal -0.0784559 0.996918 0
+    outer loop
+      vertex 230.094 -1.49704 0
+      vertex 230.141 -1.49334 -5
+      vertex 230.094 -1.49704 -5
+    endloop
+  endfacet
+  facet normal -0.0471064 0.99889 0
+    outer loop
+      vertex 230.094 -1.49704 -5
+      vertex 230.047 -1.49926 0
+      vertex 230.094 -1.49704 0
+    endloop
+  endfacet
+  facet normal -0.0471064 0.99889 0
+    outer loop
+      vertex 230.047 -1.49926 0
+      vertex 230.094 -1.49704 -5
+      vertex 230.047 -1.49926 -5
+    endloop
+  endfacet
+  facet normal -0.23344 0.972371 0
+    outer loop
+      vertex 230.373 -1.45287 -5
+      vertex 230.327 -1.46387 0
+      vertex 230.373 -1.45287 0
+    endloop
+  endfacet
+  facet normal -0.23344 0.972371 0
+    outer loop
+      vertex 230.327 -1.46387 0
+      vertex 230.373 -1.45287 -5
+      vertex 230.327 -1.46387 -5
+    endloop
+  endfacet
+  facet normal -0.263847 0.964565 0
+    outer loop
+      vertex 230.418 -1.44044 -5
+      vertex 230.373 -1.45287 0
+      vertex 230.418 -1.44044 0
+    endloop
+  endfacet
+  facet normal -0.263847 0.964565 0
+    outer loop
+      vertex 230.373 -1.45287 0
+      vertex 230.418 -1.44044 -5
+      vertex 230.373 -1.45287 -5
+    endloop
+  endfacet
+  facet normal -0.323984 0.946062 0
+    outer loop
+      vertex 230.508 -1.41132 -5
+      vertex 230.464 -1.42658 0
+      vertex 230.508 -1.41132 0
+    endloop
+  endfacet
+  facet normal -0.323984 0.946062 0
+    outer loop
+      vertex 230.464 -1.42658 0
+      vertex 230.508 -1.41132 -5
+      vertex 230.464 -1.42658 -5
+    endloop
+  endfacet
+  facet normal -0.382683 0.92388 0
+    outer loop
+      vertex 230.596 -1.37663 -5
+      vertex 230.552 -1.39466 0
+      vertex 230.596 -1.37663 0
+    endloop
+  endfacet
+  facet normal -0.382683 0.92388 0
+    outer loop
+      vertex 230.552 -1.39466 0
+      vertex 230.596 -1.37663 -5
+      vertex 230.552 -1.39466 -5
+    endloop
+  endfacet
+  facet normal -0.993957 -0.109772 0
+    outer loop
+      vertex 231.493 0.141162 -5
+      vertex 231.488 0.188 0
+      vertex 231.488 0.188 -5
+    endloop
+  endfacet
+  facet normal -0.993957 -0.109772 0
+    outer loop
+      vertex 231.488 0.188 0
+      vertex 231.493 0.141162 -5
+      vertex 231.493 0.141162 0
+    endloop
+  endfacet
+  facet normal -0.998897 -0.0469536 0
+    outer loop
+      vertex 231.499 0.0471153 -5
+      vertex 231.497 0.0941849 0
+      vertex 231.497 0.0941849 -5
+    endloop
+  endfacet
+  facet normal -0.998897 -0.0469536 0
+    outer loop
+      vertex 231.497 0.0941849 0
+      vertex 231.499 0.0471153 -5
+      vertex 231.499 0.0471153 0
+    endloop
+  endfacet
+  facet normal -0.964549 -0.263905 0
+    outer loop
+      vertex 231.453 0.373034 -5
+      vertex 231.44 0.418487 0
+      vertex 231.44 0.418487 -5
+    endloop
+  endfacet
+  facet normal -0.964549 -0.263905 0
+    outer loop
+      vertex 231.44 0.418487 0
+      vertex 231.453 0.373034 -5
+      vertex 231.453 0.373034 0
+    endloop
+  endfacet
+  facet normal -0.972438 -0.233162 0
+    outer loop
+      vertex 231.464 0.327214 -5
+      vertex 231.453 0.373034 0
+      vertex 231.453 0.373034 -5
+    endloop
+  endfacet
+  facet normal -0.972438 -0.233162 0
+    outer loop
+      vertex 231.453 0.373034 0
+      vertex 231.464 0.327214 -5
+      vertex 231.464 0.327214 0
+    endloop
+  endfacet
+  facet normal -0.979174 -0.203023 0
+    outer loop
+      vertex 231.473 0.281072 -5
+      vertex 231.464 0.327214 0
+      vertex 231.464 0.327214 -5
+    endloop
+  endfacet
+  facet normal -0.979174 -0.203023 0
+    outer loop
+      vertex 231.464 0.327214 0
+      vertex 231.473 0.281072 -5
+      vertex 231.473 0.281072 0
+    endloop
+  endfacet
+  facet normal -0.979174 0.203023 0
+    outer loop
+      vertex 231.464 -0.327214 -5
+      vertex 231.473 -0.281072 0
+      vertex 231.473 -0.281072 -5
+    endloop
+  endfacet
+  facet normal -0.979174 0.203023 0
+    outer loop
+      vertex 231.473 -0.281072 0
+      vertex 231.464 -0.327214 -5
+      vertex 231.464 -0.327214 0
+    endloop
+  endfacet
+  facet normal -0.955797 0.294029 0
+    outer loop
+      vertex 231.427 -0.463525 -5
+      vertex 231.44 -0.418487 0
+      vertex 231.44 -0.418487 -5
+    endloop
+  endfacet
+  facet normal -0.955797 0.294029 0
+    outer loop
+      vertex 231.44 -0.418487 0
+      vertex 231.427 -0.463525 -5
+      vertex 231.427 -0.463525 0
+    endloop
+  endfacet
+  facet normal -0.964549 0.263905 0
+    outer loop
+      vertex 231.44 -0.418487 -5
+      vertex 231.453 -0.373034 0
+      vertex 231.453 -0.373034 -5
+    endloop
+  endfacet
+  facet normal -0.964549 0.263905 0
+    outer loop
+      vertex 231.453 -0.373034 0
+      vertex 231.44 -0.418487 -5
+      vertex 231.44 -0.418487 0
+    endloop
+  endfacet
+  facet normal -0.911382 0.411562 0
+    outer loop
+      vertex 231.357 -0.638668 -5
+      vertex 231.377 -0.595721 0
+      vertex 231.377 -0.595721 -5
+    endloop
+  endfacet
+  facet normal -0.911382 0.411562 0
+    outer loop
+      vertex 231.377 -0.595721 0
+      vertex 231.357 -0.638668 -5
+      vertex 231.357 -0.638668 0
+    endloop
+  endfacet
+  facet normal -0.625263 0.780414 0
+    outer loop
+      vertex 230.956 -1.15577 -5
+      vertex 230.919 -1.18523 0
+      vertex 230.956 -1.15577 0
+    endloop
+  endfacet
+  facet normal -0.625263 0.780414 0
+    outer loop
+      vertex 230.919 -1.18523 0
+      vertex 230.956 -1.15577 -5
+      vertex 230.919 -1.18523 -5
+    endloop
+  endfacet
+  facet normal -0.649334 0.760504 0
+    outer loop
+      vertex 230.992 -1.12517 -5
+      vertex 230.956 -1.15577 0
+      vertex 230.992 -1.12517 0
+    endloop
+  endfacet
+  facet normal -0.649334 0.760504 0
+    outer loop
+      vertex 230.956 -1.15577 0
+      vertex 230.992 -1.12517 -5
+      vertex 230.956 -1.15577 -5
+    endloop
+  endfacet
+  facet normal -0.522527 0.852623 0
+    outer loop
+      vertex 230.804 -1.26649 -5
+      vertex 230.764 -1.29111 0
+      vertex 230.804 -1.26649 0
+    endloop
+  endfacet
+  facet normal -0.522527 0.852623 0
+    outer loop
+      vertex 230.764 -1.29111 0
+      vertex 230.804 -1.26649 -5
+      vertex 230.764 -1.29111 -5
+    endloop
+  endfacet
+  facet normal -0.467963 0.883748 0
+    outer loop
+      vertex 230.723 -1.31446 -5
+      vertex 230.681 -1.33651 0
+      vertex 230.723 -1.31446 0
+    endloop
+  endfacet
+  facet normal -0.467963 0.883748 0
+    outer loop
+      vertex 230.681 -1.33651 0
+      vertex 230.723 -1.31446 -5
+      vertex 230.681 -1.33651 -5
+    endloop
+  endfacet
+  facet normal -0.673029 0.739616 0
+    outer loop
+      vertex 231.027 -1.09345 -5
+      vertex 230.992 -1.12517 0
+      vertex 231.027 -1.09345 0
+    endloop
+  endfacet
+  facet normal -0.673029 0.739616 0
+    outer loop
+      vertex 230.992 -1.12517 0
+      vertex 231.027 -1.09345 -5
+      vertex 230.992 -1.12517 -5
+    endloop
+  endfacet
+  facet normal -0.852724 0.522362 0
+    outer loop
+      vertex 231.266 -0.80374 -5
+      vertex 231.291 -0.763561 0
+      vertex 231.291 -0.763561 -5
+    endloop
+  endfacet
+  facet normal -0.852724 0.522362 0
+    outer loop
+      vertex 231.291 -0.763561 0
+      vertex 231.266 -0.80374 -5
+      vertex 231.266 -0.80374 0
+    endloop
+  endfacet
+  facet normal -0.760501 0.649337 0
+    outer loop
+      vertex 231.125 -0.991967 -5
+      vertex 231.156 -0.956136 0
+      vertex 231.156 -0.956136 -5
+    endloop
+  endfacet
+  facet normal -0.760501 0.649337 0
+    outer loop
+      vertex 231.156 -0.956136 0
+      vertex 231.125 -0.991967 -5
+      vertex 231.125 -0.991967 0
+    endloop
+  endfacet
+  facet normal 0.0157243 0.999876 -0
+    outer loop
+      vertex 230 -1.5 -5
+      vertex 229.953 -1.49926 0
+      vertex 230 -1.5 0
+    endloop
+  endfacet
+  facet normal 0.0157243 0.999876 0
+    outer loop
+      vertex 229.953 -1.49926 0
+      vertex 230 -1.5 -5
+      vertex 229.953 -1.49926 -5
+    endloop
+  endfacet
+  facet normal 0.0470911 0.998891 -0
+    outer loop
+      vertex 229.953 -1.49926 -5
+      vertex 229.906 -1.49704 0
+      vertex 229.953 -1.49926 0
+    endloop
+  endfacet
+  facet normal 0.0470911 0.998891 0
+    outer loop
+      vertex 229.906 -1.49704 0
+      vertex 229.953 -1.49926 -5
+      vertex 229.906 -1.49704 -5
+    endloop
+  endfacet
+  facet normal 0.625263 0.780414 -0
+    outer loop
+      vertex 229.081 -1.18523 -5
+      vertex 229.044 -1.15577 0
+      vertex 229.081 -1.18523 0
+    endloop
+  endfacet
+  facet normal 0.625263 0.780414 0
+    outer loop
+      vertex 229.044 -1.15577 0
+      vertex 229.081 -1.18523 -5
+      vertex 229.044 -1.15577 -5
+    endloop
+  endfacet
+  facet normal 0.549031 0.835802 -0
+    outer loop
+      vertex 229.196 -1.26649 -5
+      vertex 229.157 -1.24062 0
+      vertex 229.196 -1.26649 0
+    endloop
+  endfacet
+  facet normal 0.549031 0.835802 0
+    outer loop
+      vertex 229.157 -1.24062 0
+      vertex 229.196 -1.26649 -5
+      vertex 229.157 -1.24062 -5
+    endloop
+  endfacet
+  facet normal 0.600505 0.799621 -0
+    outer loop
+      vertex 229.118 -1.21352 -5
+      vertex 229.081 -1.18523 0
+      vertex 229.118 -1.21352 0
+    endloop
+  endfacet
+  facet normal 0.600505 0.799621 0
+    outer loop
+      vertex 229.081 -1.18523 0
+      vertex 229.118 -1.21352 -5
+      vertex 229.081 -1.18523 -5
+    endloop
+  endfacet
+  facet normal 0.382683 0.92388 -0
+    outer loop
+      vertex 229.448 -1.39466 -5
+      vertex 229.404 -1.37663 0
+      vertex 229.448 -1.39466 0
+    endloop
+  endfacet
+  facet normal 0.382683 0.92388 0
+    outer loop
+      vertex 229.404 -1.37663 0
+      vertex 229.448 -1.39466 -5
+      vertex 229.404 -1.37663 -5
+    endloop
+  endfacet
+  facet normal 0.439961 0.898017 -0
+    outer loop
+      vertex 229.361 -1.35724 -5
+      vertex 229.319 -1.33651 0
+      vertex 229.361 -1.35724 0
+    endloop
+  endfacet
+  facet normal 0.439961 0.898017 0
+    outer loop
+      vertex 229.319 -1.33651 0
+      vertex 229.361 -1.35724 -5
+      vertex 229.319 -1.33651 -5
+    endloop
+  endfacet
+  facet normal 0.263847 0.964565 -0
+    outer loop
+      vertex 229.627 -1.45287 -5
+      vertex 229.582 -1.44044 0
+      vertex 229.627 -1.45287 0
+    endloop
+  endfacet
+  facet normal 0.263847 0.964565 0
+    outer loop
+      vertex 229.582 -1.44044 0
+      vertex 229.627 -1.45287 -5
+      vertex 229.582 -1.44044 -5
+    endloop
+  endfacet
+  facet normal 0.323984 0.946062 -0
+    outer loop
+      vertex 229.536 -1.42658 -5
+      vertex 229.492 -1.41132 0
+      vertex 229.536 -1.42658 0
+    endloop
+  endfacet
+  facet normal 0.323984 0.946062 0
+    outer loop
+      vertex 229.492 -1.41132 0
+      vertex 229.536 -1.42658 -5
+      vertex 229.492 -1.41132 -5
+    endloop
+  endfacet
+  facet normal 0.294013 0.955801 -0
+    outer loop
+      vertex 229.582 -1.44044 -5
+      vertex 229.536 -1.42658 0
+      vertex 229.582 -1.44044 0
+    endloop
+  endfacet
+  facet normal 0.294013 0.955801 0
+    outer loop
+      vertex 229.536 -1.42658 0
+      vertex 229.582 -1.44044 -5
+      vertex 229.536 -1.42658 -5
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 -0
+    outer loop
+      vertex 229.719 -1.47343 -5
+      vertex 229.673 -1.46387 0
+      vertex 229.719 -1.47343 0
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 0
+    outer loop
+      vertex 229.673 -1.46387 0
+      vertex 229.719 -1.47343 -5
+      vertex 229.673 -1.46387 -5
+    endloop
+  endfacet
+  facet normal 0.171936 0.985108 -0
+    outer loop
+      vertex 229.765 -1.48153 -5
+      vertex 229.719 -1.47343 0
+      vertex 229.765 -1.48153 0
+    endloop
+  endfacet
+  facet normal 0.171936 0.985108 0
+    outer loop
+      vertex 229.719 -1.47343 0
+      vertex 229.765 -1.48153 -5
+      vertex 229.719 -1.47343 -5
+    endloop
+  endfacet
+  facet normal 0.23344 0.972371 -0
+    outer loop
+      vertex 229.673 -1.46387 -5
+      vertex 229.627 -1.45287 0
+      vertex 229.673 -1.46387 0
+    endloop
+  endfacet
+  facet normal 0.23344 0.972371 0
+    outer loop
+      vertex 229.627 -1.45287 0
+      vertex 229.673 -1.46387 -5
+      vertex 229.627 -1.45287 -5
+    endloop
+  endfacet
+  facet normal 0.109716 0.993963 -0
+    outer loop
+      vertex 229.859 -1.49334 -5
+      vertex 229.812 -1.48817 0
+      vertex 229.859 -1.49334 0
+    endloop
+  endfacet
+  facet normal 0.109716 0.993963 0
+    outer loop
+      vertex 229.812 -1.48817 0
+      vertex 229.859 -1.49334 -5
+      vertex 229.812 -1.48817 -5
+    endloop
+  endfacet
+  facet normal 0.0784812 0.996916 -0
+    outer loop
+      vertex 229.906 -1.49704 -5
+      vertex 229.859 -1.49334 0
+      vertex 229.906 -1.49704 0
+    endloop
+  endfacet
+  facet normal 0.0784812 0.996916 0
+    outer loop
+      vertex 229.859 -1.49334 0
+      vertex 229.906 -1.49704 -5
+      vertex 229.859 -1.49334 -5
+    endloop
+  endfacet
+  facet normal 0.985106 0.171946 0
+    outer loop
+      vertex 228.527 -0.281072 0
+      vertex 228.518 -0.234652 -5
+      vertex 228.518 -0.234652 0
+    endloop
+  endfacet
+  facet normal 0.985106 0.171946 0
+    outer loop
+      vertex 228.518 -0.234652 -5
+      vertex 228.527 -0.281072 0
+      vertex 228.527 -0.281072 -5
+    endloop
+  endfacet
+  facet normal 0.964549 0.263905 0
+    outer loop
+      vertex 228.56 -0.418487 0
+      vertex 228.547 -0.373034 -5
+      vertex 228.547 -0.373034 0
+    endloop
+  endfacet
+  facet normal 0.964549 0.263905 0
+    outer loop
+      vertex 228.547 -0.373034 -5
+      vertex 228.56 -0.418487 0
+      vertex 228.56 -0.418487 -5
+    endloop
+  endfacet
+  facet normal 0.972365 0.233468 0
+    outer loop
+      vertex 228.547 -0.373034 0
+      vertex 228.536 -0.327214 -5
+      vertex 228.536 -0.327214 0
+    endloop
+  endfacet
+  facet normal 0.972365 0.233468 0
+    outer loop
+      vertex 228.536 -0.327214 -5
+      vertex 228.547 -0.373034 0
+      vertex 228.547 -0.373034 -5
+    endloop
+  endfacet
+  facet normal 0.898108 0.439774 0
+    outer loop
+      vertex 228.663 -0.680985 0
+      vertex 228.643 -0.638668 -5
+      vertex 228.643 -0.638668 0
+    endloop
+  endfacet
+  facet normal 0.898108 0.439774 0
+    outer loop
+      vertex 228.643 -0.638668 -5
+      vertex 228.663 -0.680985 0
+      vertex 228.663 -0.680985 -5
+    endloop
+  endfacet
+  facet normal 0.79956 0.600586 0
+    outer loop
+      vertex 228.815 -0.91936 0
+      vertex 228.786 -0.881678 -5
+      vertex 228.786 -0.881678 0
+    endloop
+  endfacet
+  facet normal 0.79956 0.600586 0
+    outer loop
+      vertex 228.786 -0.881678 -5
+      vertex 228.815 -0.91936 0
+      vertex 228.815 -0.91936 -5
+    endloop
+  endfacet
+  facet normal 0.739695 0.672943 0
+    outer loop
+      vertex 228.907 -1.02682 0
+      vertex 228.875 -0.991967 -5
+      vertex 228.875 -0.991967 0
+    endloop
+  endfacet
+  facet normal 0.739695 0.672943 0
+    outer loop
+      vertex 228.875 -0.991967 -5
+      vertex 228.907 -1.02682 0
+      vertex 228.907 -1.02682 -5
+    endloop
+  endfacet
+  facet normal -0.171936 0.985108 0
+    outer loop
+      vertex 230.281 -1.47343 -5
+      vertex 230.235 -1.48153 0
+      vertex 230.281 -1.47343 0
+    endloop
+  endfacet
+  facet normal -0.171936 0.985108 0
+    outer loop
+      vertex 230.235 -1.48153 0
+      vertex 230.281 -1.47343 -5
+      vertex 230.235 -1.48153 -5
+    endloop
+  endfacet
+  facet normal -0.140917 0.990021 0
+    outer loop
+      vertex 230.235 -1.48153 -5
+      vertex 230.188 -1.48817 0
+      vertex 230.235 -1.48153 0
+    endloop
+  endfacet
+  facet normal -0.140917 0.990021 0
+    outer loop
+      vertex 230.188 -1.48817 0
+      vertex 230.235 -1.48153 -5
+      vertex 230.188 -1.48817 -5
+    endloop
+  endfacet
+  facet normal -0.88364 0.468167 0
+    outer loop
+      vertex 231.314 -0.722631 -5
+      vertex 231.337 -0.680985 0
+      vertex 231.337 -0.680985 -5
+    endloop
+  endfacet
+  facet normal -0.88364 0.468167 0
+    outer loop
+      vertex 231.337 -0.680985 0
+      vertex 231.314 -0.722631 -5
+      vertex 231.314 -0.722631 0
+    endloop
+  endfacet
+  facet normal -0.439961 0.898017 0
+    outer loop
+      vertex 230.681 -1.33651 -5
+      vertex 230.639 -1.35724 0
+      vertex 230.681 -1.33651 0
+    endloop
+  endfacet
+  facet normal -0.439961 0.898017 0
+    outer loop
+      vertex 230.639 -1.35724 0
+      vertex 230.681 -1.33651 -5
+      vertex 230.639 -1.35724 -5
+    endloop
+  endfacet
+  facet normal -0.69603 0.718013 0
+    outer loop
+      vertex 231.061 -1.06066 -5
+      vertex 231.027 -1.09345 0
+      vertex 231.061 -1.06066 0
+    endloop
+  endfacet
+  facet normal -0.69603 0.718013 0
+    outer loop
+      vertex 231.027 -1.09345 0
+      vertex 231.061 -1.06066 -5
+      vertex 231.027 -1.09345 -5
+    endloop
+  endfacet
+  facet normal 0.649334 0.760504 -0
+    outer loop
+      vertex 229.044 -1.15577 -5
+      vertex 229.008 -1.12517 0
+      vertex 229.044 -1.15577 0
+    endloop
+  endfacet
+  facet normal 0.649334 0.760504 0
+    outer loop
+      vertex 229.008 -1.12517 0
+      vertex 229.044 -1.15577 -5
+      vertex 229.008 -1.12517 -5
+    endloop
+  endfacet
+  facet normal 0.522527 0.852623 -0
+    outer loop
+      vertex 229.236 -1.29111 -5
+      vertex 229.196 -1.26649 0
+      vertex 229.236 -1.29111 0
+    endloop
+  endfacet
+  facet normal 0.522527 0.852623 0
+    outer loop
+      vertex 229.196 -1.26649 0
+      vertex 229.236 -1.29111 -5
+      vertex 229.196 -1.26649 -5
+    endloop
+  endfacet
+  facet normal 0.467963 0.883748 -0
+    outer loop
+      vertex 229.319 -1.33651 -5
+      vertex 229.277 -1.31446 0
+      vertex 229.319 -1.33651 0
+    endloop
+  endfacet
+  facet normal 0.467963 0.883748 0
+    outer loop
+      vertex 229.277 -1.31446 0
+      vertex 229.319 -1.33651 -5
+      vertex 229.277 -1.31446 -5
+    endloop
+  endfacet
+  facet normal -0.600505 0.799621 0
+    outer loop
+      vertex 230.919 -1.18523 -5
+      vertex 230.882 -1.21352 0
+      vertex 230.919 -1.18523 0
+    endloop
+  endfacet
+  facet normal -0.600505 0.799621 0
+    outer loop
+      vertex 230.882 -1.21352 0
+      vertex 230.919 -1.18523 -5
+      vertex 230.882 -1.21352 -5
+    endloop
+  endfacet
+  facet normal -0.57495 0.818189 0
+    outer loop
+      vertex 230.882 -1.21352 -5
+      vertex 230.843 -1.24062 0
+      vertex 230.882 -1.21352 0
+    endloop
+  endfacet
+  facet normal -0.57495 0.818189 0
+    outer loop
+      vertex 230.843 -1.24062 0
+      vertex 230.882 -1.21352 -5
+      vertex 230.843 -1.24062 -5
+    endloop
+  endfacet
+  facet normal -0.718141 0.695898 0
+    outer loop
+      vertex 231.061 -1.06066 -5
+      vertex 231.093 -1.02682 0
+      vertex 231.093 -1.02682 -5
+    endloop
+  endfacet
+  facet normal -0.718141 0.695898 0
+    outer loop
+      vertex 231.093 -1.02682 0
+      vertex 231.061 -1.06066 -5
+      vertex 231.061 -1.06066 0
+    endloop
+  endfacet
+  facet normal -0.818263 0.574844 0
+    outer loop
+      vertex 231.214 -0.881678 -5
+      vertex 231.241 -0.843124 0
+      vertex 231.241 -0.843124 -5
+    endloop
+  endfacet
+  facet normal -0.818263 0.574844 0
+    outer loop
+      vertex 231.241 -0.843124 0
+      vertex 231.214 -0.881678 -5
+      vertex 231.214 -0.881678 0
+    endloop
+  endfacet
+  facet normal -0.79956 0.600586 0
+    outer loop
+      vertex 231.185 -0.91936 -5
+      vertex 231.214 -0.881678 0
+      vertex 231.214 -0.881678 -5
+    endloop
+  endfacet
+  facet normal -0.79956 0.600586 0
+    outer loop
+      vertex 231.214 -0.881678 0
+      vertex 231.185 -0.91936 -5
+      vertex 231.185 -0.91936 0
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0157051 0
+    outer loop
+      vertex 233 0 0
+      vertex 232.999 0.0942316 5
+      vertex 232.999 0.0942316 0
+    endloop
+  endfacet
+  facet normal -0.999877 -0.0157051 0
+    outer loop
+      vertex 232.999 0.0942316 5
+      vertex 233 0 0
+      vertex 233 0 5
+    endloop
+  endfacet
+  facet normal 0.999877 0.0157051 0
+    outer loop
+      vertex 227.001 -0.0942316 5
+      vertex 227 0 0
+      vertex 227 0 5
+    endloop
+  endfacet
+  facet normal 0.999877 0.0157051 0
+    outer loop
+      vertex 227 0 0
+      vertex 227.001 -0.0942316 5
+      vertex 227.001 -0.0942316 0
+    endloop
+  endfacet
+  facet normal 0.0157141 -0.999877 0
+    outer loop
+      vertex 229.906 2.99852 0
+      vertex 230 3 5
+      vertex 229.906 2.99852 5
+    endloop
+  endfacet
+  facet normal 0.0157141 -0.999877 0
+    outer loop
+      vertex 230 3 5
+      vertex 229.906 2.99852 0
+      vertex 230 3 0
+    endloop
+  endfacet
+  facet normal -0.0157141 0.999877 0
+    outer loop
+      vertex 230.094 -2.99852 0
+      vertex 230 -3 5
+      vertex 230.094 -2.99852 5
+    endloop
+  endfacet
+  facet normal -0.0157141 0.999877 0
+    outer loop
+      vertex 230 -3 5
+      vertex 230.094 -2.99852 0
+      vertex 230 -3 0
+    endloop
+  endfacet
+  facet normal -0.695868 -0.718169 0
+    outer loop
+      vertex 232.054 2.18691 0
+      vertex 232.121 2.12132 5
+      vertex 232.054 2.18691 5
+    endloop
+  endfacet
+  facet normal -0.695868 -0.718169 -0
+    outer loop
+      vertex 232.121 2.12132 5
+      vertex 232.054 2.18691 0
+      vertex 232.121 2.12132 0
+    endloop
+  endfacet
+  facet normal 0.718146 -0.695893 0
+    outer loop
+      vertex 227.813 2.05364 5
+      vertex 227.879 2.12132 0
+      vertex 227.879 2.12132 5
+    endloop
+  endfacet
+  facet normal 0.718146 -0.695893 0
+    outer loop
+      vertex 227.879 2.12132 0
+      vertex 227.813 2.05364 5
+      vertex 227.813 2.05364 0
+    endloop
+  endfacet
+  facet normal -0.923914 -0.3826 0
+    outer loop
+      vertex 232.789 1.10437 0
+      vertex 232.753 1.19144 5
+      vertex 232.753 1.19144 0
+    endloop
+  endfacet
+  facet normal -0.923914 -0.3826 0
+    outer loop
+      vertex 232.753 1.19144 5
+      vertex 232.789 1.10437 0
+      vertex 232.789 1.10437 5
+    endloop
+  endfacet
+  facet normal -0.575019 -0.81814 0
+    outer loop
+      vertex 231.686 2.48124 0
+      vertex 231.763 2.42705 5
+      vertex 231.686 2.48124 5
+    endloop
+  endfacet
+  facet normal -0.575019 -0.81814 -0
+    outer loop
+      vertex 231.763 2.42705 5
+      vertex 231.686 2.48124 0
+      vertex 231.763 2.42705 0
+    endloop
+  endfacet
+  facet normal 0.868639 -0.495446 0
+    outer loop
+      vertex 227.371 1.44526 5
+      vertex 227.418 1.52712 0
+      vertex 227.418 1.52712 5
+    endloop
+  endfacet
+  facet normal 0.868639 -0.495446 0
+    outer loop
+      vertex 227.418 1.52712 0
+      vertex 227.371 1.44526 5
+      vertex 227.371 1.44526 0
+    endloop
+  endfacet
+  facet normal 0.673029 -0.739616 0
+    outer loop
+      vertex 227.946 2.18691 0
+      vertex 228.016 2.25033 5
+      vertex 227.946 2.18691 5
+    endloop
+  endfacet
+  facet normal 0.673029 -0.739616 0
+    outer loop
+      vertex 228.016 2.25033 5
+      vertex 227.946 2.18691 0
+      vertex 228.016 2.25033 0
+    endloop
+  endfacet
+  facet normal -0.990007 -0.141019 0
+    outer loop
+      vertex 232.976 0.375999 0
+      vertex 232.963 0.469303 5
+      vertex 232.963 0.469303 0
+    endloop
+  endfacet
+  facet normal -0.990007 -0.141019 0
+    outer loop
+      vertex 232.963 0.469303 5
+      vertex 232.976 0.375999 0
+      vertex 232.976 0.375999 5
+    endloop
+  endfacet
+  facet normal -0.171909 -0.985113 0
+    outer loop
+      vertex 230.469 2.96306 0
+      vertex 230.562 2.94686 5
+      vertex 230.469 2.96306 5
+    endloop
+  endfacet
+  facet normal -0.171909 -0.985113 -0
+    outer loop
+      vertex 230.562 2.94686 5
+      vertex 230.469 2.96306 0
+      vertex 230.562 2.94686 0
+    endloop
+  endfacet
+  facet normal -0.411467 -0.911425 0
+    outer loop
+      vertex 231.191 2.75326 0
+      vertex 231.277 2.71448 5
+      vertex 231.191 2.75326 5
+    endloop
+  endfacet
+  facet normal -0.411467 -0.911425 -0
+    outer loop
+      vertex 231.277 2.71448 5
+      vertex 231.191 2.75326 0
+      vertex 231.277 2.71448 0
+    endloop
+  endfacet
+  facet normal -0.600434 -0.799674 0
+    outer loop
+      vertex 231.763 2.42705 0
+      vertex 231.839 2.37046 5
+      vertex 231.763 2.42705 5
+    endloop
+  endfacet
+  facet normal -0.600434 -0.799674 -0
+    outer loop
+      vertex 231.839 2.37046 5
+      vertex 231.763 2.42705 0
+      vertex 231.839 2.37046 0
+    endloop
+  endfacet
+  facet normal 0.985134 -0.171789 0
+    outer loop
+      vertex 227.037 0.469303 5
+      vertex 227.053 0.562143 0
+      vertex 227.053 0.562143 5
+    endloop
+  endfacet
+  facet normal 0.985134 -0.171789 0
+    outer loop
+      vertex 227.053 0.562143 0
+      vertex 227.037 0.469303 5
+      vertex 227.037 0.469303 0
+    endloop
+  endfacet
+  facet normal 0.52252 -0.852627 0
+    outer loop
+      vertex 228.393 2.53298 0
+      vertex 228.473 2.58223 5
+      vertex 228.393 2.53298 5
+    endloop
+  endfacet
+  facet normal 0.52252 -0.852627 0
+    outer loop
+      vertex 228.473 2.58223 5
+      vertex 228.393 2.53298 0
+      vertex 228.473 2.58223 0
+    endloop
+  endfacet
+  facet normal 0.649494 -0.760367 0
+    outer loop
+      vertex 228.016 2.25033 0
+      vertex 228.088 2.31154 5
+      vertex 228.016 2.25033 5
+    endloop
+  endfacet
+  facet normal 0.649494 -0.760367 0
+    outer loop
+      vertex 228.088 2.31154 5
+      vertex 228.016 2.25033 0
+      vertex 228.088 2.31154 0
+    endloop
+  endfacet
+  facet normal 0.109726 -0.993962 0
+    outer loop
+      vertex 229.624 2.97634 0
+      vertex 229.718 2.98669 5
+      vertex 229.624 2.97634 5
+    endloop
+  endfacet
+  facet normal 0.109726 -0.993962 0
+    outer loop
+      vertex 229.718 2.98669 5
+      vertex 229.624 2.97634 0
+      vertex 229.718 2.98669 0
+    endloop
+  endfacet
+  facet normal -0.972364 0.23347 0
+    outer loop
+      vertex 232.906 -0.746069 0
+      vertex 232.928 -0.654429 5
+      vertex 232.928 -0.654429 0
+    endloop
+  endfacet
+  facet normal -0.972364 0.23347 0
+    outer loop
+      vertex 232.928 -0.654429 5
+      vertex 232.906 -0.746069 0
+      vertex 232.906 -0.746069 5
+    endloop
+  endfacet
+  facet normal -0.673029 0.739616 0
+    outer loop
+      vertex 232.054 -2.18691 0
+      vertex 231.984 -2.25033 5
+      vertex 232.054 -2.18691 5
+    endloop
+  endfacet
+  facet normal -0.673029 0.739616 0
+    outer loop
+      vertex 231.984 -2.25033 5
+      vertex 232.054 -2.18691 0
+      vertex 231.984 -2.25033 0
+    endloop
+  endfacet
+  facet normal -0.9354 0.353591 0
+    outer loop
+      vertex 232.789 -1.10437 0
+      vertex 232.823 -1.01621 5
+      vertex 232.823 -1.01621 0
+    endloop
+  endfacet
+  facet normal -0.9354 0.353591 0
+    outer loop
+      vertex 232.823 -1.01621 5
+      vertex 232.789 -1.10437 0
+      vertex 232.789 -1.10437 5
+    endloop
+  endfacet
+  facet normal 0.799716 0.600379 0
+    outer loop
+      vertex 227.63 -1.83872 5
+      vertex 227.573 -1.76336 0
+      vertex 227.573 -1.76336 5
+    endloop
+  endfacet
+  facet normal 0.799716 0.600379 0
+    outer loop
+      vertex 227.573 -1.76336 0
+      vertex 227.63 -1.83872 5
+      vertex 227.63 -1.83872 0
+    endloop
+  endfacet
+  facet normal -0.993974 -0.109613 0
+    outer loop
+      vertex 232.987 0.282325 0
+      vertex 232.976 0.375999 5
+      vertex 232.976 0.375999 0
+    endloop
+  endfacet
+  facet normal -0.993974 -0.109613 0
+    outer loop
+      vertex 232.976 0.375999 5
+      vertex 232.987 0.282325 0
+      vertex 232.987 0.282325 5
+    endloop
+  endfacet
+  facet normal -0.979207 -0.202866 0
+    outer loop
+      vertex 232.947 0.562143 0
+      vertex 232.928 0.654429 5
+      vertex 232.928 0.654429 0
+    endloop
+  endfacet
+  facet normal -0.979207 -0.202866 0
+    outer loop
+      vertex 232.928 0.654429 5
+      vertex 232.947 0.562143 0
+      vertex 232.947 0.562143 5
+    endloop
+  endfacet
+  facet normal -0.972364 -0.23347 0
+    outer loop
+      vertex 232.928 0.654429 0
+      vertex 232.906 0.746069 5
+      vertex 232.906 0.746069 0
+    endloop
+  endfacet
+  facet normal -0.972364 -0.23347 0
+    outer loop
+      vertex 232.906 0.746069 5
+      vertex 232.928 0.654429 0
+      vertex 232.928 0.654429 5
+    endloop
+  endfacet
+  facet normal -0.9354 -0.353591 0
+    outer loop
+      vertex 232.823 1.01621 0
+      vertex 232.789 1.10437 5
+      vertex 232.789 1.10437 0
+    endloop
+  endfacet
+  facet normal -0.9354 -0.353591 0
+    outer loop
+      vertex 232.789 1.10437 5
+      vertex 232.823 1.01621 0
+      vertex 232.823 1.01621 5
+    endloop
+  endfacet
+  facet normal -0.760425 -0.649425 0
+    outer loop
+      vertex 232.312 1.91227 0
+      vertex 232.25 1.98394 5
+      vertex 232.25 1.98394 0
+    endloop
+  endfacet
+  facet normal -0.760425 -0.649425 0
+    outer loop
+      vertex 232.25 1.98394 5
+      vertex 232.312 1.91227 0
+      vertex 232.312 1.91227 5
+    endloop
+  endfacet
+  facet normal -0.739609 -0.673036 0
+    outer loop
+      vertex 232.25 1.98394 0
+      vertex 232.187 2.05364 5
+      vertex 232.187 2.05364 0
+    endloop
+  endfacet
+  facet normal -0.739609 -0.673036 0
+    outer loop
+      vertex 232.187 2.05364 5
+      vertex 232.25 1.98394 0
+      vertex 232.25 1.98394 5
+    endloop
+  endfacet
+  facet normal -0.835805 -0.549027 0
+    outer loop
+      vertex 232.533 1.60748 0
+      vertex 232.481 1.68625 5
+      vertex 232.481 1.68625 0
+    endloop
+  endfacet
+  facet normal -0.835805 -0.549027 0
+    outer loop
+      vertex 232.481 1.68625 5
+      vertex 232.533 1.60748 0
+      vertex 232.533 1.60748 5
+    endloop
+  endfacet
+  facet normal -0.883774 -0.467914 0
+    outer loop
+      vertex 232.673 1.36197 0
+      vertex 232.629 1.44526 5
+      vertex 232.629 1.44526 0
+    endloop
+  endfacet
+  facet normal -0.883774 -0.467914 0
+    outer loop
+      vertex 232.629 1.44526 5
+      vertex 232.673 1.36197 0
+      vertex 232.673 1.36197 5
+    endloop
+  endfacet
+  facet normal -0.0784585 -0.996917 0
+    outer loop
+      vertex 230.188 2.99408 0
+      vertex 230.282 2.98669 5
+      vertex 230.188 2.99408 5
+    endloop
+  endfacet
+  facet normal -0.0784585 -0.996917 -0
+    outer loop
+      vertex 230.282 2.98669 5
+      vertex 230.188 2.99408 0
+      vertex 230.282 2.98669 0
+    endloop
+  endfacet
+  facet normal -0.323894 -0.946093 0
+    outer loop
+      vertex 230.927 2.85317 0
+      vertex 231.016 2.82264 5
+      vertex 230.927 2.85317 5
+    endloop
+  endfacet
+  facet normal -0.323894 -0.946093 -0
+    outer loop
+      vertex 231.016 2.82264 5
+      vertex 230.927 2.85317 0
+      vertex 231.016 2.82264 0
+    endloop
+  endfacet
+  facet normal -0.263856 -0.964562 0
+    outer loop
+      vertex 230.746 2.90575 0
+      vertex 230.837 2.88088 5
+      vertex 230.746 2.90575 5
+    endloop
+  endfacet
+  facet normal -0.263856 -0.964562 -0
+    outer loop
+      vertex 230.837 2.88088 5
+      vertex 230.746 2.90575 0
+      vertex 230.837 2.88088 0
+    endloop
+  endfacet
+  facet normal -0.140917 -0.990021 0
+    outer loop
+      vertex 230.376 2.97634 0
+      vertex 230.469 2.96306 5
+      vertex 230.376 2.97634 5
+    endloop
+  endfacet
+  facet normal -0.140917 -0.990021 -0
+    outer loop
+      vertex 230.469 2.96306 5
+      vertex 230.376 2.97634 0
+      vertex 230.469 2.96306 0
+    endloop
+  endfacet
+  facet normal -0.353509 -0.935431 0
+    outer loop
+      vertex 231.016 2.82264 0
+      vertex 231.104 2.78933 5
+      vertex 231.016 2.82264 5
+    endloop
+  endfacet
+  facet normal -0.353509 -0.935431 -0
+    outer loop
+      vertex 231.104 2.78933 5
+      vertex 231.016 2.82264 0
+      vertex 231.104 2.78933 0
+    endloop
+  endfacet
+  facet normal -0.495457 -0.868633 0
+    outer loop
+      vertex 231.445 2.62892 0
+      vertex 231.527 2.58223 5
+      vertex 231.445 2.62892 5
+    endloop
+  endfacet
+  facet normal -0.495457 -0.868633 -0
+    outer loop
+      vertex 231.527 2.58223 5
+      vertex 231.445 2.62892 0
+      vertex 231.527 2.58223 0
+    endloop
+  endfacet
+  facet normal -0.439969 -0.898013 0
+    outer loop
+      vertex 231.277 2.71448 0
+      vertex 231.362 2.67302 5
+      vertex 231.277 2.71448 5
+    endloop
+  endfacet
+  facet normal -0.439969 -0.898013 -0
+    outer loop
+      vertex 231.362 2.67302 5
+      vertex 231.277 2.71448 0
+      vertex 231.362 2.67302 0
+    endloop
+  endfacet
+  facet normal -0.649494 -0.760367 0
+    outer loop
+      vertex 231.912 2.31154 0
+      vertex 231.984 2.25033 5
+      vertex 231.912 2.31154 5
+    endloop
+  endfacet
+  facet normal -0.649494 -0.760367 -0
+    outer loop
+      vertex 231.984 2.25033 5
+      vertex 231.912 2.31154 0
+      vertex 231.984 2.25033 0
+    endloop
+  endfacet
+  facet normal 0.996925 -0.0783632 0
+    outer loop
+      vertex 227.006 0.188371 5
+      vertex 227.013 0.282325 0
+      vertex 227.013 0.282325 5
+    endloop
+  endfacet
+  facet normal 0.996925 -0.0783632 0
+    outer loop
+      vertex 227.013 0.282325 0
+      vertex 227.006 0.188371 5
+      vertex 227.006 0.188371 0
+    endloop
+  endfacet
+  facet normal 0.898042 -0.439909 0
+    outer loop
+      vertex 227.286 1.27734 5
+      vertex 227.327 1.36197 0
+      vertex 227.327 1.36197 5
+    endloop
+  endfacet
+  facet normal 0.898042 -0.439909 0
+    outer loop
+      vertex 227.327 1.36197 0
+      vertex 227.286 1.27734 5
+      vertex 227.286 1.27734 0
+    endloop
+  endfacet
+  facet normal 0.935454 -0.353449 0
+    outer loop
+      vertex 227.177 1.01621 5
+      vertex 227.211 1.10437 0
+      vertex 227.211 1.10437 5
+    endloop
+  endfacet
+  facet normal 0.935454 -0.353449 0
+    outer loop
+      vertex 227.211 1.10437 0
+      vertex 227.177 1.01621 5
+      vertex 227.177 1.01621 0
+    endloop
+  endfacet
+  facet normal 0.911382 -0.411562 0
+    outer loop
+      vertex 227.247 1.19144 5
+      vertex 227.286 1.27734 0
+      vertex 227.286 1.27734 5
+    endloop
+  endfacet
+  facet normal 0.911382 -0.411562 0
+    outer loop
+      vertex 227.286 1.27734 0
+      vertex 227.247 1.19144 5
+      vertex 227.247 1.19144 0
+    endloop
+  endfacet
+  facet normal 0.946117 -0.323825 0
+    outer loop
+      vertex 227.147 0.927051 5
+      vertex 227.177 1.01621 0
+      vertex 227.177 1.01621 5
+    endloop
+  endfacet
+  facet normal 0.946117 -0.323825 0
+    outer loop
+      vertex 227.177 1.01621 0
+      vertex 227.147 0.927051 5
+      vertex 227.147 0.927051 0
+    endloop
+  endfacet
+  facet normal 0.964549 -0.263905 0
+    outer loop
+      vertex 227.094 0.746069 5
+      vertex 227.119 0.836973 0
+      vertex 227.119 0.836973 5
+    endloop
+  endfacet
+  facet normal 0.964549 -0.263905 0
+    outer loop
+      vertex 227.119 0.836973 0
+      vertex 227.094 0.746069 5
+      vertex 227.094 0.746069 0
+    endloop
+  endfacet
+  facet normal 0.990007 -0.141019 0
+    outer loop
+      vertex 227.024 0.375999 5
+      vertex 227.037 0.469303 0
+      vertex 227.037 0.469303 5
+    endloop
+  endfacet
+  facet normal 0.990007 -0.141019 0
+    outer loop
+      vertex 227.037 0.469303 0
+      vertex 227.024 0.375999 5
+      vertex 227.024 0.375999 0
+    endloop
+  endfacet
+  facet normal 0.998889 -0.0471151 0
+    outer loop
+      vertex 227.001 0.0942316 5
+      vertex 227.006 0.188371 0
+      vertex 227.006 0.188371 5
+    endloop
+  endfacet
+  facet normal 0.998889 -0.0471151 0
+    outer loop
+      vertex 227.006 0.188371 0
+      vertex 227.001 0.0942316 5
+      vertex 227.001 0.0942316 0
+    endloop
+  endfacet
+  facet normal 0.467896 -0.883783 0
+    outer loop
+      vertex 228.555 2.62892 0
+      vertex 228.638 2.67302 5
+      vertex 228.555 2.62892 5
+    endloop
+  endfacet
+  facet normal 0.467896 -0.883783 0
+    outer loop
+      vertex 228.638 2.67302 5
+      vertex 228.555 2.62892 0
+      vertex 228.638 2.67302 0
+    endloop
+  endfacet
+  facet normal 0.600434 -0.799674 0
+    outer loop
+      vertex 228.161 2.37046 0
+      vertex 228.237 2.42705 5
+      vertex 228.161 2.37046 5
+    endloop
+  endfacet
+  facet normal 0.600434 -0.799674 0
+    outer loop
+      vertex 228.237 2.42705 5
+      vertex 228.161 2.37046 0
+      vertex 228.237 2.42705 0
+    endloop
+  endfacet
+  facet normal 0.382692 -0.923876 0
+    outer loop
+      vertex 228.809 2.75326 0
+      vertex 228.896 2.78933 5
+      vertex 228.809 2.75326 5
+    endloop
+  endfacet
+  facet normal 0.382692 -0.923876 0
+    outer loop
+      vertex 228.896 2.78933 5
+      vertex 228.809 2.75326 0
+      vertex 228.896 2.78933 0
+    endloop
+  endfacet
+  facet normal 0.233467 -0.972365 0
+    outer loop
+      vertex 229.254 2.90575 0
+      vertex 229.346 2.92775 5
+      vertex 229.254 2.90575 5
+    endloop
+  endfacet
+  facet normal 0.233467 -0.972365 0
+    outer loop
+      vertex 229.346 2.92775 5
+      vertex 229.254 2.90575 0
+      vertex 229.346 2.92775 0
+    endloop
+  endfacet
+  facet normal 0.29405 -0.95579 0
+    outer loop
+      vertex 229.073 2.85317 0
+      vertex 229.163 2.88088 5
+      vertex 229.073 2.85317 5
+    endloop
+  endfacet
+  facet normal 0.29405 -0.95579 0
+    outer loop
+      vertex 229.163 2.88088 5
+      vertex 229.073 2.85317 0
+      vertex 229.163 2.88088 0
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex 229.346 2.92775 0
+      vertex 229.438 2.94686 5
+      vertex 229.346 2.92775 5
+    endloop
+  endfacet
+  facet normal 0.20279 -0.979222 0
+    outer loop
+      vertex 229.438 2.94686 5
+      vertex 229.346 2.92775 0
+      vertex 229.438 2.94686 0
+    endloop
+  endfacet
+  facet normal 0.0784585 -0.996917 0
+    outer loop
+      vertex 229.718 2.98669 0
+      vertex 229.812 2.99408 5
+      vertex 229.718 2.98669 5
+    endloop
+  endfacet
+  facet normal 0.0784585 -0.996917 0
+    outer loop
+      vertex 229.812 2.99408 5
+      vertex 229.718 2.98669 0
+      vertex 229.812 2.99408 0
+    endloop
+  endfacet
+  facet normal -0.996912 0.0785241 0
+    outer loop
+      vertex 232.987 -0.282325 0
+      vertex 232.994 -0.188371 5
+      vertex 232.994 -0.188371 0
+    endloop
+  endfacet
+  facet normal -0.996912 0.0785241 0
+    outer loop
+      vertex 232.994 -0.188371 5
+      vertex 232.987 -0.282325 0
+      vertex 232.987 -0.282325 5
+    endloop
+  endfacet
+  facet normal 0.739609 0.673036 0
+    outer loop
+      vertex 227.813 -2.05364 5
+      vertex 227.75 -1.98394 0
+      vertex 227.75 -1.98394 5
+    endloop
+  endfacet
+  facet normal 0.739609 0.673036 0
+    outer loop
+      vertex 227.75 -1.98394 0
+      vertex 227.813 -2.05364 5
+      vertex 227.813 -2.05364 0
+    endloop
+  endfacet
+  facet normal 0.972364 0.23347 0
+    outer loop
+      vertex 227.094 -0.746069 5
+      vertex 227.072 -0.654429 0
+      vertex 227.072 -0.654429 5
+    endloop
+  endfacet
+  facet normal 0.972364 0.23347 0
+    outer loop
+      vertex 227.072 -0.654429 0
+      vertex 227.094 -0.746069 5
+      vertex 227.094 -0.746069 0
+    endloop
+  endfacet
+  facet normal 0.923857 0.382738 0
+    outer loop
+      vertex 227.247 -1.19144 5
+      vertex 227.211 -1.10437 0
+      vertex 227.211 -1.10437 5
+    endloop
+  endfacet
+  facet normal 0.923857 0.382738 0
+    outer loop
+      vertex 227.211 -1.10437 0
+      vertex 227.247 -1.19144 5
+      vertex 227.247 -1.19144 0
+    endloop
+  endfacet
+  facet normal 0.998889 0.0471151 0
+    outer loop
+      vertex 227.006 -0.188371 5
+      vertex 227.001 -0.0942316 0
+      vertex 227.001 -0.0942316 5
+    endloop
+  endfacet
+  facet normal 0.998889 0.0471151 0
+    outer loop
+      vertex 227.001 -0.0942316 0
+      vertex 227.006 -0.188371 5
+      vertex 227.006 -0.188371 0
+    endloop
+  endfacet
+  facet normal -0.0471088 0.99889 0
+    outer loop
+      vertex 230.188 -2.99408 0
+      vertex 230.094 -2.99852 5
+      vertex 230.188 -2.99408 5
+    endloop
+  endfacet
+  facet normal -0.0471088 0.99889 0
+    outer loop
+      vertex 230.094 -2.99852 5
+      vertex 230.188 -2.99408 0
+      vertex 230.094 -2.99852 0
+    endloop
+  endfacet
+  facet normal -0.996912 -0.0785241 0
+    outer loop
+      vertex 232.994 0.188371 0
+      vertex 232.987 0.282325 5
+      vertex 232.987 0.282325 0
+    endloop
+  endfacet
+  facet normal -0.996912 -0.0785241 0
+    outer loop
+      vertex 232.987 0.282325 5
+      vertex 232.994 0.188371 0
+      vertex 232.994 0.188371 5
+    endloop
+  endfacet
+  facet normal -0.998889 -0.0471151 0
+    outer loop
+      vertex 232.999 0.0942316 0
+      vertex 232.994 0.188371 5
+      vertex 232.994 0.188371 0
+    endloop
+  endfacet
+  facet normal -0.998889 -0.0471151 0
+    outer loop
+      vertex 232.994 0.188371 5
+      vertex 232.999 0.0942316 0
+      vertex 232.999 0.0942316 5
+    endloop
+  endfacet
+  facet normal -0.985134 -0.171789 0
+    outer loop
+      vertex 232.963 0.469303 0
+      vertex 232.947 0.562143 5
+      vertex 232.947 0.562143 0
+    endloop
+  endfacet
+  facet normal -0.985134 -0.171789 0
+    outer loop
+      vertex 232.947 0.562143 5
+      vertex 232.963 0.469303 0
+      vertex 232.963 0.469303 5
+    endloop
+  endfacet
+  facet normal -0.946117 -0.323825 0
+    outer loop
+      vertex 232.853 0.927051 0
+      vertex 232.823 1.01621 5
+      vertex 232.823 1.01621 0
+    endloop
+  endfacet
+  facet normal -0.946117 -0.323825 0
+    outer loop
+      vertex 232.823 1.01621 5
+      vertex 232.853 0.927051 0
+      vertex 232.853 0.927051 5
+    endloop
+  endfacet
+  facet normal -0.964549 -0.263905 0
+    outer loop
+      vertex 232.906 0.746069 0
+      vertex 232.881 0.836973 5
+      vertex 232.881 0.836973 0
+    endloop
+  endfacet
+  facet normal -0.964549 -0.263905 0
+    outer loop
+      vertex 232.881 0.836973 5
+      vertex 232.906 0.746069 0
+      vertex 232.906 0.746069 5
+    endloop
+  endfacet
+  facet normal -0.955797 -0.294026 0
+    outer loop
+      vertex 232.881 0.836973 0
+      vertex 232.853 0.927051 5
+      vertex 232.853 0.927051 0
+    endloop
+  endfacet
+  facet normal -0.955797 -0.294026 0
+    outer loop
+      vertex 232.853 0.927051 5
+      vertex 232.881 0.836973 0
+      vertex 232.881 0.836973 5
+    endloop
+  endfacet
+  facet normal -0.799716 -0.600379 0
+    outer loop
+      vertex 232.427 1.76336 0
+      vertex 232.37 1.83872 5
+      vertex 232.37 1.83872 0
+    endloop
+  endfacet
+  facet normal -0.799716 -0.600379 0
+    outer loop
+      vertex 232.37 1.83872 5
+      vertex 232.427 1.76336 0
+      vertex 232.427 1.76336 5
+    endloop
+  endfacet
+  facet normal -0.780411 -0.625267 0
+    outer loop
+      vertex 232.37 1.83872 0
+      vertex 232.312 1.91227 5
+      vertex 232.312 1.91227 0
+    endloop
+  endfacet
+  facet normal -0.780411 -0.625267 0
+    outer loop
+      vertex 232.312 1.91227 5
+      vertex 232.37 1.83872 0
+      vertex 232.37 1.83872 5
+    endloop
+  endfacet
+  facet normal -0.718146 -0.695893 0
+    outer loop
+      vertex 232.187 2.05364 0
+      vertex 232.121 2.12132 5
+      vertex 232.121 2.12132 0
+    endloop
+  endfacet
+  facet normal -0.718146 -0.695893 0
+    outer loop
+      vertex 232.121 2.12132 5
+      vertex 232.187 2.05364 0
+      vertex 232.187 2.05364 5
+    endloop
+  endfacet
+  facet normal -0.818107 -0.575066 0
+    outer loop
+      vertex 232.481 1.68625 0
+      vertex 232.427 1.76336 5
+      vertex 232.427 1.76336 0
+    endloop
+  endfacet
+  facet normal -0.818107 -0.575066 0
+    outer loop
+      vertex 232.427 1.76336 5
+      vertex 232.481 1.68625 0
+      vertex 232.481 1.68625 5
+    endloop
+  endfacet
+  facet normal -0.868639 -0.495446 0
+    outer loop
+      vertex 232.629 1.44526 0
+      vertex 232.582 1.52712 5
+      vertex 232.582 1.52712 0
+    endloop
+  endfacet
+  facet normal -0.868639 -0.495446 0
+    outer loop
+      vertex 232.582 1.52712 5
+      vertex 232.629 1.44526 0
+      vertex 232.629 1.44526 5
+    endloop
+  endfacet
+  facet normal -0.852652 -0.522479 0
+    outer loop
+      vertex 232.582 1.52712 0
+      vertex 232.533 1.60748 5
+      vertex 232.533 1.60748 0
+    endloop
+  endfacet
+  facet normal -0.852652 -0.522479 0
+    outer loop
+      vertex 232.533 1.60748 5
+      vertex 232.582 1.52712 0
+      vertex 232.582 1.52712 5
+    endloop
+  endfacet
+  facet normal -0.898042 -0.439909 0
+    outer loop
+      vertex 232.714 1.27734 0
+      vertex 232.673 1.36197 5
+      vertex 232.673 1.36197 0
+    endloop
+  endfacet
+  facet normal -0.898042 -0.439909 0
+    outer loop
+      vertex 232.673 1.36197 5
+      vertex 232.714 1.27734 0
+      vertex 232.714 1.27734 5
+    endloop
+  endfacet
+  facet normal -0.911382 -0.411562 0
+    outer loop
+      vertex 232.753 1.19144 0
+      vertex 232.714 1.27734 5
+      vertex 232.714 1.27734 0
+    endloop
+  endfacet
+  facet normal -0.911382 -0.411562 0
+    outer loop
+      vertex 232.714 1.27734 5
+      vertex 232.753 1.19144 0
+      vertex 232.753 1.19144 5
+    endloop
+  endfacet
+  facet normal -0.29405 -0.95579 0
+    outer loop
+      vertex 230.837 2.88088 0
+      vertex 230.927 2.85317 5
+      vertex 230.837 2.88088 5
+    endloop
+  endfacet
+  facet normal -0.29405 -0.95579 -0
+    outer loop
+      vertex 230.927 2.85317 5
+      vertex 230.837 2.88088 0
+      vertex 230.927 2.85317 0
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 0
+    outer loop
+      vertex 230.562 2.94686 0
+      vertex 230.654 2.92775 5
+      vertex 230.562 2.94686 5
+    endloop
+  endfacet
+  facet normal -0.20279 -0.979222 -0
+    outer loop
+      vertex 230.654 2.92775 5
+      vertex 230.562 2.94686 0
+      vertex 230.654 2.92775 0
+    endloop
+  endfacet
+  facet normal -0.233467 -0.972365 0
+    outer loop
+      vertex 230.654 2.92775 0
+      vertex 230.746 2.90575 5
+      vertex 230.654 2.92775 5
+    endloop
+  endfacet
+  facet normal -0.233467 -0.972365 -0
+    outer loop
+      vertex 230.746 2.90575 5
+      vertex 230.654 2.92775 0
+      vertex 230.746 2.90575 0
+    endloop
+  endfacet
+  facet normal -0.109726 -0.993962 0
+    outer loop
+      vertex 230.282 2.98669 0
+      vertex 230.376 2.97634 5
+      vertex 230.282 2.98669 5
+    endloop
+  endfacet
+  facet normal -0.109726 -0.993962 -0
+    outer loop
+      vertex 230.376 2.97634 5
+      vertex 230.282 2.98669 0
+      vertex 230.376 2.97634 0
+    endloop
+  endfacet
+  facet normal -0.0471088 -0.99889 0
+    outer loop
+      vertex 230.094 2.99852 0
+      vertex 230.188 2.99408 5
+      vertex 230.094 2.99852 5
+    endloop
+  endfacet
+  facet normal -0.0471088 -0.99889 -0
+    outer loop
+      vertex 230.188 2.99408 5
+      vertex 230.094 2.99852 0
+      vertex 230.188 2.99408 0
+    endloop
+  endfacet
+  facet normal -0.0157141 -0.999877 0
+    outer loop
+      vertex 230 3 0
+      vertex 230.094 2.99852 5
+      vertex 230 3 5
+    endloop
+  endfacet
+  facet normal -0.0157141 -0.999877 -0
+    outer loop
+      vertex 230.094 2.99852 5
+      vertex 230 3 0
+      vertex 230.094 2.99852 0
+    endloop
+  endfacet
+  facet normal -0.467896 -0.883783 0
+    outer loop
+      vertex 231.362 2.67302 0
+      vertex 231.445 2.62892 5
+      vertex 231.362 2.67302 5
+    endloop
+  endfacet
+  facet normal -0.467896 -0.883783 -0
+    outer loop
+      vertex 231.445 2.62892 5
+      vertex 231.362 2.67302 0
+      vertex 231.445 2.62892 0
+    endloop
+  endfacet
+  facet normal -0.382692 -0.923876 0
+    outer loop
+      vertex 231.104 2.78933 0
+      vertex 231.191 2.75326 5
+      vertex 231.104 2.78933 5
+    endloop
+  endfacet
+  facet normal -0.382692 -0.923876 -0
+    outer loop
+      vertex 231.191 2.75326 5
+      vertex 231.104 2.78933 0
+      vertex 231.191 2.75326 0
+    endloop
+  endfacet
+  facet normal -0.52252 -0.852627 0
+    outer loop
+      vertex 231.527 2.58223 0
+      vertex 231.607 2.53298 5
+      vertex 231.527 2.58223 5
+    endloop
+  endfacet
+  facet normal -0.52252 -0.852627 -0
+    outer loop
+      vertex 231.607 2.53298 5
+      vertex 231.527 2.58223 0
+      vertex 231.607 2.53298 0
+    endloop
+  endfacet
+  facet normal -0.549038 -0.835797 0
+    outer loop
+      vertex 231.607 2.53298 0
+      vertex 231.686 2.48124 5
+      vertex 231.607 2.53298 5
+    endloop
+  endfacet
+  facet normal -0.549038 -0.835797 -0
+    outer loop
+      vertex 231.686 2.48124 5
+      vertex 231.607 2.53298 0
+      vertex 231.686 2.48124 0
+    endloop
+  endfacet
+  facet normal -0.625177 -0.780483 0
+    outer loop
+      vertex 231.839 2.37046 0
+      vertex 231.912 2.31154 5
+      vertex 231.839 2.37046 5
+    endloop
+  endfacet
+  facet normal -0.625177 -0.780483 -0
+    outer loop
+      vertex 231.912 2.31154 5
+      vertex 231.839 2.37046 0
+      vertex 231.912 2.31154 0
+    endloop
+  endfacet
+  facet normal -0.673029 -0.739616 0
+    outer loop
+      vertex 231.984 2.25033 0
+      vertex 232.054 2.18691 5
+      vertex 231.984 2.25033 5
+    endloop
+  endfacet
+  facet normal -0.673029 -0.739616 -0
+    outer loop
+      vertex 232.054 2.18691 5
+      vertex 231.984 2.25033 0
+      vertex 232.054 2.18691 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.5 0 0
+      vertex 233 0 0
+      vertex 232.999 0.0942316 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.499 0.0471153 0
+      vertex 232.999 0.0942316 0
+      vertex 232.994 0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 233 0 0
+      vertex 231.5 0 0
+      vertex 232.999 -0.0942316 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.497 0.0941849 0
+      vertex 232.994 0.188371 0
+      vertex 232.987 0.282325 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.499 -0.0471153 0
+      vertex 232.999 -0.0942316 0
+      vertex 231.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.493 0.141162 0
+      vertex 232.987 0.282325 0
+      vertex 232.976 0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.999 -0.0942316 0
+      vertex 231.499 -0.0471153 0
+      vertex 232.994 -0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.488 0.188 0
+      vertex 232.976 0.375999 0
+      vertex 232.963 0.469303 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.497 -0.0941849 0
+      vertex 232.994 -0.188371 0
+      vertex 231.499 -0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.482 0.234652 0
+      vertex 232.963 0.469303 0
+      vertex 232.947 0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.994 -0.188371 0
+      vertex 231.497 -0.0941849 0
+      vertex 232.987 -0.282325 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.473 0.281072 0
+      vertex 232.947 0.562143 0
+      vertex 232.928 0.654429 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.493 -0.141162 0
+      vertex 232.987 -0.282325 0
+      vertex 231.497 -0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.464 0.327214 0
+      vertex 232.928 0.654429 0
+      vertex 232.906 0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.987 -0.282325 0
+      vertex 231.493 -0.141162 0
+      vertex 232.976 -0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.453 0.373034 0
+      vertex 232.906 0.746069 0
+      vertex 232.881 0.836973 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.488 -0.188 0
+      vertex 232.976 -0.375999 0
+      vertex 231.493 -0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.44 0.418487 0
+      vertex 232.881 0.836973 0
+      vertex 232.853 0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.976 -0.375999 0
+      vertex 231.488 -0.188 0
+      vertex 232.963 -0.469303 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.427 0.463525 0
+      vertex 232.853 0.927051 0
+      vertex 232.823 1.01621 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.482 -0.234652 0
+      vertex 232.963 -0.469303 0
+      vertex 231.488 -0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.411 0.508106 0
+      vertex 232.823 1.01621 0
+      vertex 232.789 1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.963 -0.469303 0
+      vertex 231.482 -0.234652 0
+      vertex 232.947 -0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.395 0.552186 0
+      vertex 232.789 1.10437 0
+      vertex 232.753 1.19144 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.473 -0.281072 0
+      vertex 232.947 -0.562143 0
+      vertex 231.482 -0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.377 0.595721 0
+      vertex 232.753 1.19144 0
+      vertex 232.714 1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.947 -0.562143 0
+      vertex 231.473 -0.281072 0
+      vertex 232.928 -0.654429 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.357 0.638668 0
+      vertex 232.714 1.27734 0
+      vertex 232.673 1.36197 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.464 -0.327214 0
+      vertex 232.928 -0.654429 0
+      vertex 231.473 -0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.337 0.680985 0
+      vertex 232.673 1.36197 0
+      vertex 232.629 1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.928 -0.654429 0
+      vertex 231.464 -0.327214 0
+      vertex 232.906 -0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.314 0.722631 0
+      vertex 232.629 1.44526 0
+      vertex 232.582 1.52712 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.453 -0.373034 0
+      vertex 232.906 -0.746069 0
+      vertex 231.464 -0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.291 0.763561 0
+      vertex 232.582 1.52712 0
+      vertex 232.533 1.60748 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.906 -0.746069 0
+      vertex 231.453 -0.373034 0
+      vertex 232.881 -0.836973 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.266 0.80374 0
+      vertex 232.533 1.60748 0
+      vertex 232.481 1.68625 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.44 -0.418487 0
+      vertex 232.881 -0.836973 0
+      vertex 231.453 -0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.241 0.843124 0
+      vertex 232.481 1.68625 0
+      vertex 232.427 1.76336 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.881 -0.836973 0
+      vertex 231.44 -0.418487 0
+      vertex 232.853 -0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.214 0.881678 0
+      vertex 232.427 1.76336 0
+      vertex 232.37 1.83872 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.427 -0.463525 0
+      vertex 232.853 -0.927051 0
+      vertex 231.44 -0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.185 0.91936 0
+      vertex 232.37 1.83872 0
+      vertex 232.312 1.91227 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.853 -0.927051 0
+      vertex 231.427 -0.463525 0
+      vertex 232.823 -1.01621 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.156 0.956136 0
+      vertex 232.312 1.91227 0
+      vertex 232.25 1.98394 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.411 -0.508106 0
+      vertex 232.823 -1.01621 0
+      vertex 231.427 -0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.125 0.991967 0
+      vertex 232.25 1.98394 0
+      vertex 232.187 2.05364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.823 -1.01621 0
+      vertex 231.411 -0.508106 0
+      vertex 232.789 -1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.093 1.02682 0
+      vertex 232.187 2.05364 0
+      vertex 232.121 2.12132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.395 -0.552186 0
+      vertex 232.789 -1.10437 0
+      vertex 231.411 -0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.061 1.06066 0
+      vertex 232.121 2.12132 0
+      vertex 232.054 2.18691 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.789 -1.10437 0
+      vertex 231.395 -0.552186 0
+      vertex 232.753 -1.19144 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.027 1.09345 0
+      vertex 232.054 2.18691 0
+      vertex 231.984 2.25033 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.377 -0.595721 0
+      vertex 232.753 -1.19144 0
+      vertex 231.395 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.992 1.12517 0
+      vertex 231.984 2.25033 0
+      vertex 231.912 2.31154 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.753 -1.19144 0
+      vertex 231.377 -0.595721 0
+      vertex 232.714 -1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.956 1.15577 0
+      vertex 231.912 2.31154 0
+      vertex 231.839 2.37046 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.357 -0.638668 0
+      vertex 232.714 -1.27734 0
+      vertex 231.377 -0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.919 1.18523 0
+      vertex 231.839 2.37046 0
+      vertex 231.763 2.42705 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.714 -1.27734 0
+      vertex 231.357 -0.638668 0
+      vertex 232.673 -1.36197 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.882 1.21352 0
+      vertex 231.763 2.42705 0
+      vertex 231.686 2.48124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.337 -0.680985 0
+      vertex 232.673 -1.36197 0
+      vertex 231.357 -0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.843 1.24062 0
+      vertex 231.686 2.48124 0
+      vertex 231.607 2.53298 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.673 -1.36197 0
+      vertex 231.337 -0.680985 0
+      vertex 232.629 -1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.804 1.26649 0
+      vertex 231.607 2.53298 0
+      vertex 231.527 2.58223 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.314 -0.722631 0
+      vertex 232.629 -1.44526 0
+      vertex 231.337 -0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.629 -1.44526 0
+      vertex 231.314 -0.722631 0
+      vertex 232.582 -1.52712 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.999 0.0942316 0
+      vertex 231.499 0.0471153 0
+      vertex 231.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.994 0.188371 0
+      vertex 231.497 0.0941849 0
+      vertex 231.499 0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.987 0.282325 0
+      vertex 231.493 0.141162 0
+      vertex 231.497 0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.976 0.375999 0
+      vertex 231.488 0.188 0
+      vertex 231.493 0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.963 0.469303 0
+      vertex 231.482 0.234652 0
+      vertex 231.488 0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.947 0.562143 0
+      vertex 231.473 0.281072 0
+      vertex 231.482 0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.928 0.654429 0
+      vertex 231.464 0.327214 0
+      vertex 231.473 0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.906 0.746069 0
+      vertex 231.453 0.373034 0
+      vertex 231.464 0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.764 1.29111 0
+      vertex 231.527 2.58223 0
+      vertex 231.445 2.62892 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.881 0.836973 0
+      vertex 231.44 0.418487 0
+      vertex 231.453 0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.853 0.927051 0
+      vertex 231.427 0.463525 0
+      vertex 231.44 0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.823 1.01621 0
+      vertex 231.411 0.508106 0
+      vertex 231.427 0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.789 1.10437 0
+      vertex 231.395 0.552186 0
+      vertex 231.411 0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.753 1.19144 0
+      vertex 231.377 0.595721 0
+      vertex 231.395 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.723 1.31446 0
+      vertex 231.445 2.62892 0
+      vertex 231.362 2.67302 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.714 1.27734 0
+      vertex 231.357 0.638668 0
+      vertex 231.377 0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.673 1.36197 0
+      vertex 231.337 0.680985 0
+      vertex 231.357 0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.629 1.44526 0
+      vertex 231.314 0.722631 0
+      vertex 231.337 0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.582 1.52712 0
+      vertex 231.291 0.763561 0
+      vertex 231.314 0.722631 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.681 1.33651 0
+      vertex 231.362 2.67302 0
+      vertex 231.277 2.71448 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.533 1.60748 0
+      vertex 231.266 0.80374 0
+      vertex 231.291 0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.481 1.68625 0
+      vertex 231.241 0.843124 0
+      vertex 231.266 0.80374 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.427 1.76336 0
+      vertex 231.214 0.881678 0
+      vertex 231.241 0.843124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.639 1.35724 0
+      vertex 231.277 2.71448 0
+      vertex 231.191 2.75326 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.37 1.83872 0
+      vertex 231.185 0.91936 0
+      vertex 231.214 0.881678 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.312 1.91227 0
+      vertex 231.156 0.956136 0
+      vertex 231.185 0.91936 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.25 1.98394 0
+      vertex 231.125 0.991967 0
+      vertex 231.156 0.956136 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.596 1.37663 0
+      vertex 231.191 2.75326 0
+      vertex 231.104 2.78933 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.187 2.05364 0
+      vertex 231.093 1.02682 0
+      vertex 231.125 0.991967 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.121 2.12132 0
+      vertex 231.061 1.06066 0
+      vertex 231.093 1.02682 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.054 2.18691 0
+      vertex 231.027 1.09345 0
+      vertex 231.061 1.06066 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.552 1.39466 0
+      vertex 231.104 2.78933 0
+      vertex 231.016 2.82264 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.984 2.25033 0
+      vertex 230.992 1.12517 0
+      vertex 231.027 1.09345 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.912 2.31154 0
+      vertex 230.956 1.15577 0
+      vertex 230.992 1.12517 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.508 1.41132 0
+      vertex 231.016 2.82264 0
+      vertex 230.927 2.85317 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.839 2.37046 0
+      vertex 230.919 1.18523 0
+      vertex 230.956 1.15577 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.763 2.42705 0
+      vertex 230.882 1.21352 0
+      vertex 230.919 1.18523 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.686 2.48124 0
+      vertex 230.843 1.24062 0
+      vertex 230.882 1.21352 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.464 1.42658 0
+      vertex 230.927 2.85317 0
+      vertex 230.837 2.88088 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.607 2.53298 0
+      vertex 230.804 1.26649 0
+      vertex 230.843 1.24062 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.527 2.58223 0
+      vertex 230.764 1.29111 0
+      vertex 230.804 1.26649 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.418 1.44044 0
+      vertex 230.837 2.88088 0
+      vertex 230.746 2.90575 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.445 2.62892 0
+      vertex 230.723 1.31446 0
+      vertex 230.764 1.29111 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.362 2.67302 0
+      vertex 230.681 1.33651 0
+      vertex 230.723 1.31446 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.373 1.45287 0
+      vertex 230.746 2.90575 0
+      vertex 230.654 2.92775 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.277 2.71448 0
+      vertex 230.639 1.35724 0
+      vertex 230.681 1.33651 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.191 2.75326 0
+      vertex 230.596 1.37663 0
+      vertex 230.639 1.35724 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.327 1.46387 0
+      vertex 230.654 2.92775 0
+      vertex 230.562 2.94686 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.104 2.78933 0
+      vertex 230.552 1.39466 0
+      vertex 230.596 1.37663 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.016 2.82264 0
+      vertex 230.508 1.41132 0
+      vertex 230.552 1.39466 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.281 1.47343 0
+      vertex 230.562 2.94686 0
+      vertex 230.469 2.96306 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.927 2.85317 0
+      vertex 230.464 1.42658 0
+      vertex 230.508 1.41132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.837 2.88088 0
+      vertex 230.418 1.44044 0
+      vertex 230.464 1.42658 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.235 1.48153 0
+      vertex 230.469 2.96306 0
+      vertex 230.376 2.97634 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.746 2.90575 0
+      vertex 230.373 1.45287 0
+      vertex 230.418 1.44044 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.654 2.92775 0
+      vertex 230.327 1.46387 0
+      vertex 230.373 1.45287 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.188 1.48817 0
+      vertex 230.376 2.97634 0
+      vertex 230.282 2.98669 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.562 2.94686 0
+      vertex 230.281 1.47343 0
+      vertex 230.327 1.46387 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.469 2.96306 0
+      vertex 230.235 1.48153 0
+      vertex 230.281 1.47343 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.141 1.49334 0
+      vertex 230.282 2.98669 0
+      vertex 230.188 2.99408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.376 2.97634 0
+      vertex 230.188 1.48817 0
+      vertex 230.235 1.48153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.282 2.98669 0
+      vertex 230.141 1.49334 0
+      vertex 230.188 1.48817 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.094 1.49704 0
+      vertex 230.188 2.99408 0
+      vertex 230.094 2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.188 2.99408 0
+      vertex 230.094 1.49704 0
+      vertex 230.141 1.49334 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.094 2.99852 0
+      vertex 230.047 1.49926 0
+      vertex 230.094 1.49704 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230 3 0
+      vertex 230.047 1.49926 0
+      vertex 230.094 2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230 3 0
+      vertex 230 1.5 0
+      vertex 230.047 1.49926 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230 3 0
+      vertex 229.953 1.49926 0
+      vertex 230 1.5 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.906 2.99852 0
+      vertex 229.953 1.49926 0
+      vertex 230 3 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.953 1.49926 0
+      vertex 229.906 2.99852 0
+      vertex 229.906 1.49704 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.812 2.99408 0
+      vertex 229.906 1.49704 0
+      vertex 229.906 2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.906 1.49704 0
+      vertex 229.812 2.99408 0
+      vertex 229.859 1.49334 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.718 2.98669 0
+      vertex 229.859 1.49334 0
+      vertex 229.812 2.99408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.859 1.49334 0
+      vertex 229.718 2.98669 0
+      vertex 229.812 1.48817 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.624 2.97634 0
+      vertex 229.812 1.48817 0
+      vertex 229.718 2.98669 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.812 1.48817 0
+      vertex 229.624 2.97634 0
+      vertex 229.765 1.48153 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.531 2.96306 0
+      vertex 229.765 1.48153 0
+      vertex 229.624 2.97634 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.765 1.48153 0
+      vertex 229.531 2.96306 0
+      vertex 229.719 1.47343 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.438 2.94686 0
+      vertex 229.719 1.47343 0
+      vertex 229.531 2.96306 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.719 1.47343 0
+      vertex 229.438 2.94686 0
+      vertex 229.673 1.46387 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.346 2.92775 0
+      vertex 229.673 1.46387 0
+      vertex 229.438 2.94686 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.673 1.46387 0
+      vertex 229.346 2.92775 0
+      vertex 229.627 1.45287 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.254 2.90575 0
+      vertex 229.627 1.45287 0
+      vertex 229.346 2.92775 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.627 1.45287 0
+      vertex 229.254 2.90575 0
+      vertex 229.582 1.44044 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.163 2.88088 0
+      vertex 229.582 1.44044 0
+      vertex 229.254 2.90575 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.582 1.44044 0
+      vertex 229.163 2.88088 0
+      vertex 229.536 1.42658 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 229.073 2.85317 0
+      vertex 229.536 1.42658 0
+      vertex 229.163 2.88088 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.536 1.42658 0
+      vertex 229.073 2.85317 0
+      vertex 229.492 1.41132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.984 2.82264 0
+      vertex 229.492 1.41132 0
+      vertex 229.073 2.85317 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.492 1.41132 0
+      vertex 228.984 2.82264 0
+      vertex 229.448 1.39466 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.896 2.78933 0
+      vertex 229.448 1.39466 0
+      vertex 228.984 2.82264 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.448 1.39466 0
+      vertex 228.896 2.78933 0
+      vertex 229.404 1.37663 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.809 2.75326 0
+      vertex 229.404 1.37663 0
+      vertex 228.896 2.78933 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.404 1.37663 0
+      vertex 228.809 2.75326 0
+      vertex 229.361 1.35724 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.723 2.71448 0
+      vertex 229.361 1.35724 0
+      vertex 228.809 2.75326 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.361 1.35724 0
+      vertex 228.723 2.71448 0
+      vertex 229.319 1.33651 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.638 2.67302 0
+      vertex 229.319 1.33651 0
+      vertex 228.723 2.71448 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.319 1.33651 0
+      vertex 228.638 2.67302 0
+      vertex 229.277 1.31446 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.555 2.62892 0
+      vertex 229.277 1.31446 0
+      vertex 228.638 2.67302 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.277 1.31446 0
+      vertex 228.555 2.62892 0
+      vertex 229.236 1.29111 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.473 2.58223 0
+      vertex 229.236 1.29111 0
+      vertex 228.555 2.62892 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.236 1.29111 0
+      vertex 228.473 2.58223 0
+      vertex 229.196 1.26649 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.393 2.53298 0
+      vertex 229.196 1.26649 0
+      vertex 228.473 2.58223 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.196 1.26649 0
+      vertex 228.393 2.53298 0
+      vertex 229.157 1.24062 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.314 2.48124 0
+      vertex 229.157 1.24062 0
+      vertex 228.393 2.53298 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.157 1.24062 0
+      vertex 228.314 2.48124 0
+      vertex 229.118 1.21352 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.237 2.42705 0
+      vertex 229.118 1.21352 0
+      vertex 228.314 2.48124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.118 1.21352 0
+      vertex 228.237 2.42705 0
+      vertex 229.081 1.18523 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.161 2.37046 0
+      vertex 229.081 1.18523 0
+      vertex 228.237 2.42705 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.081 1.18523 0
+      vertex 228.161 2.37046 0
+      vertex 229.044 1.15577 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.088 2.31154 0
+      vertex 229.044 1.15577 0
+      vertex 228.161 2.37046 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.044 1.15577 0
+      vertex 228.088 2.31154 0
+      vertex 229.008 1.12517 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 228.016 2.25033 0
+      vertex 229.008 1.12517 0
+      vertex 228.088 2.31154 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.008 1.12517 0
+      vertex 228.016 2.25033 0
+      vertex 228.973 1.09345 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.946 2.18691 0
+      vertex 228.973 1.09345 0
+      vertex 228.016 2.25033 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.973 1.09345 0
+      vertex 227.946 2.18691 0
+      vertex 228.939 1.06066 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.879 2.12132 0
+      vertex 228.939 1.06066 0
+      vertex 227.946 2.18691 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.939 1.06066 0
+      vertex 227.879 2.12132 0
+      vertex 228.907 1.02682 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.813 2.05364 0
+      vertex 228.907 1.02682 0
+      vertex 227.879 2.12132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.907 1.02682 0
+      vertex 227.813 2.05364 0
+      vertex 228.875 0.991967 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.75 1.98394 0
+      vertex 228.875 0.991967 0
+      vertex 227.813 2.05364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.875 0.991967 0
+      vertex 227.75 1.98394 0
+      vertex 228.844 0.956136 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.688 1.91227 0
+      vertex 228.844 0.956136 0
+      vertex 227.75 1.98394 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.844 0.956136 0
+      vertex 227.688 1.91227 0
+      vertex 228.815 0.91936 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.63 1.83872 0
+      vertex 228.815 0.91936 0
+      vertex 227.688 1.91227 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.815 0.91936 0
+      vertex 227.63 1.83872 0
+      vertex 228.786 0.881678 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.573 1.76336 0
+      vertex 228.786 0.881678 0
+      vertex 227.63 1.83872 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.786 0.881678 0
+      vertex 227.573 1.76336 0
+      vertex 228.759 0.843124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.519 1.68625 0
+      vertex 228.759 0.843124 0
+      vertex 227.573 1.76336 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.759 0.843124 0
+      vertex 227.519 1.68625 0
+      vertex 228.734 0.80374 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.467 1.60748 0
+      vertex 228.734 0.80374 0
+      vertex 227.519 1.68625 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.734 0.80374 0
+      vertex 227.467 1.60748 0
+      vertex 228.709 0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.709 0.763561 0
+      vertex 227.418 1.52712 0
+      vertex 228.686 0.722631 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.418 1.52712 0
+      vertex 228.709 0.763561 0
+      vertex 227.467 1.60748 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.291 -0.763561 0
+      vertex 232.582 -1.52712 0
+      vertex 231.314 -0.722631 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.582 -1.52712 0
+      vertex 231.291 -0.763561 0
+      vertex 232.533 -1.60748 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.266 -0.80374 0
+      vertex 232.533 -1.60748 0
+      vertex 231.291 -0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.533 -1.60748 0
+      vertex 231.266 -0.80374 0
+      vertex 232.481 -1.68625 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.241 -0.843124 0
+      vertex 232.481 -1.68625 0
+      vertex 231.266 -0.80374 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.481 -1.68625 0
+      vertex 231.241 -0.843124 0
+      vertex 232.427 -1.76336 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.214 -0.881678 0
+      vertex 232.427 -1.76336 0
+      vertex 231.241 -0.843124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.427 -1.76336 0
+      vertex 231.214 -0.881678 0
+      vertex 232.37 -1.83872 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.185 -0.91936 0
+      vertex 232.37 -1.83872 0
+      vertex 231.214 -0.881678 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.37 -1.83872 0
+      vertex 231.185 -0.91936 0
+      vertex 232.312 -1.91227 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.156 -0.956136 0
+      vertex 232.312 -1.91227 0
+      vertex 231.185 -0.91936 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.312 -1.91227 0
+      vertex 231.156 -0.956136 0
+      vertex 232.25 -1.98394 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.125 -0.991967 0
+      vertex 232.25 -1.98394 0
+      vertex 231.156 -0.956136 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.25 -1.98394 0
+      vertex 231.125 -0.991967 0
+      vertex 232.187 -2.05364 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.093 -1.02682 0
+      vertex 232.187 -2.05364 0
+      vertex 231.125 -0.991967 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.187 -2.05364 0
+      vertex 231.093 -1.02682 0
+      vertex 232.121 -2.12132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.061 -1.06066 0
+      vertex 232.121 -2.12132 0
+      vertex 231.093 -1.02682 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.121 -2.12132 0
+      vertex 231.061 -1.06066 0
+      vertex 232.054 -2.18691 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 231.027 -1.09345 0
+      vertex 232.054 -2.18691 0
+      vertex 231.061 -1.06066 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 232.054 -2.18691 0
+      vertex 231.027 -1.09345 0
+      vertex 231.984 -2.25033 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.992 -1.12517 0
+      vertex 231.984 -2.25033 0
+      vertex 231.027 -1.09345 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.984 -2.25033 0
+      vertex 230.992 -1.12517 0
+      vertex 231.912 -2.31154 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.956 -1.15577 0
+      vertex 231.912 -2.31154 0
+      vertex 230.992 -1.12517 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.912 -2.31154 0
+      vertex 230.956 -1.15577 0
+      vertex 231.839 -2.37046 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.919 -1.18523 0
+      vertex 231.839 -2.37046 0
+      vertex 230.956 -1.15577 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.839 -2.37046 0
+      vertex 230.919 -1.18523 0
+      vertex 231.763 -2.42705 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.882 -1.21352 0
+      vertex 231.763 -2.42705 0
+      vertex 230.919 -1.18523 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.763 -2.42705 0
+      vertex 230.882 -1.21352 0
+      vertex 231.686 -2.48124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.843 -1.24062 0
+      vertex 231.686 -2.48124 0
+      vertex 230.882 -1.21352 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.686 -2.48124 0
+      vertex 230.843 -1.24062 0
+      vertex 231.607 -2.53298 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.804 -1.26649 0
+      vertex 231.607 -2.53298 0
+      vertex 230.843 -1.24062 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.607 -2.53298 0
+      vertex 230.804 -1.26649 0
+      vertex 231.527 -2.58223 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.764 -1.29111 0
+      vertex 231.527 -2.58223 0
+      vertex 230.804 -1.26649 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.527 -2.58223 0
+      vertex 230.764 -1.29111 0
+      vertex 231.445 -2.62892 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.723 -1.31446 0
+      vertex 231.445 -2.62892 0
+      vertex 230.764 -1.29111 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.445 -2.62892 0
+      vertex 230.723 -1.31446 0
+      vertex 231.362 -2.67302 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.681 -1.33651 0
+      vertex 231.362 -2.67302 0
+      vertex 230.723 -1.31446 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.362 -2.67302 0
+      vertex 230.681 -1.33651 0
+      vertex 231.277 -2.71448 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.639 -1.35724 0
+      vertex 231.277 -2.71448 0
+      vertex 230.681 -1.33651 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.277 -2.71448 0
+      vertex 230.639 -1.35724 0
+      vertex 231.191 -2.75326 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.596 -1.37663 0
+      vertex 231.191 -2.75326 0
+      vertex 230.639 -1.35724 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.191 -2.75326 0
+      vertex 230.596 -1.37663 0
+      vertex 231.104 -2.78933 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.552 -1.39466 0
+      vertex 231.104 -2.78933 0
+      vertex 230.596 -1.37663 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.104 -2.78933 0
+      vertex 230.552 -1.39466 0
+      vertex 231.016 -2.82264 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.508 -1.41132 0
+      vertex 231.016 -2.82264 0
+      vertex 230.552 -1.39466 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 231.016 -2.82264 0
+      vertex 230.508 -1.41132 0
+      vertex 230.927 -2.85317 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.464 -1.42658 0
+      vertex 230.927 -2.85317 0
+      vertex 230.508 -1.41132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.927 -2.85317 0
+      vertex 230.464 -1.42658 0
+      vertex 230.837 -2.88088 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.418 -1.44044 0
+      vertex 230.837 -2.88088 0
+      vertex 230.464 -1.42658 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.837 -2.88088 0
+      vertex 230.418 -1.44044 0
+      vertex 230.746 -2.90575 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.373 -1.45287 0
+      vertex 230.746 -2.90575 0
+      vertex 230.418 -1.44044 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.746 -2.90575 0
+      vertex 230.373 -1.45287 0
+      vertex 230.654 -2.92775 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.327 -1.46387 0
+      vertex 230.654 -2.92775 0
+      vertex 230.373 -1.45287 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.654 -2.92775 0
+      vertex 230.327 -1.46387 0
+      vertex 230.562 -2.94686 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.281 -1.47343 0
+      vertex 230.562 -2.94686 0
+      vertex 230.327 -1.46387 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.562 -2.94686 0
+      vertex 230.281 -1.47343 0
+      vertex 230.469 -2.96306 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.235 -1.48153 0
+      vertex 230.469 -2.96306 0
+      vertex 230.281 -1.47343 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.469 -2.96306 0
+      vertex 230.235 -1.48153 0
+      vertex 230.376 -2.97634 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.188 -1.48817 0
+      vertex 230.376 -2.97634 0
+      vertex 230.235 -1.48153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.376 -2.97634 0
+      vertex 230.188 -1.48817 0
+      vertex 230.282 -2.98669 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.141 -1.49334 0
+      vertex 230.282 -2.98669 0
+      vertex 230.188 -1.48817 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.282 -2.98669 0
+      vertex 230.141 -1.49334 0
+      vertex 230.188 -2.99408 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.094 -1.49704 0
+      vertex 230.188 -2.99408 0
+      vertex 230.141 -1.49334 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230.188 -2.99408 0
+      vertex 230.094 -1.49704 0
+      vertex 230.094 -2.99852 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230.047 -1.49926 0
+      vertex 230.094 -2.99852 0
+      vertex 230.094 -1.49704 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 230 -1.5 0
+      vertex 230.094 -2.99852 0
+      vertex 230.047 -1.49926 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 230 -1.5 0
+      vertex 230 -3 0
+      vertex 230.094 -2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.953 -1.49926 0
+      vertex 230 -3 0
+      vertex 230 -1.5 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.906 -2.99852 0
+      vertex 229.953 -1.49926 0
+      vertex 229.906 -1.49704 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.953 -1.49926 0
+      vertex 229.906 -2.99852 0
+      vertex 230 -3 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.812 -2.99408 0
+      vertex 229.906 -1.49704 0
+      vertex 229.859 -1.49334 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.718 -2.98669 0
+      vertex 229.859 -1.49334 0
+      vertex 229.812 -1.48817 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.906 -1.49704 0
+      vertex 229.812 -2.99408 0
+      vertex 229.906 -2.99852 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.624 -2.97634 0
+      vertex 229.812 -1.48817 0
+      vertex 229.765 -1.48153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.531 -2.96306 0
+      vertex 229.765 -1.48153 0
+      vertex 229.719 -1.47343 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.859 -1.49334 0
+      vertex 229.718 -2.98669 0
+      vertex 229.812 -2.99408 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.438 -2.94686 0
+      vertex 229.719 -1.47343 0
+      vertex 229.673 -1.46387 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.346 -2.92775 0
+      vertex 229.673 -1.46387 0
+      vertex 229.627 -1.45287 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.812 -1.48817 0
+      vertex 229.624 -2.97634 0
+      vertex 229.718 -2.98669 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.254 -2.90575 0
+      vertex 229.627 -1.45287 0
+      vertex 229.582 -1.44044 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.163 -2.88088 0
+      vertex 229.582 -1.44044 0
+      vertex 229.536 -1.42658 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.765 -1.48153 0
+      vertex 229.531 -2.96306 0
+      vertex 229.624 -2.97634 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.073 -2.85317 0
+      vertex 229.536 -1.42658 0
+      vertex 229.492 -1.41132 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.984 -2.82264 0
+      vertex 229.492 -1.41132 0
+      vertex 229.448 -1.39466 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.719 -1.47343 0
+      vertex 229.438 -2.94686 0
+      vertex 229.531 -2.96306 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.896 -2.78933 0
+      vertex 229.448 -1.39466 0
+      vertex 229.404 -1.37663 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.809 -2.75326 0
+      vertex 229.404 -1.37663 0
+      vertex 229.361 -1.35724 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.673 -1.46387 0
+      vertex 229.346 -2.92775 0
+      vertex 229.438 -2.94686 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.723 -2.71448 0
+      vertex 229.361 -1.35724 0
+      vertex 229.319 -1.33651 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.638 -2.67302 0
+      vertex 229.319 -1.33651 0
+      vertex 229.277 -1.31446 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.627 -1.45287 0
+      vertex 229.254 -2.90575 0
+      vertex 229.346 -2.92775 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.555 -2.62892 0
+      vertex 229.277 -1.31446 0
+      vertex 229.236 -1.29111 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.473 -2.58223 0
+      vertex 229.236 -1.29111 0
+      vertex 229.196 -1.26649 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.582 -1.44044 0
+      vertex 229.163 -2.88088 0
+      vertex 229.254 -2.90575 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.393 -2.53298 0
+      vertex 229.196 -1.26649 0
+      vertex 229.157 -1.24062 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.314 -2.48124 0
+      vertex 229.157 -1.24062 0
+      vertex 229.118 -1.21352 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.237 -2.42705 0
+      vertex 229.118 -1.21352 0
+      vertex 229.081 -1.18523 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.536 -1.42658 0
+      vertex 229.073 -2.85317 0
+      vertex 229.163 -2.88088 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.161 -2.37046 0
+      vertex 229.081 -1.18523 0
+      vertex 229.044 -1.15577 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.088 -2.31154 0
+      vertex 229.044 -1.15577 0
+      vertex 229.008 -1.12517 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.492 -1.41132 0
+      vertex 228.984 -2.82264 0
+      vertex 229.073 -2.85317 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.016 -2.25033 0
+      vertex 229.008 -1.12517 0
+      vertex 228.973 -1.09345 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.946 -2.18691 0
+      vertex 228.973 -1.09345 0
+      vertex 228.939 -1.06066 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.879 -2.12132 0
+      vertex 228.939 -1.06066 0
+      vertex 228.907 -1.02682 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.448 -1.39466 0
+      vertex 228.896 -2.78933 0
+      vertex 228.984 -2.82264 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.813 -2.05364 0
+      vertex 228.907 -1.02682 0
+      vertex 228.875 -0.991967 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.75 -1.98394 0
+      vertex 228.875 -0.991967 0
+      vertex 228.844 -0.956136 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.688 -1.91227 0
+      vertex 228.844 -0.956136 0
+      vertex 228.815 -0.91936 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.404 -1.37663 0
+      vertex 228.809 -2.75326 0
+      vertex 228.896 -2.78933 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.63 -1.83872 0
+      vertex 228.815 -0.91936 0
+      vertex 228.786 -0.881678 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.573 -1.76336 0
+      vertex 228.786 -0.881678 0
+      vertex 228.759 -0.843124 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.519 -1.68625 0
+      vertex 228.759 -0.843124 0
+      vertex 228.734 -0.80374 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.361 -1.35724 0
+      vertex 228.723 -2.71448 0
+      vertex 228.809 -2.75326 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.467 -1.60748 0
+      vertex 228.734 -0.80374 0
+      vertex 228.709 -0.763561 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.418 -1.52712 0
+      vertex 228.709 -0.763561 0
+      vertex 228.686 -0.722631 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.371 -1.44526 0
+      vertex 228.686 -0.722631 0
+      vertex 228.663 -0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.327 -1.36197 0
+      vertex 228.663 -0.680985 0
+      vertex 228.643 -0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.319 -1.33651 0
+      vertex 228.638 -2.67302 0
+      vertex 228.723 -2.71448 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.286 -1.27734 0
+      vertex 228.643 -0.638668 0
+      vertex 228.623 -0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.247 -1.19144 0
+      vertex 228.623 -0.595721 0
+      vertex 228.605 -0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.211 -1.10437 0
+      vertex 228.605 -0.552186 0
+      vertex 228.589 -0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.177 -1.01621 0
+      vertex 228.589 -0.508106 0
+      vertex 228.573 -0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.147 -0.927051 0
+      vertex 228.573 -0.463525 0
+      vertex 228.56 -0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.277 -1.31446 0
+      vertex 228.555 -2.62892 0
+      vertex 228.638 -2.67302 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.119 -0.836973 0
+      vertex 228.56 -0.418487 0
+      vertex 228.547 -0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.094 -0.746069 0
+      vertex 228.547 -0.373034 0
+      vertex 228.536 -0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.072 -0.654429 0
+      vertex 228.536 -0.327214 0
+      vertex 228.527 -0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.053 -0.562143 0
+      vertex 228.527 -0.281072 0
+      vertex 228.518 -0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.037 -0.469303 0
+      vertex 228.518 -0.234652 0
+      vertex 228.512 -0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.024 -0.375999 0
+      vertex 228.512 -0.188 0
+      vertex 228.507 -0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.013 -0.282325 0
+      vertex 228.507 -0.141162 0
+      vertex 228.503 -0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.006 -0.188371 0
+      vertex 228.503 -0.0941849 0
+      vertex 228.501 -0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.236 -1.29111 0
+      vertex 228.473 -2.58223 0
+      vertex 228.555 -2.62892 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227.001 -0.0942316 0
+      vertex 228.501 -0.0471153 0
+      vertex 228.5 0 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.371 1.44526 0
+      vertex 228.686 0.722631 0
+      vertex 227.418 1.52712 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.686 0.722631 0
+      vertex 227.371 1.44526 0
+      vertex 228.663 0.680985 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.196 -1.26649 0
+      vertex 228.393 -2.53298 0
+      vertex 228.473 -2.58223 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.327 1.36197 0
+      vertex 228.663 0.680985 0
+      vertex 227.371 1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.157 -1.24062 0
+      vertex 228.314 -2.48124 0
+      vertex 228.393 -2.53298 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.663 0.680985 0
+      vertex 227.327 1.36197 0
+      vertex 228.643 0.638668 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.118 -1.21352 0
+      vertex 228.237 -2.42705 0
+      vertex 228.314 -2.48124 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.286 1.27734 0
+      vertex 228.643 0.638668 0
+      vertex 227.327 1.36197 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.081 -1.18523 0
+      vertex 228.161 -2.37046 0
+      vertex 228.237 -2.42705 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.643 0.638668 0
+      vertex 227.286 1.27734 0
+      vertex 228.623 0.595721 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.044 -1.15577 0
+      vertex 228.088 -2.31154 0
+      vertex 228.161 -2.37046 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.247 1.19144 0
+      vertex 228.623 0.595721 0
+      vertex 227.286 1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 229.008 -1.12517 0
+      vertex 228.016 -2.25033 0
+      vertex 228.088 -2.31154 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.623 0.595721 0
+      vertex 227.247 1.19144 0
+      vertex 228.605 0.552186 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.973 -1.09345 0
+      vertex 227.946 -2.18691 0
+      vertex 228.016 -2.25033 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.211 1.10437 0
+      vertex 228.605 0.552186 0
+      vertex 227.247 1.19144 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.939 -1.06066 0
+      vertex 227.879 -2.12132 0
+      vertex 227.946 -2.18691 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.605 0.552186 0
+      vertex 227.211 1.10437 0
+      vertex 228.589 0.508106 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.907 -1.02682 0
+      vertex 227.813 -2.05364 0
+      vertex 227.879 -2.12132 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.177 1.01621 0
+      vertex 228.589 0.508106 0
+      vertex 227.211 1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.875 -0.991967 0
+      vertex 227.75 -1.98394 0
+      vertex 227.813 -2.05364 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.589 0.508106 0
+      vertex 227.177 1.01621 0
+      vertex 228.573 0.463525 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.844 -0.956136 0
+      vertex 227.688 -1.91227 0
+      vertex 227.75 -1.98394 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.147 0.927051 0
+      vertex 228.573 0.463525 0
+      vertex 227.177 1.01621 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.815 -0.91936 0
+      vertex 227.63 -1.83872 0
+      vertex 227.688 -1.91227 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.573 0.463525 0
+      vertex 227.147 0.927051 0
+      vertex 228.56 0.418487 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.786 -0.881678 0
+      vertex 227.573 -1.76336 0
+      vertex 227.63 -1.83872 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.119 0.836973 0
+      vertex 228.56 0.418487 0
+      vertex 227.147 0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.759 -0.843124 0
+      vertex 227.519 -1.68625 0
+      vertex 227.573 -1.76336 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.56 0.418487 0
+      vertex 227.119 0.836973 0
+      vertex 228.547 0.373034 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.734 -0.80374 0
+      vertex 227.467 -1.60748 0
+      vertex 227.519 -1.68625 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.094 0.746069 0
+      vertex 228.547 0.373034 0
+      vertex 227.119 0.836973 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.709 -0.763561 0
+      vertex 227.418 -1.52712 0
+      vertex 227.467 -1.60748 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.547 0.373034 0
+      vertex 227.094 0.746069 0
+      vertex 228.536 0.327214 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.686 -0.722631 0
+      vertex 227.371 -1.44526 0
+      vertex 227.418 -1.52712 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.072 0.654429 0
+      vertex 228.536 0.327214 0
+      vertex 227.094 0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.663 -0.680985 0
+      vertex 227.327 -1.36197 0
+      vertex 227.371 -1.44526 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.536 0.327214 0
+      vertex 227.072 0.654429 0
+      vertex 228.527 0.281072 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.643 -0.638668 0
+      vertex 227.286 -1.27734 0
+      vertex 227.327 -1.36197 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.053 0.562143 0
+      vertex 228.527 0.281072 0
+      vertex 227.072 0.654429 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.623 -0.595721 0
+      vertex 227.247 -1.19144 0
+      vertex 227.286 -1.27734 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.527 0.281072 0
+      vertex 227.053 0.562143 0
+      vertex 228.518 0.234652 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.605 -0.552186 0
+      vertex 227.211 -1.10437 0
+      vertex 227.247 -1.19144 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.037 0.469303 0
+      vertex 228.518 0.234652 0
+      vertex 227.053 0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.589 -0.508106 0
+      vertex 227.177 -1.01621 0
+      vertex 227.211 -1.10437 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.518 0.234652 0
+      vertex 227.037 0.469303 0
+      vertex 228.512 0.188 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.573 -0.463525 0
+      vertex 227.147 -0.927051 0
+      vertex 227.177 -1.01621 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.024 0.375999 0
+      vertex 228.512 0.188 0
+      vertex 227.037 0.469303 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.56 -0.418487 0
+      vertex 227.119 -0.836973 0
+      vertex 227.147 -0.927051 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.512 0.188 0
+      vertex 227.024 0.375999 0
+      vertex 228.507 0.141162 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.547 -0.373034 0
+      vertex 227.094 -0.746069 0
+      vertex 227.119 -0.836973 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.013 0.282325 0
+      vertex 228.507 0.141162 0
+      vertex 227.024 0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.536 -0.327214 0
+      vertex 227.072 -0.654429 0
+      vertex 227.094 -0.746069 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.507 0.141162 0
+      vertex 227.013 0.282325 0
+      vertex 228.503 0.0941849 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.527 -0.281072 0
+      vertex 227.053 -0.562143 0
+      vertex 227.072 -0.654429 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.006 0.188371 0
+      vertex 228.503 0.0941849 0
+      vertex 227.013 0.282325 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.518 -0.234652 0
+      vertex 227.037 -0.469303 0
+      vertex 227.053 -0.562143 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.503 0.0941849 0
+      vertex 227.006 0.188371 0
+      vertex 228.501 0.0471153 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.512 -0.188 0
+      vertex 227.024 -0.375999 0
+      vertex 227.037 -0.469303 0
+    endloop
+  endfacet
+  facet normal -0 0 1
+    outer loop
+      vertex 227.001 0.0942316 0
+      vertex 228.501 0.0471153 0
+      vertex 227.006 0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.507 -0.141162 0
+      vertex 227.013 -0.282325 0
+      vertex 227.024 -0.375999 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.501 0.0471153 0
+      vertex 227.001 0.0942316 0
+      vertex 228.5 0 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.503 -0.0941849 0
+      vertex 227.006 -0.188371 0
+      vertex 227.013 -0.282325 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 227 0 0
+      vertex 228.5 0 0
+      vertex 227.001 0.0942316 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.501 -0.0471153 0
+      vertex 227.001 -0.0942316 0
+      vertex 227.006 -0.188371 0
+    endloop
+  endfacet
+  facet normal 0 0 1
+    outer loop
+      vertex 228.5 0 0
+      vertex 227 0 0
+      vertex 227.001 -0.0942316 0
+    endloop
+  endfacet
+  facet normal 0.739609 -0.673036 0
+    outer loop
+      vertex 227.75 1.98394 5
+      vertex 227.813 2.05364 0
+      vertex 227.813 2.05364 5
+    endloop
+  endfacet
+  facet normal 0.739609 -0.673036 0
+    outer loop
+      vertex 227.813 2.05364 0
+      vertex 227.75 1.98394 5
+      vertex 227.75 1.98394 0
+    endloop
+  endfacet
+  facet normal 0.818107 -0.575066 0
+    outer loop
+      vertex 227.519 1.68625 5
+      vertex 227.573 1.76336 0
+      vertex 227.573 1.76336 5
+    endloop
+  endfacet
+  facet normal 0.818107 -0.575066 0
+    outer loop
+      vertex 227.573 1.76336 0
+      vertex 227.519 1.68625 5
+      vertex 227.519 1.68625 0
+    endloop
+  endfacet
+  facet normal 0.852652 -0.522479 0
+    outer loop
+      vertex 227.418 1.52712 5
+      vertex 227.467 1.60748 0
+      vertex 227.467 1.60748 5
+    endloop
+  endfacet
+  facet normal 0.852652 -0.522479 0
+    outer loop
+      vertex 227.467 1.60748 0
+      vertex 227.418 1.52712 5
+      vertex 227.418 1.52712 0
+    endloop
+  endfacet
+  facet normal 0.760425 -0.649425 0
+    outer loop
+      vertex 227.688 1.91227 5
+      vertex 227.75 1.98394 0
+      vertex 227.75 1.98394 5
+    endloop
+  endfacet
+  facet normal 0.760425 -0.649425 0
+    outer loop
+      vertex 227.75 1.98394 0
+      vertex 227.688 1.91227 5
+      vertex 227.688 1.91227 0
+    endloop
+  endfacet
+  facet normal 0.883774 -0.467914 0
+    outer loop
+      vertex 227.327 1.36197 5
+      vertex 227.371 1.44526 0
+      vertex 227.371 1.44526 5
+    endloop
+  endfacet
+  facet normal 0.883774 -0.467914 0
+    outer loop
+      vertex 227.371 1.44526 0
+      vertex 227.327 1.36197 5
+      vertex 227.327 1.36197 0
+    endloop
+  endfacet
+  facet normal 0.923857 -0.382738 0
+    outer loop
+      vertex 227.211 1.10437 5
+      vertex 227.247 1.19144 0
+      vertex 227.247 1.19144 5
+    endloop
+  endfacet
+  facet normal 0.923857 -0.382738 0
+    outer loop
+      vertex 227.247 1.19144 0
+      vertex 227.211 1.10437 5
+      vertex 227.211 1.10437 0
+    endloop
+  endfacet
+  facet normal 0.955797 -0.294026 0
+    outer loop
+      vertex 227.119 0.836973 5
+      vertex 227.147 0.927051 0
+      vertex 227.147 0.927051 5
+    endloop
+  endfacet
+  facet normal 0.955797 -0.294026 0
+    outer loop
+      vertex 227.147 0.927051 0
+      vertex 227.119 0.836973 5
+      vertex 227.119 0.836973 0
+    endloop
+  endfacet
+  facet normal 0.979207 -0.202866 0
+    outer loop
+      vertex 227.053 0.562143 5
+      vertex 227.072 0.654429 0
+      vertex 227.072 0.654429 5
+    endloop
+  endfacet
+  facet normal 0.979207 -0.202866 0
+    outer loop
+      vertex 227.072 0.654429 0
+      vertex 227.053 0.562143 5
+      vertex 227.053 0.562143 0
+    endloop
+  endfacet
+  facet normal 0.972364 -0.23347 0
+    outer loop
+      vertex 227.072 0.654429 5
+      vertex 227.094 0.746069 0
+      vertex 227.094 0.746069 5
+    endloop
+  endfacet
+  facet normal 0.972364 -0.23347 0
+    outer loop
+      vertex 227.094 0.746069 0
+      vertex 227.072 0.654429 5
+      vertex 227.072 0.654429 0
+    endloop
+  endfacet
+  facet normal 0.993957 -0.109773 0
+    outer loop
+      vertex 227.013 0.282325 5
+      vertex 227.024 0.375999 0
+      vertex 227.024 0.375999 5
+    endloop
+  endfacet
+  facet normal 0.993957 -0.109773 0
+    outer loop
+      vertex 227.024 0.375999 0
+      vertex 227.013 0.282325 5
+      vertex 227.013 0.282325 0
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0157051 0
+    outer loop
+      vertex 227 0 5
+      vertex 227.001 0.0942316 0
+      vertex 227.001 0.0942316 5
+    endloop
+  endfacet
+  facet normal 0.999877 -0.0157051 0
+    outer loop
+      vertex 227.001 0.0942316 0
+      vertex 227 0 5
+      vertex 227 0 0
+    endloop
+  endfacet
+  facet normal 0.439969 -0.898013 0
+    outer loop
+      vertex 228.638 2.67302 0
+      vertex 228.723 2.71448 5
+      vertex 228.638 2.67302 5
+    endloop
+  endfacet
+  facet normal 0.439969 -0.898013 0
+    outer loop
+      vertex 228.723 2.71448 5
+      vertex 228.638 2.67302 0
+      vertex 228.723 2.71448 0
+    endloop
+  endfacet
+  facet normal 0.411467 -0.911425 0
+    outer loop
+      vertex 228.723 2.71448 0
+      vertex 228.809 2.75326 5
+      vertex 228.723 2.71448 5
+    endloop
+  endfacet
+  facet normal 0.411467 -0.911425 0
+    outer loop
+      vertex 228.809 2.75326 5
+      vertex 228.723 2.71448 0
+      vertex 228.809 2.75326 0
+    endloop
+  endfacet
+  facet normal 0.695868 -0.718169 0
+    outer loop
+      vertex 227.879 2.12132 0
+      vertex 227.946 2.18691 5
+      vertex 227.879 2.12132 5
+    endloop
+  endfacet
+  facet normal 0.695868 -0.718169 0
+    outer loop
+      vertex 227.946 2.18691 5
+      vertex 227.879 2.12132 0
+      vertex 227.946 2.18691 0
+    endloop
+  endfacet
+  facet normal 0.575019 -0.81814 0
+    outer loop
+      vertex 228.237 2.42705 0
+      vertex 228.314 2.48124 5
+      vertex 228.237 2.42705 5
+    endloop
+  endfacet
+  facet normal 0.575019 -0.81814 0
+    outer loop
+      vertex 228.314 2.48124 5
+      vertex 228.237 2.42705 0
+      vertex 228.314 2.48124 0
+    endloop
+  endfacet
+  facet normal 0.549038 -0.835797 0
+    outer loop
+      vertex 228.314 2.48124 0
+      vertex 228.393 2.53298 5
+      vertex 228.314 2.48124 5
+    endloop
+  endfacet
+  facet normal 0.549038 -0.835797 0
+    outer loop
+      vertex 228.393 2.53298 5
+      vertex 228.314 2.48124 0
+      vertex 228.393 2.53298 0
+    endloop
+  endfacet
+  facet normal 0.495457 -0.868633 0
+    outer loop
+      vertex 228.473 2.58223 0
+      vertex 228.555 2.62892 5
+      vertex 228.473 2.58223 5
+    endloop
+  endfacet
+  facet normal 0.495457 -0.868633 0
+    outer loop
+      vertex 228.555 2.62892 5
+      vertex 228.473 2.58223 0
+      vertex 228.555 2.62892 0
+    endloop
+  endfacet
+  facet normal 0.625177 -0.780483 0
+    outer loop
+      vertex 228.088 2.31154 0
+      vertex 228.161 2.37046 5
+      vertex 228.088 2.31154 5
+    endloop
+  endfacet
+  facet normal 0.625177 -0.780483 0
+    outer loop
+      vertex 228.161 2.37046 5
+      vertex 228.088 2.31154 0
+      vertex 228.161 2.37046 0
+    endloop
+  endfacet
+  facet normal 0.323894 -0.946093 0
+    outer loop
+      vertex 228.984 2.82264 0
+      vertex 229.073 2.85317 5
+      vertex 228.984 2.82264 5
+    endloop
+  endfacet
+  facet normal 0.323894 -0.946093 0
+    outer loop
+      vertex 229.073 2.85317 5
+      vertex 228.984 2.82264 0
+      vertex 229.073 2.85317 0
+    endloop
+  endfacet
+  facet normal 0.353509 -0.935431 0
+    outer loop
+      vertex 228.896 2.78933 0
+      vertex 228.984 2.82264 5
+      vertex 228.896 2.78933 5
+    endloop
+  endfacet
+  facet normal 0.353509 -0.935431 0
+    outer loop
+      vertex 228.984 2.82264 5
+      vertex 228.896 2.78933 0
+      vertex 228.984 2.82264 0
+    endloop
+  endfacet
+  facet normal 0.263856 -0.964562 0
+    outer loop
+      vertex 229.163 2.88088 0
+      vertex 229.254 2.90575 5
+      vertex 229.163 2.88088 5
+    endloop
+  endfacet
+  facet normal 0.263856 -0.964562 0
+    outer loop
+      vertex 229.254 2.90575 5
+      vertex 229.163 2.88088 0
+      vertex 229.254 2.90575 0
+    endloop
+  endfacet
+  facet normal 0.140917 -0.990021 0
+    outer loop
+      vertex 229.531 2.96306 0
+      vertex 229.624 2.97634 5
+      vertex 229.531 2.96306 5
+    endloop
+  endfacet
+  facet normal 0.140917 -0.990021 0
+    outer loop
+      vertex 229.624 2.97634 5
+      vertex 229.531 2.96306 0
+      vertex 229.624 2.97634 0
+    endloop
+  endfacet
+  facet normal 0.171909 -0.985113 0
+    outer loop
+      vertex 229.438 2.94686 0
+      vertex 229.531 2.96306 5
+      vertex 229.438 2.94686 5
+    endloop
+  endfacet
+  facet normal 0.171909 -0.985113 0
+    outer loop
+      vertex 229.531 2.96306 5
+      vertex 229.438 2.94686 0
+      vertex 229.531 2.96306 0
+    endloop
+  endfacet
+  facet normal 0.0471088 -0.99889 0
+    outer loop
+      vertex 229.812 2.99408 0
+      vertex 229.906 2.99852 5
+      vertex 229.812 2.99408 5
+    endloop
+  endfacet
+  facet normal 0.0471088 -0.99889 0
+    outer loop
+      vertex 229.906 2.99852 5
+      vertex 229.812 2.99408 0
+      vertex 229.906 2.99852 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0157051 0
+    outer loop
+      vertex 232.999 -0.0942316 0
+      vertex 233 0 5
+      vertex 233 0 0
+    endloop
+  endfacet
+  facet normal -0.999877 0.0157051 0
+    outer loop
+      vertex 233 0 5
+      vertex 232.999 -0.0942316 0
+      vertex 232.999 -0.0942316 5
+    endloop
+  endfacet
+  facet normal -0.990007 0.141019 0
+    outer loop
+      vertex 232.963 -0.469303 0
+      vertex 232.976 -0.375999 5
+      vertex 232.976 -0.375999 0
+    endloop
+  endfacet
+  facet normal -0.990007 0.141019 0
+    outer loop
+      vertex 232.976 -0.375999 5
+      vertex 232.963 -0.469303 0
+      vertex 232.963 -0.469303 5
+    endloop
+  endfacet
+  facet normal -0.998889 0.0471151 0
+    outer loop
+      vertex 232.994 -0.188371 0
+      vertex 232.999 -0.0942316 5
+      vertex 232.999 -0.0942316 0
+    endloop
+  endfacet
+  facet normal -0.998889 0.0471151 0
+    outer loop
+      vertex 232.999 -0.0942316 5
+      vertex 232.994 -0.188371 0
+      vertex 232.994 -0.188371 5
+    endloop
+  endfacet
+  facet normal -0.835805 0.549027 0
+    outer loop
+      vertex 232.481 -1.68625 0
+      vertex 232.533 -1.60748 5
+      vertex 232.533 -1.60748 0
+    endloop
+  endfacet
+  facet normal -0.835805 0.549027 0
+    outer loop
+      vertex 232.533 -1.60748 5
+      vertex 232.481 -1.68625 0
+      vertex 232.481 -1.68625 5
+    endloop
+  endfacet
+  facet normal 0.868639 0.495446 0
+    outer loop
+      vertex 227.418 -1.52712 5
+      vertex 227.371 -1.44526 0
+      vertex 227.371 -1.44526 5
+    endloop
+  endfacet
+  facet normal 0.868639 0.495446 0
+    outer loop
+      vertex 227.371 -1.44526 0
+      vertex 227.418 -1.52712 5
+      vertex 227.418 -1.52712 0
+    endloop
+  endfacet
+  facet normal 0.964549 0.263905 0
+    outer loop
+      vertex 227.119 -0.836973 5
+      vertex 227.094 -0.746069 0
+      vertex 227.094 -0.746069 5
+    endloop
+  endfacet
+  facet normal 0.964549 0.263905 0
+    outer loop
+      vertex 227.094 -0.746069 0
+      vertex 227.119 -0.836973 5
+      vertex 227.119 -0.836973 0
+    endloop
+  endfacet
+  facet normal -0.382692 0.923876 0
+    outer loop
+      vertex 231.191 -2.75326 0
+      vertex 231.104 -2.78933 5
+      vertex 231.191 -2.75326 5
+    endloop
+  endfacet
+  facet normal -0.382692 0.923876 0
+    outer loop
+      vertex 231.104 -2.78933 5
+      vertex 231.191 -2.75326 0
+      vertex 231.104 -2.78933 0
+    endloop
+  endfacet
+  facet normal -0.323894 0.946093 0
+    outer loop
+      vertex 231.016 -2.82264 0
+      vertex 230.927 -2.85317 5
+      vertex 231.016 -2.82264 5
+    endloop
+  endfacet
+  facet normal -0.323894 0.946093 0
+    outer loop
+      vertex 230.927 -2.85317 5
+      vertex 231.016 -2.82264 0
+      vertex 230.927 -2.85317 0
+    endloop
+  endfacet
+  facet normal -0.353509 0.935431 0
+    outer loop
+      vertex 231.104 -2.78933 0
+      vertex 231.016 -2.82264 5
+      vertex 231.104 -2.78933 5
+    endloop
+  endfacet
+  facet normal -0.353509 0.935431 0
+    outer loop
+      vertex 231.016 -2.82264 5
+      vertex 231.104 -2.78933 0
+      vertex 231.016 -2.82264 0
+    endloop
+  endfacet
+  facet normal -0.140917 0.990021 0
+    outer loop
+      vertex 230.469 -2.96306 0
+      vertex 230.376 -2.97634 5
+      vertex 230.469 -2.96306 5
+    endloop
+  endfacet
+  facet normal -0.140917 0.990021 0
+    outer loop
+      vertex 230.376 -2.97634 5
+      vertex 230.469 -2.96306 0
+      vertex 230.376 -2.97634 0
+    endloop
+  endfacet
+  facet normal -0.109726 0.993962 0
+    outer loop
+      vertex 230.376 -2.97634 0
+      vertex 230.282 -2.98669 5
+      vertex 230.376 -2.97634 5
+    endloop
+  endfacet
+  facet normal -0.109726 0.993962 0
+    outer loop
+      vertex 230.282 -2.98669 5
+      vertex 230.376 -2.97634 0
+      vertex 230.282 -2.98669 0
+    endloop
+  endfacet
+  facet normal 0.835805 -0.549027 0
+    outer loop
+      vertex 227.467 1.60748 5
+      vertex 227.519 1.68625 0
+      vertex 227.519 1.68625 5
+    endloop
+  endfacet
+  facet normal 0.835805 -0.549027 0
+    outer loop
+      vertex 227.519 1.68625 0
+      vertex 227.467 1.60748 5
+      vertex 227.467 1.60748 0
+    endloop
+  endfacet
+  facet normal 0.780411 -0.625267 0
+    outer loop
+      vertex 227.63 1.83872 5
+      vertex 227.688 1.91227 0
+      vertex 227.688 1.91227 5
+    endloop
+  endfacet
+  facet normal 0.780411 -0.625267 0
+    outer loop
+      vertex 227.688 1.91227 0
+      vertex 227.63 1.83872 5
+      vertex 227.63 1.83872 0
+    endloop
+  endfacet
+  facet normal 0.799716 -0.600379 0
+    outer loop
+      vertex 227.573 1.76336 5
+      vertex 227.63 1.83872 0
+      vertex 227.63 1.83872 5
+    endloop
+  endfacet
+  facet normal 0.799716 -0.600379 0
+    outer loop
+      vertex 227.63 1.83872 0
+      vertex 227.573 1.76336 5
+      vertex 227.573 1.76336 0
+    endloop
+  endfacet
+  facet normal -0.985134 0.171789 0
+    outer loop
+      vertex 232.947 -0.562143 0
+      vertex 232.963 -0.469303 5
+      vertex 232.963 -0.469303 0
+    endloop
+  endfacet
+  facet normal -0.985134 0.171789 0
+    outer loop
+      vertex 232.963 -0.469303 5
+      vertex 232.947 -0.562143 0
+      vertex 232.947 -0.562143 5
+    endloop
+  endfacet
+  facet normal -0.868639 0.495446 0
+    outer loop
+      vertex 232.582 -1.52712 0
+      vertex 232.629 -1.44526 5
+      vertex 232.629 -1.44526 0
+    endloop
+  endfacet
+  facet normal -0.868639 0.495446 0
+    outer loop
+      vertex 232.629 -1.44526 5
+      vertex 232.582 -1.52712 0
+      vertex 232.582 -1.52712 5
+    endloop
+  endfacet
+  facet normal -0.923914 0.3826 0
+    outer loop
+      vertex 232.753 -1.19144 0
+      vertex 232.789 -1.10437 5
+      vertex 232.789 -1.10437 0
+    endloop
+  endfacet
+  facet normal -0.923914 0.3826 0
+    outer loop
+      vertex 232.789 -1.10437 5
+      vertex 232.753 -1.19144 0
+      vertex 232.753 -1.19144 5
+    endloop
+  endfacet
+  facet normal -0.898042 0.439909 0
+    outer loop
+      vertex 232.673 -1.36197 0
+      vertex 232.714 -1.27734 5
+      vertex 232.714 -1.27734 0
+    endloop
+  endfacet
+  facet normal -0.898042 0.439909 0
+    outer loop
+      vertex 232.714 -1.27734 5
+      vertex 232.673 -1.36197 0
+      vertex 232.673 -1.36197 5
+    endloop
+  endfacet
+  facet normal -0.852652 0.522479 0
+    outer loop
+      vertex 232.533 -1.60748 0
+      vertex 232.582 -1.52712 5
+      vertex 232.582 -1.52712 0
+    endloop
+  endfacet
+  facet normal -0.852652 0.522479 0
+    outer loop
+      vertex 232.582 -1.52712 5
+      vertex 232.533 -1.60748 0
+      vertex 232.533 -1.60748 5
+    endloop
+  endfacet
+  facet normal -0.739609 0.673036 0
+    outer loop
+      vertex 232.187 -2.05364 0
+      vertex 232.25 -1.98394 5
+      vertex 232.25 -1.98394 0
+    endloop
+  endfacet
+  facet normal -0.739609 0.673036 0
+    outer loop
+      vertex 232.25 -1.98394 5
+      vertex 232.187 -2.05364 0
+      vertex 232.187 -2.05364 5
+    endloop
+  endfacet
+  facet normal -0.760425 0.649425 0
+    outer loop
+      vertex 232.25 -1.98394 0
+      vertex 232.312 -1.91227 5
+      vertex 232.312 -1.91227 0
+    endloop
+  endfacet
+  facet normal -0.760425 0.649425 0
+    outer loop
+      vertex 232.312 -1.91227 5
+      vertex 232.25 -1.98394 0
+      vertex 232.25 -1.98394 5
+    endloop
+  endfacet
+  facet normal 0.171909 0.985113 -0
+    outer loop
+      vertex 229.531 -2.96306 0
+      vertex 229.438 -2.94686 5
+      vertex 229.531 -2.96306 5
+    endloop
+  endfacet
+  facet normal 0.171909 0.985113 0
+    outer loop
+      vertex 229.438 -2.94686 5
+      vertex 229.531 -2.96306 0
+      vertex 229.438 -2.94686 0
+    endloop
+  endfacet
+  facet normal 0.29405 0.95579 -0
+    outer loop
+      vertex 229.163 -2.88088 0
+      vertex 229.073 -2.85317 5
+      vertex 229.163 -2.88088 5
+    endloop
+  endfacet
+  facet normal 0.29405 0.95579 0
+    outer loop
+      vertex 229.073 -2.85317 5
+      vertex 229.163 -2.88088 0
+      vertex 229.073 -2.85317 0
+    endloop
+  endfacet
+  facet normal 0.760425 0.649425 0
+    outer loop
+      vertex 227.75 -1.98394 5
+      vertex 227.688 -1.91227 0
+      vertex 227.688 -1.91227 5
+    endloop
+  endfacet
+  facet normal 0.760425 0.649425 0
+    outer loop
+      vertex 227.688 -1.91227 0
+      vertex 227.75 -1.98394 5
+      vertex 227.75 -1.98394 0
+    endloop
+  endfacet
+  facet normal 0.718146 0.695893 0
+    outer loop
+      vertex 227.879 -2.12132 5
+      vertex 227.813 -2.05364 0
+      vertex 227.813 -2.05364 5
+    endloop
+  endfacet
+  facet normal 0.718146 0.695893 0
+    outer loop
+      vertex 227.813 -2.05364 0
+      vertex 227.879 -2.12132 5
+      vertex 227.879 -2.12132 0
+    endloop
+  endfacet
+  facet normal 0.835805 0.549027 0
+    outer loop
+      vertex 227.519 -1.68625 5
+      vertex 227.467 -1.60748 0
+      vertex 227.467 -1.60748 5
+    endloop
+  endfacet
+  facet normal 0.835805 0.549027 0
+    outer loop
+      vertex 227.467 -1.60748 0
+      vertex 227.519 -1.68625 5
+      vertex 227.519 -1.68625 0
+    endloop
+  endfacet
+  facet normal 0.883774 0.467914 0
+    outer loop
+      vertex 227.371 -1.44526 5
+      vertex 227.327 -1.36197 0
+      vertex 227.327 -1.36197 5
+    endloop
+  endfacet
+  facet normal 0.883774 0.467914 0
+    outer loop
+      vertex 227.327 -1.36197 0
+      vertex 227.371 -1.44526 5
+      vertex 227.371 -1.44526 0
+    endloop
+  endfacet
+  facet normal 0.911382 0.411562 0
+    outer loop
+      vertex 227.286 -1.27734 5
+      vertex 227.247 -1.19144 0
+      vertex 227.247 -1.19144 5
+    endloop
+  endfacet
+  facet normal 0.911382 0.411562 0
+    outer loop
+      vertex 227.247 -1.19144 0
+      vertex 227.286 -1.27734 5
+      vertex 227.286 -1.27734 0
+    endloop
+  endfacet
+  facet normal 0.898042 0.439909 0
+    outer loop
+      vertex 227.327 -1.36197 5
+      vertex 227.286 -1.27734 0
+      vertex 227.286 -1.27734 5
+    endloop
+  endfacet
+  facet normal 0.898042 0.439909 0
+    outer loop
+      vertex 227.286 -1.27734 0
+      vertex 227.327 -1.36197 5
+      vertex 227.327 -1.36197 0
+    endloop
+  endfacet
+  facet normal 0.946117 0.323825 0
+    outer loop
+      vertex 227.177 -1.01621 5
+      vertex 227.147 -0.927051 0
+      vertex 227.147 -0.927051 5
+    endloop
+  endfacet
+  facet normal 0.946117 0.323825 0
+    outer loop
+      vertex 227.147 -0.927051 0
+      vertex 227.177 -1.01621 5
+      vertex 227.177 -1.01621 0
+    endloop
+  endfacet
+  facet normal 0.935454 0.353449 0
+    outer loop
+      vertex 227.211 -1.10437 5
+      vertex 227.177 -1.01621 0
+      vertex 227.177 -1.01621 5
+    endloop
+  endfacet
+  facet normal 0.935454 0.353449 0
+    outer loop
+      vertex 227.177 -1.01621 0
+      vertex 227.211 -1.10437 5
+      vertex 227.211 -1.10437 0
+    endloop
+  endfacet
+  facet normal 0.990007 0.141019 0
+    outer loop
+      vertex 227.037 -0.469303 5
+      vertex 227.024 -0.375999 0
+      vertex 227.024 -0.375999 5
+    endloop
+  endfacet
+  facet normal 0.990007 0.141019 0
+    outer loop
+      vertex 227.024 -0.375999 0
+      vertex 227.037 -0.469303 5
+      vertex 227.037 -0.469303 0
+    endloop
+  endfacet
+  facet normal 0.979207 0.202866 0
+    outer loop
+      vertex 227.072 -0.654429 5
+      vertex 227.053 -0.562143 0
+      vertex 227.053 -0.562143 5
+    endloop
+  endfacet
+  facet normal 0.979207 0.202866 0
+    outer loop
+      vertex 227.053 -0.562143 0
+      vertex 227.072 -0.654429 5
+      vertex 227.072 -0.654429 0
+    endloop
+  endfacet
+  facet normal 0.993957 0.109773 0
+    outer loop
+      vertex 227.024 -0.375999 5
+      vertex 227.013 -0.282325 0
+      vertex 227.013 -0.282325 5
+    endloop
+  endfacet
+  facet normal 0.993957 0.109773 0
+    outer loop
+      vertex 227.013 -0.282325 0
+      vertex 227.024 -0.375999 5
+      vertex 227.024 -0.375999 0
+    endloop
+  endfacet
+  facet normal 0.996925 0.0783632 0
+    outer loop
+      vertex 227.013 -0.282325 5
+      vertex 227.006 -0.188371 0
+      vertex 227.006 -0.188371 5
+    endloop
+  endfacet
+  facet normal 0.996925 0.0783632 0
+    outer loop
+      vertex 227.006 -0.188371 0
+      vertex 227.013 -0.282325 5
+      vertex 227.013 -0.282325 0
+    endloop
+  endfacet
+  facet normal -0.20279 0.979222 0
+    outer loop
+      vertex 230.654 -2.92775 0
+      vertex 230.562 -2.94686 5
+      vertex 230.654 -2.92775 5
+    endloop
+  endfacet
+  facet normal -0.20279 0.979222 0
+    outer loop
+      vertex 230.562 -2.94686 5
+      vertex 230.654 -2.92775 0
+      vertex 230.562 -2.94686 0
+    endloop
+  endfacet
+  facet normal -0.263856 0.964562 0
+    outer loop
+      vertex 230.837 -2.88088 0
+      vertex 230.746 -2.90575 5
+      vertex 230.837 -2.88088 5
+    endloop
+  endfacet
+  facet normal -0.263856 0.964562 0
+    outer loop
+      vertex 230.746 -2.90575 5
+      vertex 230.837 -2.88088 0
+      vertex 230.746 -2.90575 0
+    endloop
+  endfacet
+  facet normal -0.171909 0.985113 0
+    outer loop
+      vertex 230.562 -2.94686 0
+      vertex 230.469 -2.96306 5
+      vertex 230.562 -2.94686 5
+    endloop
+  endfacet
+  facet normal -0.171909 0.985113 0
+    outer loop
+      vertex 230.469 -2.96306 5
+      vertex 230.562 -2.94686 0
+      vertex 230.469 -2.96306 0
+    endloop
+  endfacet
+  facet normal -0.0784585 0.996917 0
+    outer loop
+      vertex 230.282 -2.98669 0
+      vertex 230.188 -2.99408 5
+      vertex 230.282 -2.98669 5
+    endloop
+  endfacet
+  facet normal -0.0784585 0.996917 0
+    outer loop
+      vertex 230.188 -2.99408 5
+      vertex 230.282 -2.98669 0
+      vertex 230.188 -2.99408 0
+    endloop
+  endfacet
+  facet normal -0.979207 0.202866 0
+    outer loop
+      vertex 232.928 -0.654429 0
+      vertex 232.947 -0.562143 5
+      vertex 232.947 -0.562143 0
+    endloop
+  endfacet
+  facet normal -0.979207 0.202866 0
+    outer loop
+      vertex 232.947 -0.562143 5
+      vertex 232.928 -0.654429 0
+      vertex 232.928 -0.654429 5
+    endloop
+  endfacet
+  facet normal -0.993974 0.109613 0
+    outer loop
+      vertex 232.976 -0.375999 0
+      vertex 232.987 -0.282325 5
+      vertex 232.987 -0.282325 0
+    endloop
+  endfacet
+  facet normal -0.993974 0.109613 0
+    outer loop
+      vertex 232.987 -0.282325 5
+      vertex 232.976 -0.375999 0
+      vertex 232.976 -0.375999 5
+    endloop
+  endfacet
+  facet normal -0.883774 0.467914 0
+    outer loop
+      vertex 232.629 -1.44526 0
+      vertex 232.673 -1.36197 5
+      vertex 232.673 -1.36197 0
+    endloop
+  endfacet
+  facet normal -0.883774 0.467914 0
+    outer loop
+      vertex 232.673 -1.36197 5
+      vertex 232.629 -1.44526 0
+      vertex 232.629 -1.44526 5
+    endloop
+  endfacet
+  facet normal -0.911382 0.411562 0
+    outer loop
+      vertex 232.714 -1.27734 0
+      vertex 232.753 -1.19144 5
+      vertex 232.753 -1.19144 0
+    endloop
+  endfacet
+  facet normal -0.911382 0.411562 0
+    outer loop
+      vertex 232.753 -1.19144 5
+      vertex 232.714 -1.27734 0
+      vertex 232.714 -1.27734 5
+    endloop
+  endfacet
+  facet normal -0.964549 0.263905 0
+    outer loop
+      vertex 232.881 -0.836973 0
+      vertex 232.906 -0.746069 5
+      vertex 232.906 -0.746069 0
+    endloop
+  endfacet
+  facet normal -0.964549 0.263905 0
+    outer loop
+      vertex 232.906 -0.746069 5
+      vertex 232.881 -0.836973 0
+      vertex 232.881 -0.836973 5
+    endloop
+  endfacet
+  facet normal -0.955797 0.294026 0
+    outer loop
+      vertex 232.853 -0.927051 0
+      vertex 232.881 -0.836973 5
+      vertex 232.881 -0.836973 0
+    endloop
+  endfacet
+  facet normal -0.955797 0.294026 0
+    outer loop
+      vertex 232.881 -0.836973 5
+      vertex 232.853 -0.927051 0
+      vertex 232.853 -0.927051 5
+    endloop
+  endfacet
+  facet normal -0.818107 0.575066 0
+    outer loop
+      vertex 232.427 -1.76336 0
+      vertex 232.481 -1.68625 5
+      vertex 232.481 -1.68625 0
+    endloop
+  endfacet
+  facet normal -0.818107 0.575066 0
+    outer loop
+      vertex 232.481 -1.68625 5
+      vertex 232.427 -1.76336 0
+      vertex 232.427 -1.76336 5
+    endloop
+  endfacet
+  facet normal -0.799716 0.600379 0
+    outer loop
+      vertex 232.37 -1.83872 0
+      vertex 232.427 -1.76336 5
+      vertex 232.427 -1.76336 0
+    endloop
+  endfacet
+  facet normal -0.799716 0.600379 0
+    outer loop
+      vertex 232.427 -1.76336 5
+      vertex 232.37 -1.83872 0
+      vertex 232.37 -1.83872 5
+    endloop
+  endfacet
+  facet normal -0.780411 0.625267 0
+    outer loop
+      vertex 232.312 -1.91227 0
+      vertex 232.37 -1.83872 5
+      vertex 232.37 -1.83872 0
+    endloop
+  endfacet
+  facet normal -0.780411 0.625267 0
+    outer loop
+      vertex 232.37 -1.83872 5
+      vertex 232.312 -1.91227 0
+      vertex 232.312 -1.91227 5
+    endloop
+  endfacet
+  facet normal -0.600434 0.799674 0
+    outer loop
+      vertex 231.839 -2.37046 0
+      vertex 231.763 -2.42705 5
+      vertex 231.839 -2.37046 5
+    endloop
+  endfacet
+  facet normal -0.600434 0.799674 0
+    outer loop
+      vertex 231.763 -2.42705 5
+      vertex 231.839 -2.37046 0
+      vertex 231.763 -2.42705 0
+    endloop
+  endfacet
+  facet normal -0.695868 0.718169 0
+    outer loop
+      vertex 232.121 -2.12132 0
+      vertex 232.054 -2.18691 5
+      vertex 232.121 -2.12132 5
+    endloop
+  endfacet
+  facet normal -0.695868 0.718169 0
+    outer loop
+      vertex 232.054 -2.18691 5
+      vertex 232.121 -2.12132 0
+      vertex 232.054 -2.18691 0
+    endloop
+  endfacet
+  facet normal -0.411467 0.911425 0
+    outer loop
+      vertex 231.277 -2.71448 0
+      vertex 231.191 -2.75326 5
+      vertex 231.277 -2.71448 5
+    endloop
+  endfacet
+  facet normal -0.411467 0.911425 0
+    outer loop
+      vertex 231.191 -2.75326 5
+      vertex 231.277 -2.71448 0
+      vertex 231.191 -2.75326 0
+    endloop
+  endfacet
+  facet normal -0.467896 0.883783 0
+    outer loop
+      vertex 231.445 -2.62892 0
+      vertex 231.362 -2.67302 5
+      vertex 231.445 -2.62892 5
+    endloop
+  endfacet
+  facet normal -0.467896 0.883783 0
+    outer loop
+      vertex 231.362 -2.67302 5
+      vertex 231.445 -2.62892 0
+      vertex 231.362 -2.67302 0
+    endloop
+  endfacet
+  facet normal -0.549038 0.835797 0
+    outer loop
+      vertex 231.686 -2.48124 0
+      vertex 231.607 -2.53298 5
+      vertex 231.686 -2.48124 5
+    endloop
+  endfacet
+  facet normal -0.549038 0.835797 0
+    outer loop
+      vertex 231.607 -2.53298 5
+      vertex 231.686 -2.48124 0
+      vertex 231.607 -2.53298 0
+    endloop
+  endfacet
+  facet normal -0.495457 0.868633 0
+    outer loop
+      vertex 231.527 -2.58223 0
+      vertex 231.445 -2.62892 5
+      vertex 231.527 -2.58223 5
+    endloop
+  endfacet
+  facet normal -0.495457 0.868633 0
+    outer loop
+      vertex 231.445 -2.62892 5
+      vertex 231.527 -2.58223 0
+      vertex 231.445 -2.62892 0
+    endloop
+  endfacet
+  facet normal 0.0471088 0.99889 -0
+    outer loop
+      vertex 229.906 -2.99852 0
+      vertex 229.812 -2.99408 5
+      vertex 229.906 -2.99852 5
+    endloop
+  endfacet
+  facet normal 0.0471088 0.99889 0
+    outer loop
+      vertex 229.812 -2.99408 5
+      vertex 229.906 -2.99852 0
+      vertex 229.812 -2.99408 0
+    endloop
+  endfacet
+  facet normal 0.0784585 0.996917 -0
+    outer loop
+      vertex 229.812 -2.99408 0
+      vertex 229.718 -2.98669 5
+      vertex 229.812 -2.99408 5
+    endloop
+  endfacet
+  facet normal 0.0784585 0.996917 0
+    outer loop
+      vertex 229.718 -2.98669 5
+      vertex 229.812 -2.99408 0
+      vertex 229.718 -2.98669 0
+    endloop
+  endfacet
+  facet normal 0.0157141 0.999877 -0
+    outer loop
+      vertex 230 -3 0
+      vertex 229.906 -2.99852 5
+      vertex 230 -3 5
+    endloop
+  endfacet
+  facet normal 0.0157141 0.999877 0
+    outer loop
+      vertex 229.906 -2.99852 5
+      vertex 230 -3 0
+      vertex 229.906 -2.99852 0
+    endloop
+  endfacet
+  facet normal 0.382692 0.923876 -0
+    outer loop
+      vertex 228.896 -2.78933 0
+      vertex 228.809 -2.75326 5
+      vertex 228.896 -2.78933 5
+    endloop
+  endfacet
+  facet normal 0.382692 0.923876 0
+    outer loop
+      vertex 228.809 -2.75326 5
+      vertex 228.896 -2.78933 0
+      vertex 228.809 -2.75326 0
+    endloop
+  endfacet
+  facet normal 0.625177 0.780483 -0
+    outer loop
+      vertex 228.161 -2.37046 0
+      vertex 228.088 -2.31154 5
+      vertex 228.161 -2.37046 5
+    endloop
+  endfacet
+  facet normal 0.625177 0.780483 0
+    outer loop
+      vertex 228.088 -2.31154 5
+      vertex 228.161 -2.37046 0
+      vertex 228.088 -2.31154 0
+    endloop
+  endfacet
+  facet normal 0.323894 0.946093 -0
+    outer loop
+      vertex 229.073 -2.85317 0
+      vertex 228.984 -2.82264 5
+      vertex 229.073 -2.85317 5
+    endloop
+  endfacet
+  facet normal 0.323894 0.946093 0
+    outer loop
+      vertex 228.984 -2.82264 5
+      vertex 229.073 -2.85317 0
+      vertex 228.984 -2.82264 0
+    endloop
+  endfacet
+  facet normal 0.263856 0.964562 -0
+    outer loop
+      vertex 229.254 -2.90575 0
+      vertex 229.163 -2.88088 5
+      vertex 229.254 -2.90575 5
+    endloop
+  endfacet
+  facet normal 0.263856 0.964562 0
+    outer loop
+      vertex 229.163 -2.88088 5
+      vertex 229.254 -2.90575 0
+      vertex 229.163 -2.88088 0
+    endloop
+  endfacet
+  facet normal 0.780411 0.625267 0
+    outer loop
+      vertex 227.688 -1.91227 5
+      vertex 227.63 -1.83872 0
+      vertex 227.63 -1.83872 5
+    endloop
+  endfacet
+  facet normal 0.780411 0.625267 0
+    outer loop
+      vertex 227.63 -1.83872 0
+      vertex 227.688 -1.91227 5
+      vertex 227.688 -1.91227 0
+    endloop
+  endfacet
+  facet normal 0.695868 0.718169 -0
+    outer loop
+      vertex 227.946 -2.18691 0
+      vertex 227.879 -2.12132 5
+      vertex 227.946 -2.18691 5
+    endloop
+  endfacet
+  facet normal 0.695868 0.718169 0
+    outer loop
+      vertex 227.879 -2.12132 5
+      vertex 227.946 -2.18691 0
+      vertex 227.879 -2.12132 0
+    endloop
+  endfacet
+  facet normal 0.852652 0.522479 0
+    outer loop
+      vertex 227.467 -1.60748 5
+      vertex 227.418 -1.52712 0
+      vertex 227.418 -1.52712 5
+    endloop
+  endfacet
+  facet normal 0.852652 0.522479 0
+    outer loop
+      vertex 227.418 -1.52712 0
+      vertex 227.467 -1.60748 5
+      vertex 227.467 -1.60748 0
+    endloop
+  endfacet
+  facet normal 0.818107 0.575066 0
+    outer loop
+      vertex 227.573 -1.76336 5
+      vertex 227.519 -1.68625 0
+      vertex 227.519 -1.68625 5
+    endloop
+  endfacet
+  facet normal 0.818107 0.575066 0
+    outer loop
+      vertex 227.519 -1.68625 0
+      vertex 227.573 -1.76336 5
+      vertex 227.573 -1.76336 0
+    endloop
+  endfacet
+  facet normal 0.955797 0.294026 0
+    outer loop
+      vertex 227.147 -0.927051 5
+      vertex 227.119 -0.836973 0
+      vertex 227.119 -0.836973 5
+    endloop
+  endfacet
+  facet normal 0.955797 0.294026 0
+    outer loop
+      vertex 227.119 -0.836973 0
+      vertex 227.147 -0.927051 5
+      vertex 227.147 -0.927051 0
+    endloop
+  endfacet
+  facet normal 0.985134 0.171789 0
+    outer loop
+      vertex 227.053 -0.562143 5
+      vertex 227.037 -0.469303 0
+      vertex 227.037 -0.469303 5
+    endloop
+  endfacet
+  facet normal 0.985134 0.171789 0
+    outer loop
+      vertex 227.037 -0.469303 0
+      vertex 227.053 -0.562143 5
+      vertex 227.053 -0.562143 0
+    endloop
+  endfacet
+  facet normal -0.233467 0.972365 0
+    outer loop
+      vertex 230.746 -2.90575 0
+      vertex 230.654 -2.92775 5
+      vertex 230.746 -2.90575 5
+    endloop
+  endfacet
+  facet normal -0.233467 0.972365 0
+    outer loop
+      vertex 230.654 -2.92775 5
+      vertex 230.746 -2.90575 0
+      vertex 230.654 -2.92775 0
+    endloop
+  endfacet
+  facet normal -0.29405 0.95579 0
+    outer loop
+      vertex 230.927 -2.85317 0
+      vertex 230.837 -2.88088 5
+      vertex 230.927 -2.85317 5
+    endloop
+  endfacet
+  facet normal -0.29405 0.95579 0
+    outer loop
+      vertex 230.837 -2.88088 5
+      vertex 230.927 -2.85317 0
+      vertex 230.837 -2.88088 0
+    endloop
+  endfacet
+  facet normal -0.946117 0.323825 0
+    outer loop
+      vertex 232.823 -1.01621 0
+      vertex 232.853 -0.927051 5
+      vertex 232.853 -0.927051 0
+    endloop
+  endfacet
+  facet normal -0.946117 0.323825 0
+    outer loop
+      vertex 232.853 -0.927051 5
+      vertex 232.823 -1.01621 0
+      vertex 232.823 -1.01621 5
+    endloop
+  endfacet
+  facet normal -0.649494 0.760367 0
+    outer loop
+      vertex 231.984 -2.25033 0
+      vertex 231.912 -2.31154 5
+      vertex 231.984 -2.25033 5
+    endloop
+  endfacet
+  facet normal -0.649494 0.760367 0
+    outer loop
+      vertex 231.912 -2.31154 5
+      vertex 231.984 -2.25033 0
+      vertex 231.912 -2.31154 0
+    endloop
+  endfacet
+  facet normal -0.718146 0.695893 0
+    outer loop
+      vertex 232.121 -2.12132 0
+      vertex 232.187 -2.05364 5
+      vertex 232.187 -2.05364 0
+    endloop
+  endfacet
+  facet normal -0.718146 0.695893 0
+    outer loop
+      vertex 232.187 -2.05364 5
+      vertex 232.121 -2.12132 0
+      vertex 232.121 -2.12132 5
+    endloop
+  endfacet
+  facet normal -0.439969 0.898013 0
+    outer loop
+      vertex 231.362 -2.67302 0
+      vertex 231.277 -2.71448 5
+      vertex 231.362 -2.67302 5
+    endloop
+  endfacet
+  facet normal -0.439969 0.898013 0
+    outer loop
+      vertex 231.277 -2.71448 5
+      vertex 231.362 -2.67302 0
+      vertex 231.277 -2.71448 0
+    endloop
+  endfacet
+  facet normal -0.575019 0.81814 0
+    outer loop
+      vertex 231.763 -2.42705 0
+      vertex 231.686 -2.48124 5
+      vertex 231.763 -2.42705 5
+    endloop
+  endfacet
+  facet normal -0.575019 0.81814 0
+    outer loop
+      vertex 231.686 -2.48124 5
+      vertex 231.763 -2.42705 0
+      vertex 231.686 -2.48124 0
+    endloop
+  endfacet
+  facet normal -0.52252 0.852627 0
+    outer loop
+      vertex 231.607 -2.53298 0
+      vertex 231.527 -2.58223 5
+      vertex 231.607 -2.53298 5
+    endloop
+  endfacet
+  facet normal -0.52252 0.852627 0
+    outer loop
+      vertex 231.527 -2.58223 5
+      vertex 231.607 -2.53298 0
+      vertex 231.527 -2.58223 0
+    endloop
+  endfacet
+  facet normal 0.233467 0.972365 -0
+    outer loop
+      vertex 229.346 -2.92775 0
+      vertex 229.254 -2.90575 5
+      vertex 229.346 -2.92775 5
+    endloop
+  endfacet
+  facet normal 0.233467 0.972365 0
+    outer loop
+      vertex 229.254 -2.90575 5
+      vertex 229.346 -2.92775 0
+      vertex 229.254 -2.90575 0
+    endloop
+  endfacet
+  facet normal 0.140917 0.990021 -0
+    outer loop
+      vertex 229.624 -2.97634 0
+      vertex 229.531 -2.96306 5
+      vertex 229.624 -2.97634 5
+    endloop
+  endfacet
+  facet normal 0.140917 0.990021 0
+    outer loop
+      vertex 229.531 -2.96306 5
+      vertex 229.624 -2.97634 0
+      vertex 229.531 -2.96306 0
+    endloop
+  endfacet
+  facet normal 0.353509 0.935431 -0
+    outer loop
+      vertex 228.984 -2.82264 0
+      vertex 228.896 -2.78933 5
+      vertex 228.984 -2.82264 5
+    endloop
+  endfacet
+  facet normal 0.353509 0.935431 0
+    outer loop
+      vertex 228.896 -2.78933 5
+      vertex 228.984 -2.82264 0
+      vertex 228.896 -2.78933 0
+    endloop
+  endfacet
+  facet normal 0.439969 0.898013 -0
+    outer loop
+      vertex 228.723 -2.71448 0
+      vertex 228.638 -2.67302 5
+      vertex 228.723 -2.71448 5
+    endloop
+  endfacet
+  facet normal 0.439969 0.898013 0
+    outer loop
+      vertex 228.638 -2.67302 5
+      vertex 228.723 -2.71448 0
+      vertex 228.638 -2.67302 0
+    endloop
+  endfacet
+  facet normal 0.467896 0.883783 -0
+    outer loop
+      vertex 228.638 -2.67302 0
+      vertex 228.555 -2.62892 5
+      vertex 228.638 -2.67302 5
+    endloop
+  endfacet
+  facet normal 0.467896 0.883783 0
+    outer loop
+      vertex 228.555 -2.62892 5
+      vertex 228.638 -2.67302 0
+      vertex 228.555 -2.62892 0
+    endloop
+  endfacet
+  facet normal 0.673029 0.739616 -0
+    outer loop
+      vertex 228.016 -2.25033 0
+      vertex 227.946 -2.18691 5
+      vertex 228.016 -2.25033 5
+    endloop
+  endfacet
+  facet normal 0.673029 0.739616 0
+    outer loop
+      vertex 227.946 -2.18691 5
+      vertex 228.016 -2.25033 0
+      vertex 227.946 -2.18691 0
+    endloop
+  endfacet
+  facet normal -0.625177 0.780483 0
+    outer loop
+      vertex 231.912 -2.31154 0
+      vertex 231.839 -2.37046 5
+      vertex 231.912 -2.31154 5
+    endloop
+  endfacet
+  facet normal -0.625177 0.780483 0
+    outer loop
+      vertex 231.839 -2.37046 5
+      vertex 231.912 -2.31154 0
+      vertex 231.839 -2.37046 0
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 -0
+    outer loop
+      vertex 229.438 -2.94686 0
+      vertex 229.346 -2.92775 5
+      vertex 229.438 -2.94686 5
+    endloop
+  endfacet
+  facet normal 0.20279 0.979222 0
+    outer loop
+      vertex 229.346 -2.92775 5
+      vertex 229.438 -2.94686 0
+      vertex 229.346 -2.92775 0
+    endloop
+  endfacet
+  facet normal 0.109726 0.993962 -0
+    outer loop
+      vertex 229.718 -2.98669 0
+      vertex 229.624 -2.97634 5
+      vertex 229.718 -2.98669 5
+    endloop
+  endfacet
+  facet normal 0.109726 0.993962 0
+    outer loop
+      vertex 229.624 -2.97634 5
+      vertex 229.718 -2.98669 0
+      vertex 229.624 -2.97634 0
+    endloop
+  endfacet
+  facet normal 0.411467 0.911425 -0
+    outer loop
+      vertex 228.809 -2.75326 0
+      vertex 228.723 -2.71448 5
+      vertex 228.809 -2.75326 5
+    endloop
+  endfacet
+  facet normal 0.411467 0.911425 0
+    outer loop
+      vertex 228.723 -2.71448 5
+      vertex 228.809 -2.75326 0
+      vertex 228.723 -2.71448 0
+    endloop
+  endfacet
+  facet normal 0.649494 0.760367 -0
+    outer loop
+      vertex 228.088 -2.31154 0
+      vertex 228.016 -2.25033 5
+      vertex 228.088 -2.31154 5
+    endloop
+  endfacet
+  facet normal 0.649494 0.760367 0
+    outer loop
+      vertex 228.016 -2.25033 5
+      vertex 228.088 -2.31154 0
+      vertex 228.016 -2.25033 0
+    endloop
+  endfacet
+  facet normal 0.575019 0.81814 -0
+    outer loop
+      vertex 228.314 -2.48124 0
+      vertex 228.237 -2.42705 5
+      vertex 228.314 -2.48124 5
+    endloop
+  endfacet
+  facet normal 0.575019 0.81814 0
+    outer loop
+      vertex 228.237 -2.42705 5
+      vertex 228.314 -2.48124 0
+      vertex 228.237 -2.42705 0
+    endloop
+  endfacet
+  facet normal 0.495457 0.868633 -0
+    outer loop
+      vertex 228.555 -2.62892 0
+      vertex 228.473 -2.58223 5
+      vertex 228.555 -2.62892 5
+    endloop
+  endfacet
+  facet normal 0.495457 0.868633 0
+    outer loop
+      vertex 228.473 -2.58223 5
+      vertex 228.555 -2.62892 0
+      vertex 228.473 -2.58223 0
+    endloop
+  endfacet
+  facet normal 0.52252 0.852627 -0
+    outer loop
+      vertex 228.473 -2.58223 0
+      vertex 228.393 -2.53298 5
+      vertex 228.473 -2.58223 5
+    endloop
+  endfacet
+  facet normal 0.52252 0.852627 0
+    outer loop
+      vertex 228.393 -2.53298 5
+      vertex 228.473 -2.58223 0
+      vertex 228.393 -2.53298 0
+    endloop
+  endfacet
+  facet normal 0.549038 0.835797 -0
+    outer loop
+      vertex 228.393 -2.53298 0
+      vertex 228.314 -2.48124 5
+      vertex 228.393 -2.53298 5
+    endloop
+  endfacet
+  facet normal 0.549038 0.835797 0
+    outer loop
+      vertex 228.314 -2.48124 5
+      vertex 228.393 -2.53298 0
+      vertex 228.314 -2.48124 0
+    endloop
+  endfacet
+  facet normal 0.600434 0.799674 -0
+    outer loop
+      vertex 228.237 -2.42705 0
+      vertex 228.161 -2.37046 5
+      vertex 228.237 -2.42705 5
+    endloop
+  endfacet
+  facet normal 0.600434 0.799674 0
+    outer loop
+      vertex 228.161 -2.37046 5
+      vertex 228.237 -2.42705 0
+      vertex 228.161 -2.37046 0
+    endloop
+  endfacet
+endsolid OpenSCAD_Model


### PR DESCRIPTION
Shortened legs for 3-D printing, that will fit smaller printers (210x210mm printbed size) in stl and OpenSCAD format(http://www.openscad.org/) format.

*Issue #, if available:* None

*Description of changes:*
Created an additional stl file with shorter legs.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
